### PR TITLE
add bazelrc for rbe support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,35 @@
+build:rbe --project_id=grakn-dev
+build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
+build:rbe --remote_cache=remotebuildexecution.googleapis.com
+build:rbe --remote_executor=remotebuildexecution.googleapis.com
+build:rbe --bes_backend="buildeventservice.googleapis.com"
+build:rbe --bes_results_url="https://source.cloud.google.com/results/invocations/"
+build:rbe --host_platform=//:rbe-platform
+build:rbe --platforms=//:rbe-platform
+build:rbe --extra_execution_platforms=//:rbe-platform
+build:rbe --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:jdk8
+build:rbe --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:jdk8
+build:rbe --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:rbe --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:rbe --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.20.0/cpp:cc-toolchain-clang-x86_64-default
+build:rbe --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.20.0/default:toolchain
+build:rbe --jobs=50
+build:rbe --remote_timeout=3600
+build:rbe --bes_timeout=60s
+build:rbe --tls_enabled=true
+build:rbe --auth_enabled=true
+build:rbe --spawn_strategy=remote
+build:rbe --strategy=Javac=remote
+build:rbe --strategy=Closure=remote
+build:rbe --genrule_strategy=remote
+build:rbe --define=EXECUTOR=remote
+build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build:rbe --experimental_strict_action_env=true
+
+# The following configuration forces Bazel to execute rules which depends on pkg_rpm() locally instead of in RBE.
+# The distribution_rpm() macro uses pkg_rpm() which uses the 'rpmbuild' binary under the hood.
+# It won't be available in some distributions and therefore can't be ran in RBE.
+# When executed, the pkg_rpm() rule will produce the "MakeRpm" Bazel actions
+# (you can look at what actions are produced when a target is executed by adding -s: bazel build -s //target:name).
+# Here we configure Bazel to execute "MakeRpm" actions locally:
+build:rbe --strategy_regexp=MakeRpm=local


### PR DESCRIPTION
adds `.bazelrc` to root for rbe support.

the content of the `.bazelrc` was copied over from `graknlabs/graql`