### PR TITLE
Make schema keywords searchable, key clearer

### DIFF
--- a/09-schema/01-concepts.md
+++ b/09-schema/01-concepts.md
@@ -79,7 +79,7 @@ GraqlDefine query = Graql.define(
 [tab:end]
 </div>
 
-### Assign an attribute to a attribute as a unique identifier
+### Assign an attribute to an entity as a unique identifier
 To assign a unique attribute to an entity, we use the `key` keyword followed by the attribute's label.
 
 <div class="tabs dark">

--- a/09-schema/01-concepts.md
+++ b/09-schema/01-concepts.md
@@ -1,6 +1,6 @@
 ---
 pageTitle: Schema Concepts
-keywords: graql, schema, type hierarchy, concept, define
+keywords: graql, schema, type hierarchy, concept, define, sub, key, abstract,relates, plays, datatype, regex, define, undefine
 longTailKeywords: graql schema, graql define query, graql type hierarchy, graql concepts, graql define entity, graql define relation, graql define attribute, graql schema definition
 Summary: A comprehensive guide on defining Schema Concepts in Grakn.
 ---

--- a/09-schema/01-concepts.md
+++ b/09-schema/01-concepts.md
@@ -79,6 +79,7 @@ GraqlDefine query = Graql.define(
 [tab:end]
 </div>
 
+### Assign an attribute to a attribute as a unique identifier
 To assign a unique attribute to an entity, we use the `key` keyword followed by the attribute's label.
 
 <div class="tabs dark">
@@ -378,6 +379,7 @@ GraqlDefine query = Graql.define(
 [tab:end]
 </div>
 
+### Assign an attribute to a relation as a unique identifier
 To assign a unique attribute to a relation, we use the `key` keyword followed by the attribute's label.
 
 <div class="tabs dark">


### PR DESCRIPTION
## What is the goal of this PR?
Make schema keywords searchable and provide better documentation on the `key` keyword. closes #138 

## What are the changes implemented in this PR?
Adds schema keywords to schema/concepts page
Adds headers for assigning a `key` to a `relation` or `entity`