### PR TITLE
Close clients in example code snippets

### DIFF
--- a/03-client-api/01-java.md
+++ b/03-client-api/01-java.md
@@ -71,11 +71,13 @@ import grakn.client.GraknClient;
 public class GraknQuickstartA {
     public static void main(String[] args) {
         GraknClient client = new GraknClient("localhost:48555");
+        // client is open
         GraknClient.Session session = client.session("social_network");
         // session is open
         session.close();
         // session is closed
         client.close();
+        // client is closed
     }
 }
 ```
@@ -155,7 +157,7 @@ public class GraknQuickstartC {
     Stream<ConceptMap> answers = readTransaction.stream(getQuery);
     answers.forEach(answer -> System.out.println(answer.get("p").id()));
 
-    // a read transaction and session must always be closed
+    // transactions, sessions and clients must always be closed
     readTransaction.close();
     session.close();
     client.close();

--- a/03-client-api/01-java.md
+++ b/03-client-api/01-java.md
@@ -75,6 +75,7 @@ public class GraknQuickstartA {
         // session is open
         session.close();
         // session is closed
+        client.close();
     }
 }
 ```
@@ -113,6 +114,7 @@ public class GraknQuickstartB {
         readTransaction.close();
 
         session.close();
+        client.close();
     }
 }
 
@@ -156,6 +158,7 @@ public class GraknQuickstartC {
     // a read transaction and session must always be closed
     readTransaction.close();
     session.close();
+    client.close();
   }
 }
 


### PR DESCRIPTION
## What is the goal of this PR?

`.close()` should be called on all instantiated clients, which was omitted in the code examples for the Java client. We have corrected this.

## What are the changes implemented in this PR?

We have added `.close()` calls to the Java client code examples