### PR TITLE
Clarify wording on iterator

### DIFF
--- a/03-client-api/references/iterator.yml
+++ b/03-client-api/references/iterator.yml
@@ -1,8 +1,8 @@
 
 title: Iterator
 description:
-  javascript: "In addition to the methods below, the items in an Iterator can be consumed individually using <code>await iterator.next()</code> method."
-  python: "In addition to the methods below, the items in an Iterator can be consumed individually using <code>next(iterator)</code> method."
+  javascript: "Transaction queries return iterators of answers. In addition to the method below, the items in an Iterator can be consumed individually using <code>await iterator.next()</code> method."
+  python: "Transaction queries return iterators of answers. In addition to the method below, the items in an Iterator can be consumed individually using <code>next(iterator)</code> method."
 methods:
   - method:
     common: &method-collect


### PR DESCRIPTION
## What is the goal of this PR?
We used to be unclear with what the iterator methods were and that queries return iterators. Now, the wording is updated such that the number of available methods is clear (just the 1 on iterators) and that transaction.query() returns an iterator always.

## What are the changes implemented in this PR?
* Add a sentence describe the fact that iterators stem from transaction.query
* Update the plurality of a noun from plural to singular