### PR TITLE
Add meta keywords and summary for each page

### DIFF
--- a/00-general/04-quickstart.md
+++ b/00-general/04-quickstart.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Quickstart
 pageTitle: Quickstart
+keywords: getting started, grakn, graql, tutorial, quickstart, overview
+longTailKeywords: get started with grakn, grakn tutorial, grakn quickstart, learn grakn
 permalink: /docs/general/quickstart
 ---
 

--- a/00-general/04-quickstart.md
+++ b/00-general/04-quickstart.md
@@ -2,6 +2,7 @@
 pageTitle: Quickstart
 keywords: getting started, grakn, graql, tutorial, quickstart, overview
 longTailKeywords: get started with grakn, grakn tutorial, grakn quickstart, learn grakn
+summary: Learn about the constructs of the Grakn Schema, visualise a knowledge graph, perform read and write queries and explore the power of automated reasoning and analytics with Grakn.
 permalink: /docs/general/quickstart
 ---
 

--- a/02-running-grakn/01-install-and-run.md
+++ b/02-running-grakn/01-install-and-run.md
@@ -2,6 +2,7 @@
 pageTitle: Install and Run Grakn
 keywords: setup, getting started, grakn, download, install, server, linux, mac, windows
 longTailKeywords: grakn on linux, grakn on mac, grakn on windows, start grakn server
+summary: Install and run the Grakn Server on Linux, Mac or Windows.
 toc: false
 permalink: /docs/running-grakn/install-and-run
 ---

--- a/02-running-grakn/01-install-and-run.md
+++ b/02-running-grakn/01-install-and-run.md
@@ -1,13 +1,13 @@
 ---
-sidebarTitle: Install & Run
 pageTitle: Install and Run Grakn
-permalink: /docs/running-grakn/install-and-run
+keywords: setup, getting started, grakn, download, install, server, linux, mac, windows
+longTailKeywords: grakn on linux, grakn on mac, grakn on windows, start grakn server
 toc: false
