### PR TITLE
rename parab lang to tab

### DIFF
--- a/04-concept-api/02-type.md
+++ b/04-concept-api/02-type.md
@@ -91,12 +91,12 @@ toc: true
 <div class="note">
 [Important]
 At the moment, `Role` inherits an intermediary class which, for the sake of simplicity, has not been documented. Therefore, besides the `Concept` methods, Role inherits the following methods from the `Type` class.
-- [label();](?lang=java#concept-api-java-method-retrieve-the-label)
-- [type.label(Label.of(label));](?lang=java#concept-api-java-method-rename-the-label)
-- [sup();](?lang=java#concept-api-java-method-retrieve-direct-supertype)
-- [sup(Type type);](?lang=java#concept-api-java-method-change-direct-supertype)
-- [sups();](?lang=java#concept-api-java-method-retrieve-all-supertypes)
-- [subs();](?lang=java#concept-api-java-method-retrieve-all-subtypes)
+- [label();](?tab=java#concept-api-java-method-retrieve-the-label)
+- [type.label(Label.of(label));](?tab=java#concept-api-java-method-rename-the-label)
+- [sup();](?tab=java#concept-api-java-method-retrieve-direct-supertype)
+- [sup(Type type);](?tab=java#concept-api-java-method-change-direct-supertype)
+- [sups();](?tab=java#concept-api-java-method-retrieve-all-supertypes)
+- [subs();](?tab=java#concept-api-java-method-retrieve-all-subtypes)
 </div>
 
 {% include api/generic.html data=site.data.concept_api.role language="java" class_prefix="concept-api-java" %}
@@ -106,12 +106,12 @@ At the moment, `Role` inherits an intermediary class which, for the sake of simp
 <div class="note">
 [Important]
 At the moment, `Role` inherits an intermediary class which, for the sake of simplicity, has not been documented. Therefore, besides the `Concept` methods, Role inherits the following methods from the `Type` class.
-- [label();](?lang=javascript#concept-api-nodejs-method-retrieve-the-label)
-- [type.label(Label.of(label));](?lang=javascript#concept-api-nodejs-method-rename-the-label)
-- [sup();](?lang=javascript#concept-api-nodejs-method-retrieve-direct-supertype)
-- [sup(Type type);](?lang=javascript#concept-api-nodejs-method-change-direct-supertype)
-- [sups();](?lang=javascript#concept-api-nodejs-method-retrieve-all-supertypes)
-- [subs();](?lang=javascript#concept-api-nodejs-method-retrieve-all-subtypes)
+- [label();](?tab=javascript#concept-api-nodejs-method-retrieve-the-label)
+- [type.label(Label.of(label));](?tab=javascript#concept-api-nodejs-method-rename-the-label)
+- [sup();](?tab=javascript#concept-api-nodejs-method-retrieve-direct-supertype)
+- [sup(Type type);](?tab=javascript#concept-api-nodejs-method-change-direct-supertype)
+- [sups();](?tab=javascript#concept-api-nodejs-method-retrieve-all-supertypes)
+- [subs();](?tab=javascript#concept-api-nodejs-method-retrieve-all-subtypes)
 </div>
 {% include api/generic.html data=site.data.concept_api.role language="javascript" class_prefix="concept-api-nodejs" %}
 [tab:end]
@@ -120,12 +120,12 @@ At the moment, `Role` inherits an intermediary class which, for the sake of simp
 <div class="note">
 [Important]
 At the moment, `Role` inherits an intermediary class which, for the sake of simplicity, has not been documented. Therefore, besides the `Concept` methods, Role inherits the following methods from the `Type` class.
-- [label();](?lang=python#concept-api-python-method-retrieve-the-label)
-- [type.label(Label.of(label));](?lang=python#concept-api-python-method-rename-the-label)
-- [sup();](?lang=python#concept-api-python-method-retrieve-direct-supertype)
-- [sup(Type type);](?lang=python#concept-api-python-method-change-direct-supertype)
-- [sups();](?lang=python#concept-api-python-method-retrieve-all-supertypes)
-- [subs();](?lang=python#concept-api-python-method-retrieve-all-subtypes)
+- [label();](?tab=python#concept-api-python-method-retrieve-the-label)
+- [type.label(Label.of(label));](?tab=python#concept-api-python-method-rename-the-label)
+- [sup();](?tab=python#concept-api-python-method-retrieve-direct-supertype)
+- [sup(Type type);](?tab=python#concept-api-python-method-change-direct-supertype)
+- [sups();](?tab=python#concept-api-python-method-retrieve-all-supertypes)
+- [subs();](?tab=python#concept-api-python-method-retrieve-all-subtypes)
 </div>
 {% include api/generic.html data=site.data.concept_api.role language="python" class_prefix="concept-api-python" %}
 [tab:end]

--- a/04-concept-api/references/attribute.yml
+++ b/04-concept-api/references/attribute.yml
@@ -38,14 +38,14 @@ methods:
       <<: *method-owners
       method: attribute.owners();
       return:
-        - "Stream of [`Thing`](/docs/concept-api/thing?lang=java) objects"
+        - "Stream of [`Thing`](/docs/concept-api/thing?tab=java) objects"
     javascript:
       <<: *method-owners
       method: await attribute.owners();
       return:
-        - "Iterator of [`Thing`](/docs/concept-api/thing?lang=javascript) objects"
+        - "Iterator of [`Thing`](/docs/concept-api/thing?tab=javascript) objects"
     python:
       <<: *method-owners
       method: attribute.owners()
       return:
-        - "Iterator of [`Thing`](/docs/concept-api/thing?lang=python) objects"
+        - "Iterator of [`Thing`](/docs/concept-api/thing?tab=python) objects"

--- a/04-concept-api/references/attribute_type.yml
+++ b/04-concept-api/references/attribute_type.yml
@@ -18,7 +18,7 @@ methods:
           <<: *accepts-create-value
           type: String &#124; boolean &#124; long &#124; double &#124; Date
       returns:
-        - "[`Attribute`](/docs/concept-api/thing?lang=java#attribute-methods) object"
+        - "[`Attribute`](/docs/concept-api/thing?tab=java#attribute-methods) object"
     javascript:
       <<: *method-create
       method: await attributeType.create(value);
@@ -27,7 +27,7 @@ methods:
           <<: *accepts-create-value
           type: String &#124; boolean &#124; integer &#124; float &#124; date
       returns:
-        - "[`Attribute`](/docs/concept-api/thing?lang=javascript#attribute-methods) object"
+        - "[`Attribute`](/docs/concept-api/thing?tab=javascript#attribute-methods) object"
     python:
       <<: *method-create
       method: attribute_type.create(value)
@@ -36,7 +36,7 @@ methods:
           <<: *accepts-create-value
           type: String &#124; boolean &#124; integer &#124; float &#124; date
       returns:
-        - "[`Attribute`](/docs/concept-api/thing?lang=python#attribute-methods) object"
+        - "[`Attribute`](/docs/concept-api/thing?tab=python#attribute-methods) object"
 
   - method:
     common: &method-attribute
@@ -53,19 +53,19 @@ methods:
       <<: *method-attribute
       method: attributeType.attribute(Object value);
       returns:
-        - "[`Attribute`](/docs/concept-api/thing?lang=java#attribute-methods) object"
+        - "[`Attribute`](/docs/concept-api/thing?tab=java#attribute-methods) object"
         - "NULL"
     javascript:
       <<: *method-attribute
       method: await attributeType.attribute(value);
       returns:
-        - "[`Attribute`](/docs/concept-api/thing?lang=javascript#attribute-methods) object"
+        - "[`Attribute`](/docs/concept-api/thing?tab=javascript#attribute-methods) object"
         - "`null`"
     python:
       <<: *method-attribute
       method: attribute_type.attribute(value)
       returns:
-        - "[`Attribute`](/docs/concept-api/thing?lang=python#attribute-methods) object"
+        - "[`Attribute`](/docs/concept-api/thing?tab=python#attribute-methods) object"
         - "`None`"
 
   - method:
@@ -122,7 +122,7 @@ methods:
       <<: *method-regex-set
       method: attributeType.regex(String regex);
       returns:
-        - "[`AttributeType`](/docs/concept-api/type?lang=java#attributetype-methods) object"
+        - "[`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods) object"
     javascript:
       <<: *method-regex-set
       method: await attributeType.regex(regex);
@@ -132,4 +132,4 @@ methods:
       <<: *method-regex-set
       method: attribute_type.regex(regex)
       returns:
-        - "[`AttributeType`](/docs/concept-api/type?lang=python#attributetype-methods) object"
+        - "[`AttributeType`](/docs/concept-api/type?tab=python#attributetype-methods) object"

--- a/04-concept-api/references/concept.yml
+++ b/04-concept-api/references/concept.yml
@@ -164,7 +164,7 @@ methods:
       description: Casts the concept as Type so that we can call the Type methods on it.
       method: concept.asType();
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=java) object"
+        - "[`Type`](/docs/concept-api/type?tab=java) object"
     java:
       <<: *method-asType
 
@@ -174,7 +174,7 @@ methods:
       description: Casts the concept as Thing so that we can call the Thing methods on it.
       method: concept.asThing();
       returns:
-        - "[`Thing`](/docs/concept-api/thing?lang=java) object"
+        - "[`Thing`](/docs/concept-api/thing?tab=java) object"
     java:
       <<: *method-asThing
 
@@ -184,7 +184,7 @@ methods:
       description: Casts the concept as EntityType so that we can call the EntityType methods on it.
       method: concept.asEntityType();
       returns:
-        - "[`EntityType`](/docs/concept-api/type?lang=java#entitytype-methods) object"
+        - "[`EntityType`](/docs/concept-api/type?tab=java#entitytype-methods) object"
     java:
       <<: *method-asEntityType
 
@@ -194,7 +194,7 @@ methods:
       description: Casts the concept as AttributeType so that we can call the AttributeType methods on it.
       method: concept.asAttributeType();
       returns:
-        - "[`AttributeType`](/docs/concept-api/type?lang=java#attributetype-methods) object"
+        - "[`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods) object"
     java:
       <<: *method-asAttributeType
 
@@ -204,7 +204,7 @@ methods:
       description: Casts the concept as RelationType so that we can call the RelationType methods on it.
       method: concept.asRelationType();
       returns:
-        - "[`RelationType`](/docs/concept-api/type?lang=java#relationtype-methods) object"
+        - "[`RelationType`](/docs/concept-api/type?tab=java#relationtype-methods) object"
     java:
       <<: *method-asRelationType
 
@@ -214,7 +214,7 @@ methods:
       description: Casts the concept as AttributeType so that we can call the AttributeType methods on it.
       method: concept.asAttributeType();
       returns:
-        - "[`AttributeType`](/docs/concept-api/type?lang=java#attributetype-methods) object"
+        - "[`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods) object"
     java:
       <<: *method-asAttributeType
 
@@ -234,7 +234,7 @@ methods:
       description: Casts the concept as Attribute so that we can call the Attribute methods on it.
       method: concept.asAttribute();
       returns:
-        - "[`Attribute`](/docs/concept-api/thing?lang=java#attribute-methods) object"
+        - "[`Attribute`](/docs/concept-api/thing?tab=java#attribute-methods) object"
     java:
       <<: *method-asAttribute
 
@@ -244,7 +244,7 @@ methods:
       description: Casts the concept as Relation so that we can call the Relation methods on it.
       method: concept.asRelation();
       returns:
-        - "[`Relation`](/docs/concept-api/thing?lang=java#relation-methods) object"
+        - "[`Relation`](/docs/concept-api/thing?tab=java#relation-methods) object"
     java:
       <<: *method-asRelation
 
@@ -254,7 +254,7 @@ methods:
         description: Casts the concept as Relation so that we can call the Relation methods on it.
         method: concept.asRelation();
         returns:
-          - "[`Rule`](/docs/concept-api/rule?lang=java) object"
+          - "[`Rule`](/docs/concept-api/rule?tab=java) object"
       java:
         <<: *method-asRelation
 

--- a/04-concept-api/references/relation.yml
+++ b/04-concept-api/references/relation.yml
@@ -7,17 +7,17 @@ methods:
       <<: *method-rolePlayersMap
       method: relation.rolePlayersMap();
       returns:
-        - 'Map<[`Role`](/docs/concept-api/type?lang=java#role-methods), Set<[`Thing`](/docs/concept-api/thing?lang=java#thing-methods)>>'
+        - 'Map<[`Role`](/docs/concept-api/type?tab=java#role-methods), Set<[`Thing`](/docs/concept-api/thing?tab=java#thing-methods)>>'
     javascript:
       <<: *method-rolePlayersMap
       method: await relation.rolePlayersMap();
       returns:
-        - 'Map<[`Role`](/docs/concept-api/type?lang=java#role-methods), Set<[`Thing`](/docs/concept-api/thing?lang=java#thing-methods)>>'
+        - 'Map<[`Role`](/docs/concept-api/type?tab=java#role-methods), Set<[`Thing`](/docs/concept-api/thing?tab=java#thing-methods)>>'
     python:
       <<: *method-rolePlayersMap
       method: relation.role_players_map()
       returns:
-        - Dict[[`Role`](/docs/concept-api/type?lang=java#role-methods), set[[`Thing`](/docs/concept-api/thing?lang=java#thing-methods)]]
+        - Dict[[`Role`](/docs/concept-api/type?tab=java#role-methods), set[[`Thing`](/docs/concept-api/thing?tab=java#thing-methods)]]
 
   - method:
     common: &method-rolePlayers
@@ -35,27 +35,27 @@ methods:
       accepts:
         param:
           <<: *accepts-rolePlayers-role
-          type: "[`Role`](/docs/concept-api/type?lang=java#role-methods)"
+          type: "[`Role`](/docs/concept-api/type?tab=java#role-methods)"
       returns:
-        - "Stream of [`Thing`](/docs/concept-api/thing?lang=java) objects"
+        - "Stream of [`Thing`](/docs/concept-api/thing?tab=java) objects"
     javascript:
       <<: *method-rolePlayers
       method: await relation.rolePlayers(role);
       accepts:
         param:
           <<: *accepts-rolePlayers-role
-          type: "[`Role`](/docs/concept-api/type?lang=javascript#role-methods)"
+          type: "[`Role`](/docs/concept-api/type?tab=javascript#role-methods)"
       returns:
-        - "Iterator of [`Thing`](/docs/concept-api/thing?lang=java) objects"
+        - "Iterator of [`Thing`](/docs/concept-api/thing?tab=java) objects"
     python:
       <<: *method-rolePlayers
       method: relation.role_players(role)
       accepts:
         param:
           <<: *accepts-rolePlayers-role
-          type: "[`Role`](/docs/concept-api/type?lang=python#role-methods)"
+          type: "[`Role`](/docs/concept-api/type?tab=python#role-methods)"
       returns:
-        - "Iterator of [`Thing`](/docs/concept-api/thing?lang=java) objects"
+        - "Iterator of [`Thing`](/docs/concept-api/thing?tab=java) objects"
 
   - method:
     common: &method-assign
@@ -78,10 +78,10 @@ methods:
       accepts:
         param1:
           <<: *accepts-assign-role
-          type: "[`Role`](/docs/concept-api/type?lang=java#role-methods)"
+          type: "[`Role`](/docs/concept-api/type?tab=java#role-methods)"
         param2:
           <<: *accepts-assign-thing
-          type: "[`Thing`](/docs/concept-api/thing?lang=java)"
+          type: "[`Thing`](/docs/concept-api/thing?tab=java)"
       returns:
         - '[`Relation`](/docs/concept-api/thing#relation-methods) object'
     javascript:
@@ -90,10 +90,10 @@ methods:
       accepts:
         param1:
           <<: *accepts-assign-role
-          type: "[`Role`](/docs/concept-api/type?lang=javascript#role-methods)"
+          type: "[`Role`](/docs/concept-api/type?tab=javascript#role-methods)"
         param2:
           <<: *accepts-assign-thing
-          type: "[`Thing`](/docs/concept-api/thing?lang=javascript)"
+          type: "[`Thing`](/docs/concept-api/thing?tab=javascript)"
       returns:
         - "`void`"
     python:
@@ -102,10 +102,10 @@ methods:
       accepts:
         param1:
           <<: *accepts-assign-role
-          type: "[`Role`](/docs/concept-api/type?lang=python#role-methods)"
+          type: "[`Role`](/docs/concept-api/type?tab=python#role-methods)"
         param2:
           <<: *accepts-assign-thing
-          type: "[`Thing`](/docs/concept-api/thing?lang=python)"
+          type: "[`Thing`](/docs/concept-api/thing?tab=python)"
       returns:
         - '[`Relation`](/docs/concept-api/thing#relation-methods) object'
 
@@ -131,10 +131,10 @@ methods:
       accepts:
         param1:
           <<: *accepts-unassign-role
-          type: "[`Role`](/docs/concept-api/type?lang=java#role-methods)"
+          type: "[`Role`](/docs/concept-api/type?tab=java#role-methods)"
         param2:
           <<: *accepts-unassign-thing
-          type: "[`Thing`](/docs/concept-api/thing?lang=java)"
+          type: "[`Thing`](/docs/concept-api/thing?tab=java)"
       returns:
         - '[`Relation`](/docs/concept-api/thing#relation-methods) object'
     javascript:
@@ -143,10 +143,10 @@ methods:
       accepts:
         param1:
           <<: *accepts-unassign-role
-          type: "[`Role`](/docs/concept-api/type?lang=javascript#role-methods)"
+          type: "[`Role`](/docs/concept-api/type?tab=javascript#role-methods)"
         param2:
           <<: *accepts-unassign-thing
-          type: "[`Thing`](/docs/concept-api/thing?lang=javascript)"
+          type: "[`Thing`](/docs/concept-api/thing?tab=javascript)"
       returns:
         - "`void`"
     python:
@@ -155,9 +155,9 @@ methods:
       accepts:
         param1:
           <<: *accepts-unassign-role
-          type: "[`Role`](/docs/concept-api/type?lang=python#role-methods)"
+          type: "[`Role`](/docs/concept-api/type?tab=python#role-methods)"
         param2:
           <<: *accepts-unassign-thing
-          type: "[`Thing`](/docs/concept-api/thing?lang=python)"
+          type: "[`Thing`](/docs/concept-api/thing?tab=python)"
       returns:
         - "[`Relation`](/docs/concept-api/thing#relation-methods) object"

--- a/04-concept-api/references/relation_type.yml
+++ b/04-concept-api/references/relation_type.yml
@@ -7,17 +7,17 @@ methods:
       <<: *method-create
       method: relationType.create();
       returns:
-        - "[`Relation`](/docs/concept-api/thing?lang=java#relation-methods) object"
+        - "[`Relation`](/docs/concept-api/thing?tab=java#relation-methods) object"
     javascript:
       <<: *method-create
       method: await relationType.create();
       returns:
-        - "[`Relation`](/docs/concept-api/thing?lang=nodejs#relation-methods) object"
+        - "[`Relation`](/docs/concept-api/thing?tab=nodejs#relation-methods) object"
     python:
       <<: *method-create
       method: relation_type.create()
       returns:
-        - "[`Relation`](/docs/concept-api/thing?lang=python#relation-methods) object"
+        - "[`Relation`](/docs/concept-api/thing?tab=python#relation-methods) object"
 
   - method:
     common: &method-roles
@@ -27,17 +27,17 @@ methods:
       <<: *method-roles
       method: relationType.roles();
       returns:
-        - "Stream of [`Role`](/docs/concept-api/type?javalang=#role-methods) objects"
+        - "Stream of [`Role`](/docs/concept-api/type?javatab=#role-methods) objects"
     javascript:
       <<: *method-roles
       method: await relationType.roles();
       returns:
-        - "Iterator of [`Role`](/docs/concept-api/type?javascriptlang=#role-methods) objects"
+        - "Iterator of [`Role`](/docs/concept-api/type?javascripttab=#role-methods) objects"
     python:
       <<: *method-roles
       method: relation_type.roles()
       returns:
-        - "Iterator of [`Role`](/docs/concept-api/type?lang=python#role-methods) objects"
+        - "Iterator of [`Role`](/docs/concept-api/type?tab=python#role-methods) objects"
 
   - method:
     common: &method-relates
@@ -54,7 +54,7 @@ methods:
       <<: *method-relates
       method: relationType.relates(Role role);
       returns:
-        - "[`RelationType`](/docs/concept-api/type?lang=java#relationtype-methods) object"
+        - "[`RelationType`](/docs/concept-api/type?tab=java#relationtype-methods) object"
     javascript:
       <<: *method-relates
       method: await relationType.relates(role);
@@ -64,7 +64,7 @@ methods:
       <<: *method-relates
       method: relation_type.relates(role)
       returns:
-        - "[`RelationType`](/docs/concept-api/type?lang=python#relationtype-methods) object"
+        - "[`RelationType`](/docs/concept-api/type?tab=python#relationtype-methods) object"
 
   - method:
     common: &method-unrelate
@@ -81,7 +81,7 @@ methods:
       <<: *method-unrelate
       method: relationType.unrelate(Role role);
       returns:
-        - "[`RelationType`](/docs/concept-api/type?lang=java#relationtype-methods) object"
+        - "[`RelationType`](/docs/concept-api/type?tab=java#relationtype-methods) object"
     javascript:
       <<: *method-unrelate
       method: await relationType.unrelate(role);
@@ -91,4 +91,4 @@ methods:
       <<: *method-unrelate
       method: relation_type.unrelate(role)
       returns:
-        - "[`RelationType`](/docs/concept-api/type?lang=python#relationtype-methods) object"
+        - "[`RelationType`](/docs/concept-api/type?tab=python#relationtype-methods) object"

--- a/04-concept-api/references/role.yml
+++ b/04-concept-api/references/role.yml
@@ -7,17 +7,17 @@ methods:
       <<: *method-relations
       method: role.relations();
       returns:
-        - "Stream of [`Relation`](/docs/concept-api/thing?lang=java#relation-methods) objects"
+        - "Stream of [`Relation`](/docs/concept-api/thing?tab=java#relation-methods) objects"
     javascript:
       <<: *method-relations
       method: await role.relations();
       returns:
-        - "Iterator of [`Relation](/docs/concept-api/thing?lang=javascript#relation-methods) objects"
+        - "Iterator of [`Relation](/docs/concept-api/thing?tab=javascript#relation-methods) objects"
     python:
       <<: *method-relations
       method: role.relations()
       returns:
-        - "Iterator of [`Relation`](/docs/concept-api/thing?lang=python#relation-methods) objects"
+        - "Iterator of [`Relation`](/docs/concept-api/thing?tab=python#relation-methods) objects"
   - method:
     common: &method-players
       title: Retrieve roleplayers
@@ -26,14 +26,14 @@ methods:
       <<: *method-players
       method: role.players();
       returns:
-        - "Stream of [`Type`](/docs/concept-api/type?lang=java) objects"
+        - "Stream of [`Type`](/docs/concept-api/type?tab=java) objects"
     javascript:
       <<: *method-players
       method: await role.players();
       returns:
-        - "Iterator of [`Type`](/docs/concept-api/type?lang=nodejs) objects"
+        - "Iterator of [`Type`](/docs/concept-api/type?tab=nodejs) objects"
     python:
       <<: *method-players
       method: role.players()
       returns:
-        - "Iterator of [`Type`](/docs/concept-api/type?lang=python) objects"
+        - "Iterator of [`Type`](/docs/concept-api/type?tab=python) objects"

--- a/04-concept-api/references/thing.yml
+++ b/04-concept-api/references/thing.yml
@@ -31,27 +31,27 @@ methods:
       accepts:
         param:
           <<: *accepts-relations-param-roles
-          type: "Varargs of [`Role`](/docs/concept-api/type?lang=java#role-methods) objects"
+          type: "Varargs of [`Role`](/docs/concept-api/type?tab=java#role-methods) objects"
       returns:
-        - "Stream of [`Relation`](/docs/concept-api/thing?lang=java#relation-methods) objects"
+        - "Stream of [`Relation`](/docs/concept-api/thing?tab=java#relation-methods) objects"
     javascript:
       <<: *method-relations
       method: await thing.relations(roles);
       accepts:
         param:
           <<: *accepts-relations-param-roles
-          type: "Array of [`Role`](/docs/concept-api/type?lang=javascript#role-methods)s"
+          type: "Array of [`Role`](/docs/concept-api/type?tab=javascript#role-methods)s"
       returns:
-        - "Iterator of [`Relation`](/docs/concept-api/thing?lang=javascript#relation-methods) objects"
+        - "Iterator of [`Relation`](/docs/concept-api/thing?tab=javascript#relation-methods) objects"
     python:
       <<: *method-relations
       method: thing.relations(roles)
       accepts:
         param:
           <<: *accepts-relations-param-roles
-          type: "List of [`Role`](/docs/concept-api/type?lang=python#role-methods)s"
+          type: "List of [`Role`](/docs/concept-api/type?tab=python#role-methods)s"
       returns:
-        - "Iterator of [`Relation`](/docs/concept-api/thing?lang=python#relation-methods) objects"
+        - "Iterator of [`Relation`](/docs/concept-api/thing?tab=python#relation-methods) objects"
 
   - method:
     common: &method-roles
@@ -61,17 +61,17 @@ methods:
       <<: *method-roles
       method: thing.roles();
       returns:
-        - "Stream of [`Role`](/docs/concept-api/type?lang=java#role-methods) objects"
+        - "Stream of [`Role`](/docs/concept-api/type?tab=java#role-methods) objects"
     javascript:
       <<: *method-roles
       method: await thing.roles();
       returns:
-        - "Iterator of [`Role`](/docs/concept-api/type?lang=javascript#role-methods) objects"
+        - "Iterator of [`Role`](/docs/concept-api/type?tab=javascript#role-methods) objects"
     python:
       <<: *method-roles
       method: thing.roles()
       returns:
-        - "Iterator of [`Role`](/docs/concept-api/type?lang=python#role-methods) objects"
+        - "Iterator of [`Role`](/docs/concept-api/type?tab=python#role-methods) objects"
 
   - method:
     common: &method-attributes
@@ -90,9 +90,9 @@ methods:
         param:
           <<: *accepts-attributes-param-types
           name: attributeTypes
-          type: "Varargs of [`AttributeType`](/docs/concept-api/type?lang=java#attributetype-methods)s"
+          type: "Varargs of [`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods)s"
       returns:
-        - "Stream of [`Attribute`](/docs/concept-api/thing?lang=java#attribute-methods) objects"
+        - "Stream of [`Attribute`](/docs/concept-api/thing?tab=java#attribute-methods) objects"
     javascript:
       <<: *method-attributes
       method: await thing.attributes(attributeTypes);
@@ -101,9 +101,9 @@ methods:
         param:
           <<: *accepts-attributes-param-types
           name: attributeTypes
-          type: "Array of [`AttributeType`](/docs/concept-api/type?lang=javascript#attributetype-methods)s"
+          type: "Array of [`AttributeType`](/docs/concept-api/type?tab=javascript#attributetype-methods)s"
       returns:
-        - "Iterator of [`Attribute`](/docs/concept-api/thing?lang=javascript#attribute-methods) objects"
+        - "Iterator of [`Attribute`](/docs/concept-api/thing?tab=javascript#attribute-methods) objects"
     python:
       <<: *method-attributes
       method: thing.attributes(attribute_types)
@@ -112,9 +112,9 @@ methods:
         param:
           <<: *accepts-attributes-param-types
           name: attribute_types
-          type: "List of [`AttributeType`](/docs/concept-api/type?lang=pyhthon#attributetype-methods)s"
+          type: "List of [`AttributeType`](/docs/concept-api/type?tab=pyhthon#attributetype-methods)s"
       returns:
-        - "Iterator of [`Attribute`](/docs/concept-api/thing?lang=pyhthon#attribute-methods) objects"
+        - "Iterator of [`Attribute`](/docs/concept-api/thing?tab=pyhthon#attribute-methods) objects"
 
   - method:
     common: &method-keys
@@ -133,9 +133,9 @@ methods:
         param:
           <<: *accepts-keys-param-types
           name: attributeTypes
-          type: "Array of [`AttributeType`](/docs/concept-api/type?lang=java#attributetype-methods)s"
+          type: "Array of [`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods)s"
       returns:
-        - "Stream of [`Attribute`](/docs/concept-api/thing?lang=java#attribute-methods) objects"
+        - "Stream of [`Attribute`](/docs/concept-api/thing?tab=java#attribute-methods) objects"
     javascript:
       <<: *method-keys
       method: await thing.keys(attributeTypes);
@@ -144,9 +144,9 @@ methods:
         param:
           <<: *accepts-keys-param-types
           name: attributeTypes
-          type: "Array of [`AttributeType`](/docs/concept-api/type?lang=javascript#attributetype-methods)s"
+          type: "Array of [`AttributeType`](/docs/concept-api/type?tab=javascript#attributetype-methods)s"
       returns:
-        - "Iterator of [`Attribute`](/docs/concept-api/thing?lang=javascript#attribute-methods) objects"
+        - "Iterator of [`Attribute`](/docs/concept-api/thing?tab=javascript#attribute-methods) objects"
     python:
       <<: *method-keys
       method: thing.keys(attribute_types)
@@ -155,9 +155,9 @@ methods:
         param:
           <<: *accepts-keys-param-types
           name: attribute_types
-          type: "List of [`AttributeType`](/docs/concept-api/type?lang=python#attributetype-methods)s"
+          type: "List of [`AttributeType`](/docs/concept-api/type?tab=python#attributetype-methods)s"
       returns:
-        - "Iterator of [`Attribute`](/docs/concept-api/thing?lang=python#attribute-methods) objects"
+        - "Iterator of [`Attribute`](/docs/concept-api/thing?tab=python#attribute-methods) objects"
 
   - method:
     common: &method-has
@@ -175,27 +175,27 @@ methods:
       accepts:
         param:
           <<: *accepts-has-attribute
-          type: "[`Attribute`](/docs/concept-api/thing?lang=java#attribute-methods)"
+          type: "[`Attribute`](/docs/concept-api/thing?tab=java#attribute-methods)"
       returns:
-        - "[`Thing`](/docs/concept-api/thing?lang=java) object"
+        - "[`Thing`](/docs/concept-api/thing?tab=java) object"
     javascript:
       <<: *method-has
       method: await thing.has(attribute);
       accepts:
         param:
           <<: *accepts-has-attribute
-          type: "[`Attribute`](/docs/concept-api/thing?lang=javascript#attribute-methods)"
+          type: "[`Attribute`](/docs/concept-api/thing?tab=javascript#attribute-methods)"
       returns:
-        - "[`Thing`](/docs/concept-api/thing?lang=javascript) object"
+        - "[`Thing`](/docs/concept-api/thing?tab=javascript) object"
     python:
       <<: *method-has
       method: thing.has(attribute)
       accepts:
         param:
           <<: *accepts-has-attribute
-          type: "[`Attribute`](/docs/concept-api/thing?lang=python#attribute-methods)"
+          type: "[`Attribute`](/docs/concept-api/thing?tab=python#attribute-methods)"
       returns:
-        - "[`Thing`](/docs/concept-api/thing?lang=python) object"
+        - "[`Thing`](/docs/concept-api/thing?tab=python) object"
 
   - method:
     common: &method-unhas
@@ -212,17 +212,17 @@ methods:
       <<: *method-unhas
       method: thing.unhas(Attribute attribute);
       returns:
-        - "[`Thing`](/docs/concept-api/thing?lang=java) object"
+        - "[`Thing`](/docs/concept-api/thing?tab=java) object"
     javascript:
       <<: *method-unhas
       method: await thing.unhas(attribute);
       returns:
-        - "[`Thing`](/docs/concept-api/thing?lang=javascript) object"
+        - "[`Thing`](/docs/concept-api/thing?tab=javascript) object"
     python:
       <<: *method-unhas
       method: thing.unhas(attribute)
       returns:
-        - "[`Thing`](/docs/concept-api/thing?lang=python) object"
+        - "[`Thing`](/docs/concept-api/thing?tab=python) object"
 
   - method:
     common: &method-isInferred

--- a/04-concept-api/references/type.yml
+++ b/04-concept-api/references/type.yml
@@ -30,7 +30,7 @@ methods:
       <<: *method-label-rename
       method: type.label(Label.of(String label));
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=java#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
     javascript:
       <<: *method-label-rename
       method: await type.label(label);
@@ -40,7 +40,7 @@ methods:
       <<: *method-label-rename
       method: type.label(label)
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=python#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
 
   - method:
     common: &method-sup-retrieve
@@ -50,19 +50,19 @@ methods:
       <<: *method-sup-retrieve
       method: type.sup();
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=java#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
         - "`NULL`"
     javascript:
       <<: *method-sup-retrieve
       method: await type.sup();
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=javascript#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=javascript#type-methods) object"
         - "`null`"
     python:
       <<: *method-sup-retrieve
       method: type.sup()
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=python#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
         - "`None`"
 
   - method:
@@ -80,7 +80,7 @@ methods:
     #   <<: *method-sup-reset
     #   method: type.sup(Type type);
     #   returns:
-    #     - "[`Type`](/docs/concept-api/type?lang=java#type-methods) object"
+    #     - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
     #     - "`null`"
     javascript:
       <<: *method-sup-reset
@@ -91,7 +91,7 @@ methods:
       <<: *method-sup-reset
       method: type.sup(type)
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=python) object"
+        - "[`Type`](/docs/concept-api/type?tab=python) object"
         - "`None`"
 
   - method:
@@ -102,17 +102,17 @@ methods:
       <<: *method-sups
       method: type.sups();
       returns:
-        - "Stream of [`Type`](/docs/concept-api/type?lang=java#type-methods) objects"
+        - "Stream of [`Type`](/docs/concept-api/type?tab=java#type-methods) objects"
     javascript:
       <<: *method-sups
       method: await type.sups()
       returns:
-        - "Iterator of [`Type`](/docs/concept-api/type?lang=java#type-methods) objects"
+        - "Iterator of [`Type`](/docs/concept-api/type?tab=java#type-methods) objects"
     python:
       <<: *method-sups
       method: type.sups()
       returns:
-        - "Iterator of [`Type`](/docs/concept-api/type?lang=python#type-methods) objects"
+        - "Iterator of [`Type`](/docs/concept-api/type?tab=python#type-methods) objects"
 
   - method:
     common: &method-subs
@@ -122,17 +122,17 @@ methods:
       <<: *method-subs
       method: type.subs();
       returns:
-        - "Stream of [`Type`](/docs/concept-api/type?lang=java#type-methods) objects"
+        - "Stream of [`Type`](/docs/concept-api/type?tab=java#type-methods) objects"
     javascript:
       <<: *method-subs
       method: await type.subs()
       returns:
-        - "Iterator of [`Type`](/docs/concept-api/type?lang=nodejs#type-methods) objects"
+        - "Iterator of [`Type`](/docs/concept-api/type?tab=nodejs#type-methods) objects"
     python:
       <<: *method-subs
       method: type.subs()
       returns:
-        - "Iterator of [`Type`](/docs/concept-api/type?lang=python#type-methods) objects"
+        - "Iterator of [`Type`](/docs/concept-api/type?tab=python#type-methods) objects"
 
   - method:
     common: &method-isImplicit
@@ -181,7 +181,7 @@ methods:
       <<: *method-isAbstract-set
       method: type.isAbstract(Boolean abstract);
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=java#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
     javascript:
       <<: *method-isAbstract-set
       method: await type.isAbstract(abstract);
@@ -191,7 +191,7 @@ methods:
       <<: *method-isAbstract-set
       method: type.is_abstract(abstract)
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=python#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
 
   - method:
     common: &method-playing
@@ -201,17 +201,17 @@ methods:
       <<: *method-playing
       method: type.playing();
       returns:
-        - "Stream of [`Role`](/docs/concept-api/type?lang=java#role-methods) objects"
+        - "Stream of [`Role`](/docs/concept-api/type?tab=java#role-methods) objects"
     javascript:
       <<: *method-playing
       method: await type.playing();
       returns:
-        - "Iterator of [`Role`](/docs/concept-api/type?lang=javascript#role-methods) objects"
+        - "Iterator of [`Role`](/docs/concept-api/type?tab=javascript#role-methods) objects"
     python:
       <<: *method-playing
       method: type.playing()
       returns:
-        - "Iterator of [`Role`](/docs/concept-api/type?lang=python#role-methods) objects"
+        - "Iterator of [`Role`](/docs/concept-api/type?tab=python#role-methods) objects"
 
   - method:
     common: &method-plays
@@ -229,16 +229,16 @@ methods:
       accepts:
         param:
           <<: *accepts-plays-role
-          type: "[`Role`](/docs/concept-api/type?lang=java#role-methods)"
+          type: "[`Role`](/docs/concept-api/type?tab=java#role-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=java#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
     javascript:
       <<: *method-plays
       method: await type.plays(role);
       accepts:
         param:
           <<: *accepts-plays-role
-          type: "[`Role`](/docs/concept-api/type?lang=javascript#role-methods)"
+          type: "[`Role`](/docs/concept-api/type?tab=javascript#role-methods)"
       returns:
         - "`void`"
     python:
@@ -247,9 +247,9 @@ methods:
       accepts:
         param:
           <<: *accepts-plays-role
-          type: "[`Role`](/docs/concept-api/type?lang=python#role-methods)"
+          type: "[`Role`](/docs/concept-api/type?tab=python#role-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=python#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
 
   - method:
     common: &method-unplay
@@ -267,16 +267,16 @@ methods:
       accepts:
         param:
           <<: *accepts-unplay
-          type: "[`Role`](/docs/concept-api/type?lang=java#role-methods)"
+          type: "[`Role`](/docs/concept-api/type?tab=java#role-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=java#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
     javascript:
       <<: *method-unplay
       method: await type.unplay(role);
       accepts:
         param:
           <<: *accepts-unplay
-          type: "[`Role`](/docs/concept-api/type?lang=javascript#role-methods)"
+          type: "[`Role`](/docs/concept-api/type?tab=javascript#role-methods)"
       returns:
         - "`void`"
     python:
@@ -285,9 +285,9 @@ methods:
       accepts:
         param:
           <<: *accepts-unplay
-          type: "[`Role`](/docs/concept-api/type?lang=python#role-methods)"
+          type: "[`Role`](/docs/concept-api/type?tab=python#role-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=python#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
 
   - method:
     common: &method-attributes
@@ -297,17 +297,17 @@ methods:
       <<: *method-attributes
       method: type.attributes();
       returns:
-        - "Stream of [`AttributeType`](/docs/concept-api/type?lang=java#attributetype-methods) objects"
+        - "Stream of [`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods) objects"
     javascript:
       <<: *method-attributes
       method: await type.attributes();
       returns:
-        - "Iterator of [`AttributeType`](/docs/concept-api/type?lang=javascript#attributetype-methods) objects"
+        - "Iterator of [`AttributeType`](/docs/concept-api/type?tab=javascript#attributetype-methods) objects"
     python:
       <<: *method-attributes
       method: type.attributes()
       returns:
-        - "Iterator of [`AttributeType`](/docs/concept-api/type?lang=python#attributetype-methods) objects"
+        - "Iterator of [`AttributeType`](/docs/concept-api/type?tab=python#attributetype-methods) objects"
 
   - method:
     common: &method-has
@@ -325,9 +325,9 @@ methods:
         param:
           <<: *accepts-has-attributeType
           name: attributeType
-          type: "[`AttributeType`](/docs/concept-api/type?lang=java#attributetype-methods)"
+          type: "[`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=java#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
     javascript:
       <<: *method-has
       method: await type.has(attributeType);
@@ -335,7 +335,7 @@ methods:
         param:
           <<: *accepts-has-attributeType
           name: attributeType
-          type: "[`AttributeType`](/docs/concept-api/type?lang=javascript#attributetype-methods)"
+          type: "[`AttributeType`](/docs/concept-api/type?tab=javascript#attributetype-methods)"
       returns:
         - "`void`"
     python:
@@ -345,9 +345,9 @@ methods:
         param:
           <<: *accepts-has-attributeType
           name: attribute_type
-          type: "[`AttributeType`](/docs/concept-api/type?lang=python#attributetype-methods)"
+          type: "[`AttributeType`](/docs/concept-api/type?tab=python#attributetype-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=python#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
 
   - method:
     common: &method-unhas
@@ -365,9 +365,9 @@ methods:
         param:
           <<: *accepts-unhas-attributeType
           name: attributeType
-          type: "[`AttributeType`](/docs/concept-api/type?lang=java#attributetype-methods)"
+          type: "[`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=java#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
     javascript:
       <<: *method-unhas
       method: await type.unhas(attributeType);
@@ -375,7 +375,7 @@ methods:
         param:
           <<: *accepts-unhas-attributeType
           name: attributeType
-          type: "[`AttributeType`](/docs/concept-api/type?lang=javascript#attributetype-methods)"
+          type: "[`AttributeType`](/docs/concept-api/type?tab=javascript#attributetype-methods)"
       returns:
         - "`void`"
     python:
@@ -385,9 +385,9 @@ methods:
         param:
           <<: *accepts-unhas-attributeType
           name: attribute_type
-          type: "[`AttributeType`](/docs/concept-api/type?lang=python#attributetype-methods)"
+          type: "[`AttributeType`](/docs/concept-api/type?tab=python#attributetype-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=python#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
 
   - method:
     common: &method-keys
@@ -397,17 +397,17 @@ methods:
       <<: *method-keys
       method: type.keys();
       returns:
-        - "Stream of [`AttributeType`](/docs/concept-api/type?lang=java#attributetype-methods) objects"
+        - "Stream of [`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods) objects"
     javascript:
       <<: *method-keys
       method: await type.keys();
       returns:
-        - "Iterator of [`AttributeType`](/docs/concept-api/type?lang=javascript#attributetype-methods) objects"
+        - "Iterator of [`AttributeType`](/docs/concept-api/type?tab=javascript#attributetype-methods) objects"
     python:
       <<: *method-keys
       method: type.keys()
       returns:
-        - "Iterator of [`AttributeType`](/docs/concept-api/type?lang=python#attributetype-methods) objects"
+        - "Iterator of [`AttributeType`](/docs/concept-api/type?tab=python#attributetype-methods) objects"
   - method:
     common: &method-key
       title: Add key
@@ -424,16 +424,16 @@ methods:
       accepts:
         param:
           <<: *accepts-key-key
-          type: "[`AttributeType`](/docs/concept-api/type?lang=java#attributetype-methods)"
+          type: "[`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=java#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
     javascript:
       <<: *method-key
       method: await type.key(attributeType);
       accepts:
         param:
           <<: *accepts-key-key
-          type: "[`AttributeType`](/docs/concept-api/type?lang=javascript#attributetype-methods)"
+          type: "[`AttributeType`](/docs/concept-api/type?tab=javascript#attributetype-methods)"
       returns:
         - "`void`"
     python:
@@ -442,9 +442,9 @@ methods:
       accepts:
         param:
           <<: *accepts-key-key
-          type: "[`AttributeType`](/docs/concept-api/type?lang=python#attributetype-methods)"
+          type: "[`AttributeType`](/docs/concept-api/type?tab=python#attributetype-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=python#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
 
   - method:
     common: &method-unkey
@@ -462,9 +462,9 @@ methods:
         param:
           <<: *accepts-unkey-attributeType
           name: attributeType
-          type: "[`AttributeType`](/docs/concept-api/type?lang=java#attributetype-methods)"
+          type: "[`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=java#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
     javascript:
       <<: *method-unkey
       method: await type.unkey(attributeType);
@@ -472,7 +472,7 @@ methods:
         param:
           <<: *accepts-unkey-attributeType
           name: attributeType
-          type: "[`AttributeType`](/docs/concept-api/type?lang=javascript#attributetype-methods)"
+          type: "[`AttributeType`](/docs/concept-api/type?tab=javascript#attributetype-methods)"
       returns:
         - "`void`"
     python:
@@ -482,9 +482,9 @@ methods:
         param:
           <<: *accepts-unkey-attributeType
           name: attribute_type
-          type: "[`AttributeType`](/docs/concept-api/type?lang=python#attributetype-methods)"
+          type: "[`AttributeType`](/docs/concept-api/type?tab=python#attributetype-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?lang=python#type-methods) object"
+        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
 
   - method:
     common: &method-instances
@@ -494,14 +494,14 @@ methods:
       <<: *method-instances
       method: type.instances();
       returns:
-        - "Stream of [`Thing`](/docs/concept-api/thing?lang=java) objects"
+        - "Stream of [`Thing`](/docs/concept-api/thing?tab=java) objects"
     javascript:
       <<: *method-instances
       method: await type.instances();
       returns:
-        - "Iterator of [`Thing`](/docs/concept-api/thing?lang=javascript) objects"
+        - "Iterator of [`Thing`](/docs/concept-api/thing?tab=javascript) objects"
     python:
       <<: *method-instances
       method: type.instances()
       returns:
-        - "Iterator of [`Thing`](/docs/concept-api/thing?lang=python) objects"
+        - "Iterator of [`Thing`](/docs/concept-api/thing?tab=python) objects"

--- a/08-examples/03-migration-java.md
+++ b/08-examples/03-migration-java.md
@@ -1394,4 +1394,4 @@ Lastly, we ran the `main` method which fired the `connectAndMigrate` method with
 
 ## Next
 
-Now that we have some actual data in our knowledge graph, we can go ahead and [query for insights](/docs/examples/phone-calls-queries?lang=java).
+Now that we have some actual data in our knowledge graph, we can go ahead and [query for insights](/docs/examples/phone-calls-queries?tab=java).

--- a/08-examples/04-migration-nodejs.md
+++ b/08-examples/04-migration-nodejs.md
@@ -882,4 +882,4 @@ Lastly, we ran `npm run migrate.js` which fired the `buildPhoneCallGraph` functi
 
 ## Next
 
-Now that we have some actual data in our knowledge graph, we can go ahead and [query for insights](/docs/examples/phone-calls-queries?lang=javascript).
+Now that we have some actual data in our knowledge graph, we can go ahead and [query for insights](/docs/examples/phone-calls-queries?tab=javascript).

--- a/08-examples/05-migration-python.md
+++ b/08-examples/05-migration-python.md
@@ -732,4 +732,4 @@ Lastly, we ran `python3 migrate.py` which fired the `build_phone_call_graph` fun
 
 ## Next
 
-Now that we have some actual data in our knowledge graph, we can go ahead and [query for insights](/docs/examples/phone-calls-queries?lang=python).
+Now that we have some actual data in our knowledge graph, we can go ahead and [query for insights](/docs/examples/phone-calls-queries?tab=python).


### PR DESCRIPTION
uses the url param `lang` to `tab` so that we can use it for non-code tabbed content as well.