### PR TITLE
Add `ConceptMap.get(var)` to docs

### DIFF
--- a/03-client-api/references/answer.yml
+++ b/03-client-api/references/answer.yml
@@ -80,7 +80,7 @@ types:
               description: The string representation of a variable
               type: String
           returns:
-            - [`Concept`](../concept-api/concept)
+            - "[`Concept`](../concept-api/concept)"
         java:
           <<: *method-conceptmap-get
           method: answer.get(var)

--- a/03-client-api/references/answer.yml
+++ b/03-client-api/references/answer.yml
@@ -79,16 +79,15 @@ types:
               name: var
               description: The string representation of a variable
               type: String
+          returns:
+            - [`Concept`](../concept-api/concept)
         java:
           <<: *method-conceptmap-get
           method: answer.get(var)
-          returns:
-            - Concept
         python:
           <<: *method-conceptmap-get
           method: answer.get(var)
-          returns:
-            - Concept
+
 
       - method:
         common: &method-explanation

--- a/03-client-api/references/answer.yml
+++ b/03-client-api/references/answer.yml
@@ -71,6 +71,26 @@ types:
             - Dictionary of String to Concept
 
       - method:
+        common: &method-conceptmap-get
+          title: Retrieve a concept corresponding to a specific variable
+          description: Retrieve a concept for a given variable name without explicitly retriving the map
+          accepts: &method-conceptmap-get-var
+            param1:
+              name: var
+              description: The string representation of a variable
+              type: String
+        java:
+          <<: *method-conceptmap-get
+          method: answer.get(var)
+          returns:
+            - Concept
+        python:
+          <<: *method-conceptmap-get
+          method: answer.get(var)
+          returns:
+            - Concept
+
+      - method:
         common: &method-explanation
           title: Explaining an inferred answer
           description: Provides an explanation on the inference of the concept in the answer, if the concept is in fact inferred.


### PR DESCRIPTION
## What is the goal of this PR?
We never documented the fact that client-java and client-python have a method `ConceptMap.get(x)`, which accepts a string and returns a Concept and is consistent across languages (not yet implemented in client-nodejs).

With this change we will add the method to the docs.

## What are the changes implemented in this PR?
Document `ConceptMap.get(var)`

@vmax  will make another small PR for this when client-nodejs has the same functionality.