+permalink: /docs/running-grakn/install-and-run
 ---
 
 ## System Requirements
 Grakn runs on Mac, Linux and Windows. The only requirement is Java 8 which can be downloaded from [OpenJDK](http://openjdk.java.net/install/) or [Oracle Java](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
-
 
 ## Download and Install Grakn
 <div class="tabs light">

--- a/02-running-grakn/02-console.md
+++ b/02-running-grakn/02-console.md
@@ -1,15 +1,13 @@
 ---
-sidebarTitle: Console
 pageTitle: Grakn Console
-summary:
-permalink: /docs/running-grakn/console
+keywords: grakn, console
+longTailKeywords: load schema into grakn, create grakn keyspace, grakn console
 toc: false
+permalink: /docs/running-grakn/console
 ---
 
 ## What is the Grakn Console?
 The Grakn Console, along with the [Grakn Clients](/docs/client-api/overview) and [Workbase](...), is an interface which we can use to read from and write to a Grakn knowledge graph. Console interacts directly with a given keyspace that contains the Grakn knowledge graph.
-
-<!-- keyspace -> kbase -->
 
 ## Console Options {#console-options}
 

--- a/02-running-grakn/02-console.md
+++ b/02-running-grakn/02-console.md
@@ -2,6 +2,7 @@
 pageTitle: Grakn Console
 keywords: grakn, console
 longTailKeywords: load schema into grakn, create grakn keyspace, grakn console
+summary: List of options and commands for the Grakn Console.
 toc: false
 permalink: /docs/running-grakn/console
 ---

--- a/02-running-grakn/03-configuration.md
+++ b/02-running-grakn/03-configuration.md
@@ -2,6 +2,7 @@
 pageTitle: Configuring Grakn
 keywords: grakn, configure
 longTailKeywords: configure grakn, grakn configuration
+summary: Configure the Grakn Server based on your production and development needs.
 permalink: /docs/running-grakn/configuration
 ---
 

--- a/02-running-grakn/03-configuration.md
+++ b/02-running-grakn/03-configuration.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Configuration
 pageTitle: Configuring Grakn
+keywords: grakn, configure
+longTailKeywords: configure grakn, grakn configuration
 permalink: /docs/running-grakn/configuration
 ---
 

--- a/03-client-api/00-overview.md
+++ b/03-client-api/00-overview.md
@@ -2,6 +2,7 @@
 pageTitle: Grakn Clients
 keywords: grakn, client, api, grpc
 longTailKeywords: grakn client api, grakn api, client api, grakn client architecture, grakn session, grakn transaction
+Summary: All you need to know about the architecture of a Grakn Client.
 permalink: /docs/client-api/overview
 ---
 

--- a/03-client-api/00-overview.md
+++ b/03-client-api/00-overview.md
@@ -1,7 +1,7 @@
 ---
-sidebarTitle: Overview
 pageTitle: Grakn Clients
-
+keywords: grakn, client, api, grpc
+longTailKeywords: grakn client api, grakn api, client api, grakn client architecture, grakn session, grakn transaction
 permalink: /docs/client-api/overview
 ---
 

--- a/03-client-api/01-java.md
+++ b/03-client-api/01-java.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Java
 pageTitle: Client Java
+keywords: grakn, client, java
+longTailKeywords: grakn java client, grakn client java, client java, java client
 permalink: /docs/client-api/java
 ---
 

--- a/03-client-api/01-java.md
+++ b/03-client-api/01-java.md
@@ -2,6 +2,7 @@
 pageTitle: Client Java
 keywords: grakn, client, java
 longTailKeywords: grakn java client, grakn client java, client java, java client
+Summary: API Reference of Grakn Client Java.
 permalink: /docs/client-api/java
 ---
 

--- a/03-client-api/02-python.md
+++ b/03-client-api/02-python.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Python
 pageTitle: Client Python
+keywords: grakn, client, python
+longTailKeywords: grakn python client, grakn client python, client python, python client
 permalink: /docs/client-api/python
 ---
 

--- a/03-client-api/02-python.md
+++ b/03-client-api/02-python.md
@@ -2,6 +2,7 @@
 pageTitle: Client Python
 keywords: grakn, client, python
 longTailKeywords: grakn python client, grakn client python, client python, python client
+Summary: API Reference of Grakn Client Python.
 permalink: /docs/client-api/python
 ---
 

--- a/03-client-api/03-nodejs.md
+++ b/03-client-api/03-nodejs.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Node.js
 pageTitle: Client Node.js
+keywords: grakn, client, node.js
+longTailKeywords: grakn node.js client, grakn client node.js, client node.js, python node.js
 permalink: /docs/client-api/nodejs
 ---
 

--- a/03-client-api/03-nodejs.md
+++ b/03-client-api/03-nodejs.md
@@ -2,6 +2,7 @@
 pageTitle: Client Node.js
 keywords: grakn, client, node.js
 longTailKeywords: grakn node.js client, grakn client node.js, client node.js, python node.js
+Summary: API Reference of Grakn Client Node.js.
 permalink: /docs/client-api/nodejs
 ---
 

--- a/04-concept-api/00-overview.md
+++ b/04-concept-api/00-overview.md
@@ -2,6 +2,7 @@
 pageTitle: Concept API
 keywords: grakn, concept, api
 longTailKeywords: grakn concept api, concept api
+Summary: Concept Hierarchy in Grakn.
 toc: false
 permalink: /docs/concept-api/overview
 ---

--- a/04-concept-api/00-overview.md
+++ b/04-concept-api/00-overview.md
@@ -1,8 +1,9 @@
 ---
-sidebarTitle: Overview
 pageTitle: Concept API
-permalink: /docs/concept-api/overview
+keywords: grakn, concept, api
+longTailKeywords: grakn concept api, concept api
 toc: false
+permalink: /docs/concept-api/overview
 ---
 
 ## Concept Architecture

--- a/04-concept-api/01-concept.md
+++ b/04-concept-api/01-concept.md
@@ -1,8 +1,9 @@
 ---
-sidebarTitle: Concept
 pageTitle: Concept
-permalink: /docs/concept-api/concept
+keywords: grakn, concept, api, methods
+longTailKeywords: grakn concept, concept methods, grakn concept methods
 toc: true
+permalink: /docs/concept-api/concept
 ---
 
 ## Concept Methods & Props

--- a/04-concept-api/01-concept.md
+++ b/04-concept-api/01-concept.md
@@ -2,6 +2,7 @@
 pageTitle: Concept
 keywords: grakn, concept, api, methods
 longTailKeywords: grakn concept, concept methods, grakn concept methods
+Summary: Methods and props available on a Concept object.
 toc: true
 permalink: /docs/concept-api/concept
 ---

--- a/04-concept-api/02-type.md
+++ b/04-concept-api/02-type.md
@@ -1,7 +1,7 @@
 ---
-sidebarTitle: Type
 pageTitle: Type
-permalink: /docs/concept-api/type
+keywords: grakn, type, api, methods
+longTailKeywords: grakn type, type methods, grakn type methods, grakn entity type methods, grakn attribute type methods, grakn relation type methods, grakn role methods
 toc: true
 ---
 

--- a/04-concept-api/02-type.md
+++ b/04-concept-api/02-type.md
@@ -2,6 +2,7 @@
 pageTitle: Type
 keywords: grakn, type, api, methods
 longTailKeywords: grakn type, type methods, grakn type methods, grakn entity type methods, grakn attribute type methods, grakn relation type methods, grakn role methods
+Summary: Methods available on Type objects.
 toc: true
 ---
 

--- a/04-concept-api/03-rule.md
+++ b/04-concept-api/03-rule.md
@@ -1,8 +1,9 @@
 ---
-sidebarTitle: Rule
 pageTitle: Rule
-permalink: /docs/concept-api/rule
+keywords: grakn, rule, api, methods
+longTailKeywords: grakn rule, rule methods, grakn rule methods
 toc: false
+permalink: /docs/concept-api/rule
 ---
 
 ## Rule Methods

--- a/04-concept-api/03-rule.md
+++ b/04-concept-api/03-rule.md
@@ -2,6 +2,7 @@
 pageTitle: Rule
 keywords: grakn, rule, api, methods
 longTailKeywords: grakn rule, rule methods, grakn rule methods
+Summary: Methods available on a Rule object.
 toc: false
 permalink: /docs/concept-api/rule
 ---

--- a/04-concept-api/04-thing.md
+++ b/04-concept-api/04-thing.md
@@ -1,8 +1,9 @@
 ---
-sidebarTitle: Thing
 pageTitle: Thing
-permalink: /docs/concept-api/thing
+keywords: grakn, thing, api, methods, attribute
+longTailKeywords: grakn thing, grakn attribute, grakn relation, grakn thing methods, grakn attribute methods, grakn relation methods
 toc: true
+permalink: /docs/concept-api/thing
 ---
 
 ## Thing Methods

--- a/04-concept-api/04-thing.md
+++ b/04-concept-api/04-thing.md
@@ -2,6 +2,7 @@
 pageTitle: Thing
 keywords: grakn, thing, api, methods, attribute
 longTailKeywords: grakn thing, grakn attribute, grakn relation, grakn thing methods, grakn attribute methods, grakn relation methods
+Summary: Methods available on Thing objects.
 toc: true
 permalink: /docs/concept-api/thing
 ---

--- a/05-cloud-deployment/01-kgms.md
+++ b/05-cloud-deployment/01-kgms.md
@@ -1,8 +1,9 @@
 ---
-sidebarTitle: KGMS
 pageTitle: Grakn KGMS
-permalink: /docs/cloud-deployment/kgms
+keywords: grakn, kgms, knowledge graph management system, scalability, elastic throughput, cluster management
+longTailKeywords: grakn kgms, grakn knowledge graph management system, grakn enterprise
 toc: false
+permalink: /docs/cloud-deployment/kgms
 ---
 
 ## What is Grakn KGMS?

--- a/05-cloud-deployment/01-kgms.md
+++ b/05-cloud-deployment/01-kgms.md
@@ -2,6 +2,7 @@
 pageTitle: Grakn KGMS
 keywords: grakn, kgms, knowledge graph management system, scalability, elastic throughput, cluster management
 longTailKeywords: grakn kgms, grakn knowledge graph management system, grakn enterprise
+Summary: Features available exclusively on Grakn KGMS.
 toc: false
 permalink: /docs/cloud-deployment/kgms
 ---

--- a/05-cloud-deployment/02-google-cloud.md
+++ b/05-cloud-deployment/02-google-cloud.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Google Cloud
 pageTitle: Google Cloud Deployment
+keywords: grakn, cloud, deployment, google cloud, kgms
+longTailKeywords: grakn cloud deployment, grakn on the cloud, grakn kgms on the cloud, grakn kgms google cloud, grakn google cloud
 permalink: /docs/cloud-deployment/google-cloud
 ---
 

--- a/05-cloud-deployment/02-google-cloud.md
+++ b/05-cloud-deployment/02-google-cloud.md
@@ -2,10 +2,11 @@
 pageTitle: Google Cloud Deployment
 keywords: grakn, cloud, deployment, google cloud, kgms
 longTailKeywords: grakn cloud deployment, grakn on the cloud, grakn kgms on the cloud, grakn kgms google cloud, grakn google cloud
+Summary: Learn how to deploy Grakn KGMS on Google Cloud.
 permalink: /docs/cloud-deployment/google-cloud
 ---
 
-## Deploying Grakn on Google Cloud
+## Deploy Grakn on Google Cloud
 
 As illustrated below, deploying [Grakn KGMS on Google Cloud](https://console.cloud.google.com/marketplace/details/grakn-public/grakn-kgms-premium) is a straight-forward process.
 
@@ -159,16 +160,16 @@ While [logged into a node](#logging-into-a-node), run `grakn cluster status`. Th
 
 ![Cluster Health Check](/docs/images/cloud-deployment/gc_cluster_health_check.png)
 
-## Accessing Grakn Console
+## Access Grakn Console
 While [logged into a node](#logging-into-a-node), run `grakn console start`. This requires us to enter our credentials. If this is our first login, we need to enter the [default credentials](#default-credentials). Once authenticated, we are in the Grakn Console where, for instance, we may manage [authentication](/docs/management/users).
 
-## Accessing Grakn Console
+## Access Grakn Console
 While [logged into a node](#logging-into-a-node), we can enter the [Grakn Console](/docs/running-grakn/console) where we can interact with and perform [queries](/docs/query/overview) on our [keyspaces](/docs/management/keyspace).
 
 ## Configuring Grakn
 To ensure Grakn behaves according to your specific needs, you may [configure Grakn](/docs/running-grakn/configuration). One important attribute in Grakn configuration file, is the [path to the data directory](/docs/running-grakn/configuration#where-data-is-stored).
 
-## Signing up For Enterprise Support
+## Sign up For Enterprise Support
 As a user of Grakn KGMS on Google Cloud, you are entitled to [premium enterprise support](...).
 
 <hr style="margin-top: 40px">

--- a/05-cloud-deployment/03-aws.md
+++ b/05-cloud-deployment/03-aws.md
@@ -2,10 +2,11 @@
 pageTitle: Amazon Web Services Deployment
 keywords: grakn, cloud, deployment, amazon web services, aws, kgms
 longTailKeywords: grakn cloud deployment, grakn on the cloud, grakn kgms on the cloud, grakn kgms aws, grakn aws
+Summary: Learn how to deploy Grakn KGMS on Amazon Web Services.
 permalink: /docs/cloud-deployment/aws
 ---
 
-## Deploying Grakn on AWS
+## Deploy Grakn on AWS
 
 As illustrated below, deploying [Grakn KGMS on Amazon Web Services](https://aws.amazon.com/marketplace/pp/B07H8RMX5X) is a straight-forward process.
 
@@ -112,7 +113,7 @@ As illustrated below, deploying [Grakn KGMS on Amazon Web Services](https://aws.
 
 </div>
 
-## Running Grakn
+## Run Grakn
 Once the deployment is complete, a Grakn Cluster starts automatically. There is no need for starting Grakn Servers manually.
 
 <div class="note">
@@ -284,7 +285,7 @@ For more information check out AWS documentation on [Starting and Stopping Insta
 [slide:end]
 </div>
 
-## Running Grakn
+## Run Grakn
 Once the deployment is complete, Grakn starts automatically. There is no need for starting Grakn Servers manually.
 
 ## Default Credentials
@@ -293,7 +294,7 @@ When deploying an AMI, the default password is the instance id with username bei
 [tab:end]
 </div>
 
-## Logging into a node
+## Log into a node
 For a more direct interaction with the database, we need to log into one of the cluster nodes. To do so, we need to run the `ssh` as shown below.
 
 ```
@@ -311,16 +312,16 @@ While [logged into a node](#logging-into-a-node), run `grakn cluster status`. Th
 
 ![Cluster Health Check](/docs/images/cloud-deployment/aws_cluster_health_check.png)
 
-## Accessing Grakn Console
+## Access Grakn Console
 While [logged into a node](#logging-into-a-node), run `grakn console start`. This requires us to enter our credentials. If this is our first login, we need to enter the [default credentials](#default-credentials). Once authenticated, we are in the Grakn Console where, for instance, we may manage [authentication](/docs/management/users).
 
-## Accessing Grakn Console
+## Access Graql Console
 While [logged into a node](#logging-into-a-node), we can enter the [Grakn Console](/docs/running-grakn/console) where we can interact with and perform [queries](/docs/query/overview) on our [keyspaces](/docs/management/keyspace).
 
 ## Configuring Grakn
 To ensure Grakn behaves according to your specific needs, you may [configure Grakn](/docs/running-grakn/configuration). One important attribute in Grakn configuration file, is the [path to the data directory](/docs/running-grakn/configuration#where-data-is-stored).
 
-## Signing up For Enterprise Support
+## Sign up For Enterprise Support
 As a user of Grakn KGMS on Google Cloud, you are entitled to [premium enterprise support](...).
 
 <hr style="margin-top: 40px">

--- a/05-cloud-deployment/03-aws.md
+++ b/05-cloud-deployment/03-aws.md
@@ -1,7 +1,7 @@
 ---
-sidebarTitle: AWS
 pageTitle: Amazon Web Services Deployment
-summary:
+keywords: grakn, cloud, deployment, amazon web services, aws, kgms
+longTailKeywords: grakn cloud deployment, grakn on the cloud, grakn kgms on the cloud, grakn kgms aws, grakn aws
 permalink: /docs/cloud-deployment/aws
 ---
 

--- a/06-management/01-keyspace.md
+++ b/06-management/01-keyspace.md
@@ -1,8 +1,9 @@
 ---
-sidebarTitle: Keyspace
 pageTitle: Managing Keyspaces
-permalink: /docs/management/keyspace
+keywords: grakn, keyspace
+longTailKeywords: grakn keyspace
 toc: false
+permalink: /docs/management/keyspace
 ---
 
 ## What is a Keyspace?

--- a/06-management/01-keyspace.md
+++ b/06-management/01-keyspace.md
@@ -2,6 +2,7 @@
 pageTitle: Managing Keyspaces
 keywords: grakn, keyspace
 longTailKeywords: grakn keyspace
+Summary: Creating, listing, cleaning and deleting Grakn Keyspaces.
 toc: false
 permalink: /docs/management/keyspace
 ---

--- a/06-management/02-users.md
+++ b/06-management/02-users.md
@@ -1,8 +1,9 @@
 ---
-sidebarTitle: Users
 pageTitle: Managing Users
-permalink: /docs/management/users
+keywords: grakn, management, authentication, users
+longTailKeywords: grakn managing users, grakn authentication, grakn users
 toc: false
+permalink: /docs/management/users
 ---
 
 ## Managing Users [KGMS ONLY]

--- a/06-management/02-users.md
+++ b/06-management/02-users.md
@@ -2,6 +2,7 @@
 pageTitle: Managing Users
 keywords: grakn, management, authentication, users
 longTailKeywords: grakn managing users, grakn authentication, grakn users
+Summary: User authentication in Grakn KGMS.
 toc: false
 permalink: /docs/management/users
 ---

--- a/07-workbase/00-overview.md
+++ b/07-workbase/00-overview.md
@@ -2,6 +2,7 @@
 pageTitle: Grakn Workbase
 keywords: grakn, workbase, visualiser, visualisation, visualizer, visualization
 longTailKeywords: grakn workbase, grakn visualiser, grakn visualisation, grakn visualizer, grakn visualization
+Summary: An overview of Grakn Workbase.
 toc: false
 permalink: /docs/workbase/overview
 ---

--- a/07-workbase/00-overview.md
+++ b/07-workbase/00-overview.md
@@ -1,8 +1,9 @@
 ---
-sidebarTitle: Overview
 pageTitle: Grakn Workbase
-permalink: /docs/workbase/overview
+keywords: grakn, workbase, visualiser, visualisation, visualizer, visualization
+longTailKeywords: grakn workbase, grakn visualiser, grakn visualisation, grakn visualizer, grakn visualization
 toc: false
+permalink: /docs/workbase/overview
 ---
 
 ## What is Workbase?

--- a/07-workbase/01-preferences.md
+++ b/07-workbase/01-preferences.md
@@ -2,6 +2,7 @@
 pageTitle: Configuring Connection
 keywords: grakn, workbase, workbase preferences
 longTailKeywords: grakn workbase preferences, grakn workbase connection, grakn workbase manage keyspaces
+Summary: Working with the preferences panel in Grakn Workbase.
 toc: false
 permalink: /docs/workbase/connection
 ---

--- a/07-workbase/01-preferences.md
+++ b/07-workbase/01-preferences.md
@@ -1,8 +1,9 @@
 ---
-sidebarTitle: Connection
 pageTitle: Configuring Connection
-permalink: /docs/workbase/connection
+keywords: grakn, workbase, workbase preferences
+longTailKeywords: grakn workbase preferences, grakn workbase connection, grakn workbase manage keyspaces
 toc: false
+permalink: /docs/workbase/connection
 ---
 
 ## Connect to Grakn

--- a/07-workbase/02-visualising.md
+++ b/07-workbase/02-visualising.md
@@ -1,8 +1,9 @@
 ---
-sidebarTitle: Visualisation
 pageTitle: Visualising Results
-permalink: /docs/workbase/visualisation
+keywords: grakn, workbase, visualisation
+longTailKeywords: grakn visualise graph, visualise grakn, visualise grakn graph, workbase visualisation, grakn visualize graph, visualize grakn, visualize grakn graph, workbase visualization
 toc: false
+permalink: /docs/workbase/visualisation
 ---
 
 ## Visualise
@@ -67,13 +68,8 @@ Workbase allows visualisation of answers returned by [Graql queries](/docs/query
 [slide:end]
 <!-- -->
 [slide:start]
-<<<<<<< HEAD
 [body:start]![Launch](/docs/images/workbase/1.1.1/visualise_types-select.png)[body:end]
 [footer:start]We can then click on any of the Concept Types which may be an entity, an attribute or a relationship.[footer:end]
-=======
-[body:start]![Launch](/docs/images/workbase/types_select.png)[body:end]
-[footer:start]We can then click on any of the Concept Types which may be an entity, an attribute or a relation.[footer:end]
->>>>>>> 9b0d32d6d262336d84b33380cae01d110fc55c04
 [slide:end]
 <!-- -->
 [slide:start]

--- a/07-workbase/02-visualising.md
+++ b/07-workbase/02-visualising.md
@@ -2,6 +2,7 @@
 pageTitle: Visualising Results
 keywords: grakn, workbase, visualisation
 longTailKeywords: grakn visualise graph, visualise grakn, visualise grakn graph, workbase visualisation, grakn visualize graph, visualize grakn, visualize grakn graph, workbase visualization
+Summary: Using Workbase to visualise a Grakn Knowledge Graph.
 toc: false
 permalink: /docs/workbase/visualisation
 ---

--- a/07-workbase/03-investigating.md
+++ b/07-workbase/03-investigating.md
@@ -2,6 +2,7 @@
 pageTitle: Investigating Results
 keywords: grakn, workbase, investigation
 longTailKeywords: grakn investigate nodes, workbase investigation
+Summary: Using Workbase to investigate nodes in a Grakn Knowledge Graph.
 toc: false
 permalink: /docs/workbase/investigation
 ---

--- a/07-workbase/03-investigating.md
+++ b/07-workbase/03-investigating.md
@@ -1,8 +1,9 @@
 ---
-sidebarTitle: Investigation
 pageTitle: Investigating Results
-permalink: /docs/workbase/investigation
+keywords: grakn, workbase, investigation
+longTailKeywords: grakn investigate nodes, workbase investigation
 toc: false
+permalink: /docs/workbase/investigation
 ---
 
 ## Investigate

--- a/07-workbase/04-schema-designer.md
+++ b/07-workbase/04-schema-designer.md
@@ -1,8 +1,9 @@
 ---
-sidebarTitle: Schema Designer
 pageTitle: Schema
-permalink: /docs/workbase/schema-designer
+keywords: grakn, workbase, schema designer
+longTailKeywords: grakn design schema, workbase schema designer
 toc: false
+permalink: /docs/workbase/schema-designer
 ---
 
 ## Design a Schema

--- a/07-workbase/04-schema-designer.md
+++ b/07-workbase/04-schema-designer.md
@@ -2,6 +2,7 @@
 pageTitle: Schema
 keywords: grakn, workbase, schema designer
 longTailKeywords: grakn design schema, workbase schema designer
+Summary: Using Workbase to design a schema.
 toc: false
 permalink: /docs/workbase/schema-designer
 ---

--- a/08-examples/01-overview.md
+++ b/08-examples/01-overview.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Overview
 pageTitle: Phone Calls Knowledge Graph
+keywords: grakn, examples, migration, queries, schema
+longTailKeywords: grakn examples, grakn migration, grakn query examples, grakn schema example
 permalink: /docs/examples/phone-calls-overview
 ---
 

--- a/08-examples/01-overview.md
+++ b/08-examples/01-overview.md
@@ -2,6 +2,7 @@
 pageTitle: Phone Calls Knowledge Graph
 keywords: grakn, examples, migration, queries, schema
 longTailKeywords: grakn examples, grakn migration, grakn query examples, grakn schema example
+Summary: Grakn examples showcasing schema definition, data migration and retrieval queries
 permalink: /docs/examples/phone-calls-overview
 ---
 

--- a/08-examples/02-schema.md
+++ b/08-examples/02-schema.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Schema
 pageTitle: Defining a Sample Schema
+keywords: grakn, examples, schema
+longTailKeywords: grakn examples, grakn schema example
 permalink: /docs/examples/phone-calls-schema
 ---
 

--- a/08-examples/02-schema.md
+++ b/08-examples/02-schema.md
@@ -2,6 +2,7 @@
 pageTitle: Defining a Sample Schema
 keywords: grakn, examples, schema
 longTailKeywords: grakn examples, grakn schema example
+Summary: Learn how to define a simple schema in Grakn.
 permalink: /docs/examples/phone-calls-schema
 ---
 

--- a/08-examples/03-migration-java.md
+++ b/08-examples/03-migration-java.md
@@ -1,7 +1,7 @@
 ---
-sidebarTitle: Migrate - Java
 pageTitle: Migrating CSV, JSON and XML Data with Client Java
-
+keywords: grakn, examples, migration, java
+longTailKeywords: grakn java migration
 permalink: /docs/examples/phone-calls-migration-java
 ---
 

--- a/08-examples/03-migration-java.md
+++ b/08-examples/03-migration-java.md
@@ -2,6 +2,7 @@
 pageTitle: Migrating CSV, JSON and XML Data with Client Java
 keywords: grakn, examples, migration, java
 longTailKeywords: grakn java migration
+Summary: Learn how to use Client Java to migrate CSV, JSON and XML data into a Grakn Knowledge Graph.
 permalink: /docs/examples/phone-calls-migration-java
 ---
 

--- a/08-examples/04-migration-nodejs.md
+++ b/08-examples/04-migration-nodejs.md
@@ -2,6 +2,7 @@
 pageTitle: Migrating CSV, JSON and XML Data with Client Node.js
 keywords: grakn, examples, migration, node.js
 longTailKeywords: grakn node.js migration
+Summary: Learn how to use Client Node.js to migrate CSV, JSON and XML data into a Grakn Knowledge Graph.
 permalink: /docs/examples/phone-calls-migration-nodejs
 ---
 

--- a/08-examples/04-migration-nodejs.md
+++ b/08-examples/04-migration-nodejs.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Migrate - Node.js
 pageTitle: Migrating CSV, JSON and XML Data with Client Node.js
+keywords: grakn, examples, migration, node.js
+longTailKeywords: grakn node.js migration
 permalink: /docs/examples/phone-calls-migration-nodejs
 ---
 

--- a/08-examples/05-migration-python.md
+++ b/08-examples/05-migration-python.md
@@ -2,6 +2,7 @@
 pageTitle: Migrating CSV, JSON and XML Data with Client Python
 keywords: grakn, examples, migration, python
 longTailKeywords: grakn python migration
+Summary: Learn how to use Client Python to migrate CSV, JSON and XML data into a Grakn Knowledge Graph.
 permalink: /docs/examples/phone-calls-migration-python
 ---
 

--- a/08-examples/05-migration-python.md
+++ b/08-examples/05-migration-python.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Migrate - Python
 pageTitle: Migrating CSV, JSON and XML Data with Client Python
+keywords: grakn, examples, migration, python
+longTailKeywords: grakn python migration
 permalink: /docs/examples/phone-calls-migration-python
 ---
 

--- a/08-examples/06-queries.md
+++ b/08-examples/06-queries.md
@@ -2,6 +2,7 @@
 pageTitle: Queries the Phone Calls Knowledge Graph
 keywords: grakn, examples, queries
 longTailKeywords: grakn query example
+Summary: Learn how to obtain insights by writing expressive Graql queries.
 permalink: /docs/examples/phone-calls-queries
 ---
 

--- a/08-examples/06-queries.md
+++ b/08-examples/06-queries.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Queries
 pageTitle: Queries the Phone Calls Knowledge Graph
+keywords: grakn, examples, queries
+longTailKeywords: grakn query example
 permalink: /docs/examples/phone-calls-queries
 ---
 

--- a/09-schema/00-overview.md
+++ b/09-schema/00-overview.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Overview
 pageTitle: Schema
+keywords: graql, schema, type hierarchy, reserved keywords
+longTailKeywords: graql schema, graql type hierarchy, graql data model, graql reserved keyword
 permalink: /docs/schema/overview
 ---
 

--- a/09-schema/00-overview.md
+++ b/09-schema/00-overview.md
@@ -2,6 +2,7 @@
 pageTitle: Schema
 keywords: graql, schema, type hierarchy, reserved keywords
 longTailKeywords: graql schema, graql type hierarchy, graql data model, graql reserved keyword
+Summary: Introduction to the Grakn Schema.
 permalink: /docs/schema/overview
 ---
 

--- a/09-schema/01-concepts.md
+++ b/09-schema/01-concepts.md
@@ -2,6 +2,7 @@
 pageTitle: Schema Concepts
 keywords: graql, schema, type hierarchy, concept, define
 longTailKeywords: graql schema, graql define query, graql type hierarchy, graql concepts, graql define entity, graql define relation, graql define attribute, graql schema definition
+Summary: A comprehensive guide on defining Schema Concepts in Grakn.
 permalink: /docs/schema/concepts
 ---
 

--- a/09-schema/01-concepts.md
+++ b/09-schema/01-concepts.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Concepts
 pageTitle: Schema Concepts
+keywords: graql, schema, type hierarchy, concept, define
+longTailKeywords: graql schema, graql define query, graql type hierarchy, graql concepts, graql define entity, graql define relation, graql define attribute, graql schema definition
 permalink: /docs/schema/concepts
 ---
 

--- a/09-schema/03-rules.md
+++ b/09-schema/03-rules.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Rules
 pageTitle: Rules
+keywords: graql, rule, reasoning, automated reasoning
+longTailKeywords: grakn reasoning, grakn automated reasoning, grakn rules
 permalink: /docs/schema/rules
 ---
 

--- a/09-schema/03-rules.md
+++ b/09-schema/03-rules.md
@@ -2,6 +2,7 @@
 pageTitle: Rules
 keywords: graql, rule, reasoning, automated reasoning
 longTailKeywords: grakn reasoning, grakn automated reasoning, grakn rules
+Summary: Taking advantage of automated reasoning with Rules in Grakn.
 permalink: /docs/schema/rules
 ---
 

--- a/10-query/00-overview.md
+++ b/10-query/00-overview.md
@@ -2,6 +2,7 @@
 pageTitle: Graql Queries
 keywords: graql, query, reserved keywords
 longTailKeywords: graql queries, graql query structure, graql reserved keywords
+Summary: Introduction to Graql queries.
 permalink: /docs/query/overview
 ---
 

--- a/10-query/00-overview.md
+++ b/10-query/00-overview.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Overview
 pageTitle: Graql Queries
+keywords: graql, query, reserved keywords
+longTailKeywords: graql queries, graql query structure, graql reserved keywords
 permalink: /docs/query/overview
 ---
 

--- a/10-query/01-match-clause.md
+++ b/10-query/01-match-clause.md
@@ -2,6 +2,7 @@
 pageTitle: Match Clause
 keywords: graql, query, match, pattern, statement, variable
 longTailKeywords: graql match, graql match get, graql patterns, graql statements, graql variables
+Summary: Targeting instances of data that match expressive patterns in Grakn.
 permalink: /docs/query/match-clause
 ---
 

--- a/10-query/01-match-clause.md
+++ b/10-query/01-match-clause.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Match
 pageTitle: Match Clause
+keywords: graql, query, match, pattern, statement, variable
+longTailKeywords: graql match, graql match get, graql patterns, graql statements, graql variables
 permalink: /docs/query/match-clause
 ---
 

--- a/10-query/02-get-query.md
+++ b/10-query/02-get-query.md
@@ -2,6 +2,7 @@
 pageTitle: Get Query
 keywords: graql, get query, retrieval, modifier
 longTailKeywords: grakn retrieve data, grakn read data, graql get query, graql modifiers, graql offset, graql sort, graql limit
+Summary: Get (retrieval) queries and modifiers in Grakn.
 permalink: /docs/query/get-query
 ---
 

--- a/10-query/02-get-query.md
+++ b/10-query/02-get-query.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Get
 pageTitle: Get Query
+keywords: graql, get query, retrieval, modifier
+longTailKeywords: grakn retrieve data, grakn read data, graql get query, graql modifiers, graql offset, graql sort, graql limit
 permalink: /docs/query/get-query
 ---
 

--- a/10-query/03-insert-query.md
+++ b/10-query/03-insert-query.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Insert
 pageTitle: Insert Query
+keywords: graql, insert query, insertion
+longTailKeywords: grakn insert data, graql insert query, graql create instances
 permalink: /docs/query/insert-query
 ---
 

--- a/10-query/03-insert-query.md
+++ b/10-query/03-insert-query.md
@@ -2,6 +2,7 @@
 pageTitle: Insert Query
 keywords: graql, insert query, insertion
 longTailKeywords: grakn insert data, graql insert query, graql create instances
+Summary: Insert queries in Grakn.
 permalink: /docs/query/insert-query
 ---
 

--- a/10-query/04-delete-query.md
+++ b/10-query/04-delete-query.md
@@ -2,6 +2,7 @@
 pageTitle: Delete Query
 keywords: graql, delete query, deletion
 longTailKeywords: grakn delete data, graql delete query, graql delete instances
+Summary: Delete queries in Grakn.
 permalink: /docs/query/delete-query
 ---
 

--- a/10-query/04-delete-query.md
+++ b/10-query/04-delete-query.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Delete
 pageTitle: Delete Query
+keywords: graql, delete query, deletion
+longTailKeywords: grakn delete data, graql delete query, graql delete instances
 permalink: /docs/query/delete-query
 ---
 

--- a/10-query/05-updating-data.md
+++ b/10-query/05-updating-data.md
@@ -2,6 +2,7 @@
 pageTitle: Updating Data
 keywords: graql, update query, modification
 longTailKeywords: grakn update data, graql update query, graql update instances
+Summary: Updating data in Grakn.
 permalink: /docs/query/updating-data
 ---
 

--- a/10-query/05-updating-data.md
+++ b/10-query/05-updating-data.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Update
 pageTitle: Updating Data
+keywords: graql, update query, modification
+longTailKeywords: grakn update data, graql update query, graql update instances
 permalink: /docs/query/updating-data
 ---
 

--- a/10-query/06-aggregate-query.md
+++ b/10-query/06-aggregate-query.md
@@ -2,6 +2,7 @@
 pageTitle: Aggregate Query
 keywords: graql, aggregate query, calculation, statistics
 longTailKeywords: grakn aggregate data, graql aggregate query, graql statistics
+Summary: Statistical queries in Grakn.
 permalink: /docs/query/aggregate-query
 ---
 

--- a/10-query/06-aggregate-query.md
+++ b/10-query/06-aggregate-query.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Aggregate
 pageTitle: Aggregate Query
+keywords: graql, aggregate query, calculation, statistics
+longTailKeywords: grakn aggregate data, graql aggregate query, graql statistics
 permalink: /docs/query/aggregate-query
 ---
 

--- a/10-query/07-compute-query.md
+++ b/10-query/07-compute-query.md
@@ -2,6 +2,7 @@
 pageTitle: Compute Query
 keywords: graql, compute query, shortest path, cluster, centrality, statistics
 longTailKeywords: grakn compute data, graql compute statistics, graql compute shortest path, graql compute centrality, graql compute cluster
+Summary: Compute statistics, shortest path, clusters and centrality in Grakn.
 permalink: /docs/query/compute-query
 ---
 

--- a/10-query/07-compute-query.md
+++ b/10-query/07-compute-query.md
@@ -1,6 +1,7 @@
 ---
-sidebarTitle: Compute
 pageTitle: Compute Query
+keywords: graql, compute query, shortest path, cluster, centrality, statistics
+longTailKeywords: grakn compute data, graql compute statistics, graql compute shortest path, graql compute centrality, graql compute cluster
 permalink: /docs/query/compute-query
 ---
 


### PR DESCRIPTION
This PR is for SEO purposes.

The keywords and summaries added to each markdown page are contained within `meta` tags inside the `head` tag of each page. The file that contains content of the `head` tag is a part of the `web-dev` repository (https://github.com/graknlabs/web-dev/blob/master/_includes/head.html).

The `web-dev` counterpart of this PR is: https://github.com/graknlabs/web-dev/pull/37 