### PR TITLE
Update instructions for installing/downloading with docker and mac (on master)

### DIFF
--- a/00-general/04-quickstart.md
+++ b/00-general/04-quickstart.md
@@ -3,6 +3,7 @@ pageTitle: Quickstart
 keywords: getting started, grakn, graql, tutorial, quickstart, overview
 longTailKeywords: get started with grakn, grakn tutorial, grakn quickstart, learn grakn
 summary: Learn about the constructs of the Grakn Schema, visualise a knowledge graph, perform read and write queries and explore the power of automated reasoning and analytics with Grakn.
+toc: false
 ---
 
 ### An Overview

--- a/02-running-grakn/01-install-and-run.md
+++ b/02-running-grakn/01-install-and-run.md
@@ -69,6 +69,12 @@ brew install grakn-core
 #### Manual Download
 Download the [latest release](https://grakn.ai/download?os=mac_os_x#core), unzip it in a location on your machine that is easily accessible via terminal.
 
+<div class="note">
+[Warning]
+At the moment, to avoid encountering a permission error, you need to unzip the downloaded distribution using the `unzip` command via terminal, i.e. `unzip grakn-core-all-mac.zip`. This is a known issue that is expected to be resolved with the next release.
+</div>
+
+
 Having installed or downloaded Grakn, we can now start the [Server](#start-the-grakn-server) and interact with the [Console](../02-running-grakn/02-console.md).
 
 [tab:end]

--- a/02-running-grakn/01-install-and-run.md
+++ b/02-running-grakn/01-install-and-run.md
@@ -87,7 +87,8 @@ Having installed or downloaded Grakn, we can now start the [Server](#start-the-g
 
 Run :
 ```
-docker run -d -p 48555:48555 graknlabs/grakn
+docker pull graknlabs/grakn:1.5.0
+docker run -d -p 48555:48555 graknlabs/grakn:1.5.0
 ```
 
 Having installed or downloaded Grakn, we can now start the [Server](#start-the-grakn-server) and interact with the [Console](../02-running-grakn/02-console.md).

--- a/02-running-grakn/01-install-and-run.md
+++ b/02-running-grakn/01-install-and-run.md
@@ -85,10 +85,26 @@ Having installed or downloaded Grakn, we can now start the [Server](#start-the-g
 
 [tab:Docker]
 
-Run :
+#### Without an External Volume
+
+For testing purposes, run:
 ```
 docker pull graknlabs/grakn:1.5.0
 docker run -d -p 48555:48555 graknlabs/grakn:1.5.0
+```
+
+<div class="note">
+[Note]
+Running the container without specifying a volume does NOT save the data if the instance is killed.
+</div>
+
+#### With an External Volume
+
+To ensure that data is preserved even when the instance is killed or restarted, run:
+
+```
+docker pull graknlabs/grakn:1.5.0
+docker run -d -v $(pwd)/db/:/grakn-core-all-linux/server/db/ -p 48555:48555 graknlabs/grakn:1.5.0
 ```
 
 Having installed or downloaded Grakn, we can now start the [Server](#start-the-grakn-server) and interact with the [Console](../02-running-grakn/02-console.md).

--- a/02-running-grakn/01-install-and-run.md
+++ b/02-running-grakn/01-install-and-run.md
@@ -95,7 +95,7 @@ docker run -d -p 48555:48555 graknlabs/grakn:1.5.0
 
 <div class="note">
 [Note]
-Running the image without specifying a volume does NOT save the data if the instance is killed.
+Running the instance without specifying a volume does NOT save the data if the instance is killed.
 </div>
 
 #### With an External Volume

--- a/02-running-grakn/01-install-and-run.md
+++ b/02-running-grakn/01-install-and-run.md
@@ -95,7 +95,7 @@ docker run -d -p 48555:48555 graknlabs/grakn:1.5.0
 
 <div class="note">
 [Note]
-Running the container without specifying a volume does NOT save the data if the instance is killed.
+Running the image without specifying a volume does NOT save the data if the instance is killed.
 </div>
 
 #### With an External Volume


### PR DESCRIPTION
## What is the goal of this PR?
To provide:
-  complete/correct instructions for installing Grakn Docker.
- warning on unzipping the manually downloaded Grakn distribution for Mac.

## What are the changes implemented in this PR?
Added the instructions as per on the Grakn page on Docker Hub.
Added a warning colored panel under manual download with Mac.