### PR TITLE
Fixes broken links in Client/Concept API References

### DIFF
--- a/03-client-api/references/answer.yml
+++ b/03-client-api/references/answer.yml
@@ -56,7 +56,7 @@ types:
           method: answer.map();
           description: Produces a Map where keys are variable names and values are [`concept`](../concept-api/concept)s.
           returns:
-            - "`Map<Variable, Concept>"
+            - "Map<Variable, Concept>"
         javascript:
           <<: *method-conceptmap-map
           method: answer.map();

--- a/03-client-api/references/answer.yml
+++ b/03-client-api/references/answer.yml
@@ -54,7 +54,7 @@ types:
         java:
           <<: *method-conceptmap-map
           method: answer.map();
-          description: Produces a Map where keys are variable names and values are [`concept`]](../04-concept-api/01-concept.md)s.
+          description: Produces a Map where keys are variable names and values are [`concept`](../concept-api/concept)s.
           returns:
             - "`Map<Variable, Concept>"
         javascript:
@@ -229,7 +229,7 @@ types:
         common: &method-answergroup-owner
           title: Retrieve the concept that is the group owner
           returns:
-            - "[Concept](../04-concept-api/01-concept.md)"
+            - "[Concept](../concept-api/concept)"
         java:
           <<: *method-answergroup-owner
           method: answer.owner();

--- a/03-client-api/references/graql.yml
+++ b/03-client-api/references/graql.yml
@@ -29,11 +29,11 @@ description:
 
     We are now ready to construct Graql queries, using the methods available on the `Graql` class.
     Check out the following pages to learn, by example, how the Graql API allows construction of various Graql queries:
-    - [Expressive pattenrs](query/match-clause)
-    - [Retrieval queries](query/get-query)
-    - [Insertion queries](query/insert-query)
-    - [Deletion queries](query/delete-query)
-    - [Aggregation queries](query/aggregate-query)
-    - [Analytical queries](query/aggregate-query)
+    - [Expressive pattenrs](../query/match-clause)
+    - [Retrieval queries](../query/get-query)
+    - [Insertion queries](../query/insert-query)
+    - [Deletion queries](../query/delete-query)
+    - [Aggregation queries](../query/aggregate-query)
+    - [Analytical queries](../query/aggregate-query)
 
   java: *common-description

--- a/03-client-api/references/graql.yml
+++ b/03-client-api/references/graql.yml
@@ -29,11 +29,11 @@ description:
 
     We are now ready to construct Graql queries, using the methods available on the `Graql` class.
     Check out the following pages to learn, by example, how the Graql API allows construction of various Graql queries:
-    - [Expressive pattenrs](../11-query/01-match-clause.md)
-    - [Retrieval queries](../11-query/02-get-query.md)
-    - [Insertion queries](../11-query/03-insert-query.md)
-    - [Deletion queries](../11-query/04-delete-query.md)
-    - [Aggregation queries](../11-query/06-aggregate-query.md)
-    - [Analytical queries](../11-query/06-aggregate-query.md)
+    - [Expressive pattenrs](query/match-clause)
+    - [Retrieval queries](query/get-query)
+    - [Insertion queries](query/insert-query)
+    - [Deletion queries](query/delete-query)
+    - [Aggregation queries](query/aggregate-query)
+    - [Analytical queries](query/aggregate-query)
 
   java: *common-description

--- a/03-client-api/references/iterator.yml
+++ b/03-client-api/references/iterator.yml
@@ -10,7 +10,7 @@ methods:
       method: await iterator.collect();
       description: Consumes the iterator and collects all the elements into an array.
       returns:
-        - Array of IteratorEelement
+        - Array of IteratorElement
     javascript:
       <<: *method-collect
   - method:
@@ -21,10 +21,10 @@ methods:
       description: Consumes the iterator and collects all Concepts into an array.
       method: await iterator.collectConcepts();
       returns:
-        - "Array of [Concept](../04-concept-api/01-concept.md)"
+        - "Array of [Concept](../concept-api/concept)"
     python:
       <<: *method-collectConcepts
       description: Consumes the iterator and collects all Concepts into a list.
       method: iterator.collect_concepts();
       returns:
-        - "List of [Concept](../04-concept-api/01-concept.md)"
+        - "List of [Concept](../concept-api/concept)"

--- a/03-client-api/references/transaction.yml
+++ b/03-client-api/references/transaction.yml
@@ -245,7 +245,7 @@ methods:
           required: true
           default: N/A
       returns:
-        - "[`RelationType`](../concept-api/type#relation-methods) object"
+        - "[`RelationType`](../concept-api/type#relationtype-methods) object"
     java:
       <<: *method-putRelationType
       method: transaction.putRelationType(Label.of(String label));
@@ -337,7 +337,7 @@ methods:
           required: true
           default: N/A
       returns:
-        - "[`Rule`](../concept-api/03-rule) object"
+        - "[`Rule`](../concept-api/rule) object"
     java:
       <<: *method-putRule
       method: transaction.putRule(Label.of(String label), Pattern when, Pattern then);

--- a/03-client-api/references/transaction.yml
+++ b/03-client-api/references/transaction.yml
@@ -140,17 +140,17 @@ methods:
       <<: *method-getConcept
       method: transaction.getConcept(ConceptId.of(String id));
       returns:
-        - "[`<T extends Concept>`](../04-concept-api/01-concept.md) object or `NULL`"
+        - "[`<T extends Concept>`](../concept-api/concept) object or `NULL`"
     javascript:
       <<: *method-getConcept
       method: await transaction.getConcept(id);
       returns:
-        - "[`Concept`](../04-concept-api/01-concept.md) object or `null`"
+        - "[`Concept`](../concept-api/concept) object or `null`"
     python:
       <<: *method-getConcept
       method: 'transaction.get_concept(id)'
       returns:
-        - "[`Concept`](../04-concept-api/01-concept.md) object or `None`"
+        - "[`Concept`](../concept-api/concept) object or `None`"
 
   - method:
     common: &method-getSchemaConcept
@@ -163,7 +163,7 @@ methods:
           required: true
           default: N/A
       returns:
-        - "[Type](/docs/concept-api/type) object"
+        - "[Type](../concept-api/type) object"
     java:
       <<: *method-getSchemaConcept
       method: transaction.getSchemaConcept(Label.of(String label));
@@ -198,17 +198,17 @@ methods:
           <<: *accepts-getAttributesByValue-value
           type: "String &#124; Date &#124; long &#124; double &#124; boolean"
       returns:
-        -  "[`Collection<Attribute>`](../04-concept-api/04-thing#attribute-methods.md)"
+        -  "[`Collection<Attribute>`](../concept-api/thing#attribute-methods)"
     javascript:
       <<: *method-getAttributesByValue
       method: await transaction.getAttributesByValue(value, datatype);
       returns:
-        - Iterator of [`Attribute`](../04-concept-api/04-thing#attribute-methods.md)s
+        - Iterator of [`Attribute`](../concept-api/thing#attribute-methods)s
     python:
       <<: *method-getAttributesByValue
       method: transaction.get_attributes_by_value(value, datatype)
       returns:
-        - Iterator of [`Attribute`](../04-concept-api/04-thing#attribute-methods.md)s
+        - Iterator of [`Attribute`](../concept-api/thing#attribute-methods)s
 
   - method:
     common: &method-putEntity
@@ -222,7 +222,7 @@ methods:
           required: true
           default: N/A
       returns:
-        - "[`EntityType`](/docs/concept-api/type#entitytype-methods) object"
+        - "[`EntityType`](../concept-api/type#entitytype-methods) object"
     java:
       <<: *method-putEntity
       method: transaction.putEntityType(Label.of(String label));
@@ -245,7 +245,7 @@ methods:
           required: true
           default: N/A
       returns:
-        - "[`RelationType`](/docs/concept-api/type#relation-methods) object"
+        - "[`RelationType`](../concept-api/type#relation-methods) object"
     java:
       <<: *method-putRelationType
       method: transaction.putRelationType(Label.of(String label));
@@ -274,7 +274,7 @@ methods:
           required: true
           default: N/A
       returns:
-        - "[`AttributeType`](/docs/concept-api/type#attributetype-methods) object"
+        - "[`AttributeType`](../concept-api/type#attributetype-methods) object"
     java:
       <<: *method-putAttributeType
       method: transaction.putAttributeType(Label.of(String label), AttributeType.DataType<V> dataType)
@@ -302,7 +302,7 @@ methods:
           required: true
           default: N/A
       returns:
-        - "[`Role`](/docs/concept-api/type#role-methods) object"
+        - "[`Role`](../concept-api/type#role-methods) object"
     java:
       <<: *method-putRole
       method: transaction.putRole(Label.of(String label));
@@ -337,7 +337,7 @@ methods:
           required: true
           default: N/A
       returns:
-        - "[`Rule`](../04-concept-api/03-rule.md) object"
+        - "[`Rule`](../concept-api/03-rule) object"
     java:
       <<: *method-putRule
       method: transaction.putRule(Label.of(String label), Pattern when, Pattern then);

--- a/04-concept-api/02-type.md
+++ b/04-concept-api/02-type.md
@@ -91,8 +91,8 @@ toc: true
 <div class="note">
 [Important]
 At the moment, `Role` inherits an intermediary class which, for the sake of simplicity, has not been documented. Therefore, besides the `Concept` methods, Role inherits the following methods from the `Type` class.
-- [label();](?tab=java#retrieve-the-label)
-- [type.label(Label.of(label));](?tab=java#rename-the-label)
+- [label();](?tab=java#retrieve-label)
+- [type.label(Label.of(label));](?tab=java#rename-label)
 - [sup();](?tab=java#retrieve-direct-supertype)
 - [sup(Type type);](?tab=java#change-direct-supertype)
 - [sups();](?tab=java#retrieve-all-supertypes)
@@ -106,8 +106,8 @@ At the moment, `Role` inherits an intermediary class which, for the sake of simp
 <div class="note">
 [Important]
 At the moment, `Role` inherits an intermediary class which, for the sake of simplicity, has not been documented. Therefore, besides the `Concept` methods, Role inherits the following methods from the `Type` class.
-- [label();](?tab=javascript#retrieve-the-label)
-- [type.label(Label.of(label));](?tab=javascript#rename-the-label)
+- [label();](?tab=javascript#retrieve-label)
+- [type.label(Label.of(label));](?tab=javascript#rename-label)
 - [sup();](?tab=javascript#retrieve-direct-supertype)
 - [sup(Type type);](?tab=javascript#change-direct-supertype)
 - [sups();](?tab=javascript#retrieve-all-supertypes)
@@ -120,8 +120,8 @@ At the moment, `Role` inherits an intermediary class which, for the sake of simp
 <div class="note">
 [Important]
 At the moment, `Role` inherits an intermediary class which, for the sake of simplicity, has not been documented. Therefore, besides the `Concept` methods, Role inherits the following methods from the `Type` class.
-- [label();](?tab=python#retrieve-the-label)
-- [type.label(Label.of(label));](?tab=python#rename-the-label)
+- [label();](?tab=python#retrieve-label)
+- [type.label(Label.of(label));](?tab=python#rename-label)
 - [sup();](?tab=python#retrieve-direct-supertype)
 - [sup(Type type);](?tab=python#change-direct-supertype)
 - [sups();](?tab=python#retrieve-all-supertypes)

--- a/04-concept-api/02-type.md
+++ b/04-concept-api/02-type.md
@@ -91,12 +91,12 @@ toc: true
 <div class="note">
 [Important]
 At the moment, `Role` inherits an intermediary class which, for the sake of simplicity, has not been documented. Therefore, besides the `Concept` methods, Role inherits the following methods from the `Type` class.
-- [label();](?tab=java#concept-api-java-method-retrieve-the-label)
-- [type.label(Label.of(label));](?tab=java#concept-api-java-method-rename-the-label)
-- [sup();](?tab=java#concept-api-java-method-retrieve-direct-supertype)
-- [sup(Type type);](?tab=java#concept-api-java-method-change-direct-supertype)
-- [sups();](?tab=java#concept-api-java-method-retrieve-all-supertypes)
-- [subs();](?tab=java#concept-api-java-method-retrieve-all-subtypes)
+- [label();](?tab=java#retrieve-the-label)
+- [type.label(Label.of(label));](?tab=java#rename-the-label)
+- [sup();](?tab=java#retrieve-direct-supertype)
+- [sup(Type type);](?tab=java#change-direct-supertype)
+- [sups();](?tab=java#retrieve-all-supertypes)
+- [subs();](?tab=java#retrieve-all-subtypes)
 </div>
 
 {% include api/generic.html data=site.data.04_concept_api.references.role language="java" %}
@@ -106,12 +106,12 @@ At the moment, `Role` inherits an intermediary class which, for the sake of simp
 <div class="note">
 [Important]
 At the moment, `Role` inherits an intermediary class which, for the sake of simplicity, has not been documented. Therefore, besides the `Concept` methods, Role inherits the following methods from the `Type` class.
-- [label();](?tab=javascript#concept-api-nodejs-method-retrieve-the-label)
-- [type.label(Label.of(label));](?tab=javascript#concept-api-nodejs-method-rename-the-label)
-- [sup();](?tab=javascript#concept-api-nodejs-method-retrieve-direct-supertype)
-- [sup(Type type);](?tab=javascript#concept-api-nodejs-method-change-direct-supertype)
-- [sups();](?tab=javascript#concept-api-nodejs-method-retrieve-all-supertypes)
-- [subs();](?tab=javascript#concept-api-nodejs-method-retrieve-all-subtypes)
+- [label();](?tab=javascript#retrieve-the-label)
+- [type.label(Label.of(label));](?tab=javascript#rename-the-label)
+- [sup();](?tab=javascript#retrieve-direct-supertype)
+- [sup(Type type);](?tab=javascript#change-direct-supertype)
+- [sups();](?tab=javascript#retrieve-all-supertypes)
+- [subs();](?tab=javascript#retrieve-all-subtypes)
 </div>
 {% include api/generic.html data=site.data.04_concept_api.references.role language="javascript" %}
 [tab:end]
@@ -120,12 +120,12 @@ At the moment, `Role` inherits an intermediary class which, for the sake of simp
 <div class="note">
 [Important]
 At the moment, `Role` inherits an intermediary class which, for the sake of simplicity, has not been documented. Therefore, besides the `Concept` methods, Role inherits the following methods from the `Type` class.
-- [label();](?tab=python#concept-api-python-method-retrieve-the-label)
-- [type.label(Label.of(label));](?tab=python#concept-api-python-method-rename-the-label)
-- [sup();](?tab=python#concept-api-python-method-retrieve-direct-supertype)
-- [sup(Type type);](?tab=python#concept-api-python-method-change-direct-supertype)
-- [sups();](?tab=python#concept-api-python-method-retrieve-all-supertypes)
-- [subs();](?tab=python#concept-api-python-method-retrieve-all-subtypes)
+- [label();](?tab=python#retrieve-the-label)
+- [type.label(Label.of(label));](?tab=python#rename-the-label)
+- [sup();](?tab=python#retrieve-direct-supertype)
+- [sup(Type type);](?tab=python#change-direct-supertype)
+- [sups();](?tab=python#retrieve-all-supertypes)
+- [subs();](?tab=python#retrieve-all-subtypes)
 </div>
 {% include api/generic.html data=site.data.04_concept_api.references.role language="python" %}
 [tab:end]

--- a/04-concept-api/references/attribute.yml
+++ b/04-concept-api/references/attribute.yml
@@ -38,14 +38,14 @@ methods:
       <<: *method-owners
       method: attribute.owners();
       return:
-        - "Stream of [`Thing`](../04-concept-api/04-thing?tab=java.md) objects"
+        - "Stream of [`Thing`](../concept-api/thing?tab=java) objects"
     javascript:
       <<: *method-owners
       method: await attribute.owners();
       return:
-        - "Iterator of [`Thing`](../04-concept-api/04-thing?tab=javascript.md) objects"
+        - "Iterator of [`Thing`](../concept-api/thing?tab=javascript) objects"
     python:
       <<: *method-owners
       method: attribute.owners()
       return:
-        - "Iterator of [`Thing`](../04-concept-api/04-thing?tab=python.md) objects"
+        - "Iterator of [`Thing`](../concept-api/thing?tab=python) objects"

--- a/04-concept-api/references/attribute_type.yml
+++ b/04-concept-api/references/attribute_type.yml
@@ -18,7 +18,7 @@ methods:
           <<: *accepts-create-value
           type: String &#124; boolean &#124; long &#124; double &#124; Date
       returns:
-        - "[`Attribute`](../04-concept-api/04-thing?tab=java#attribute-methods.md) object"
+        - "[`Attribute`](../concept-api/thing?tab=java#attribute-methods) object"
     javascript:
       <<: *method-create
       method: await attributeType.create(value);
@@ -27,7 +27,7 @@ methods:
           <<: *accepts-create-value
           type: String &#124; boolean &#124; integer &#124; float &#124; date
       returns:
-        - "[`Attribute`](../04-concept-api/04-thing?tab=javascript#attribute-methods.md) object"
+        - "[`Attribute`](../concept-api/thing?tab=javascript#attribute-methods) object"
     python:
       <<: *method-create
       method: attribute_type.create(value)
@@ -36,7 +36,7 @@ methods:
           <<: *accepts-create-value
           type: String &#124; boolean &#124; integer &#124; float &#124; date
       returns:
-        - "[`Attribute`](../04-concept-api/04-thing?tab=python#attribute-methods.md) object"
+        - "[`Attribute`](../concept-api/thing?tab=python#attribute-methods) object"
 
   - method:
     common: &method-attribute
@@ -53,19 +53,19 @@ methods:
       <<: *method-attribute
       method: attributeType.attribute(Object value);
       returns:
-        - "[`Attribute`](../04-concept-api/04-thing?tab=java#attribute-methods.md) object"
+        - "[`Attribute`](../concept-api/thing?tab=java#attribute-methods) object"
         - "NULL"
     javascript:
       <<: *method-attribute
       method: await attributeType.attribute(value);
       returns:
-        - "[`Attribute`](../04-concept-api/04-thing?tab=javascript#attribute-methods.md) object"
+        - "[`Attribute`](../concept-api/thing?tab=javascript#attribute-methods) object"
         - "`null`"
     python:
       <<: *method-attribute
       method: attribute_type.attribute(value)
       returns:
-        - "[`Attribute`](../04-concept-api/04-thing?tab=python#attribute-methods.md) object"
+        - "[`Attribute`](../concept-api/thing?tab=python#attribute-methods) object"
         - "`None`"
 
   - method:
@@ -122,7 +122,7 @@ methods:
       <<: *method-regex-set
       method: attributeType.regex(String regex);
       returns:
-        - "[`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods) object"
+        - "[`AttributeType`](../concept-api/type?tab=java#attributetype-methods) object"
     javascript:
       <<: *method-regex-set
       method: await attributeType.regex(regex);
@@ -132,4 +132,4 @@ methods:
       <<: *method-regex-set
       method: attribute_type.regex(regex)
       returns:
-        - "[`AttributeType`](/docs/concept-api/type?tab=python#attributetype-methods) object"
+        - "[`AttributeType`](../concept-api/type?tab=python#attributetype-methods) object"

--- a/04-concept-api/references/concept.yml
+++ b/04-concept-api/references/concept.yml
@@ -164,7 +164,7 @@ methods:
       description: Casts the concept as Type so that we can call the Type methods on it.
       method: concept.asType();
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=java) object"
+        - "[`Type`](../concept-api/type?tab=java) object"
     java:
       <<: *method-asType
 
@@ -174,7 +174,7 @@ methods:
       description: Casts the concept as Thing so that we can call the Thing methods on it.
       method: concept.asThing();
       returns:
-        - "[`Thing`](../04-concept-api/04-thing?tab=java.md) object"
+        - "[`Thing`](../concept-api/thing?tab=java) object"
     java:
       <<: *method-asThing
 
@@ -184,7 +184,7 @@ methods:
       description: Casts the concept as EntityType so that we can call the EntityType methods on it.
       method: concept.asEntityType();
       returns:
-        - "[`EntityType`](/docs/concept-api/type?tab=java#entitytype-methods) object"
+        - "[`EntityType`](../concept-api/type?tab=java#entitytype-methods) object"
     java:
       <<: *method-asEntityType
 
@@ -194,7 +194,7 @@ methods:
       description: Casts the concept as AttributeType so that we can call the AttributeType methods on it.
       method: concept.asAttributeType();
       returns:
-        - "[`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods) object"
+        - "[`AttributeType`](../concept-api/type?tab=java#attributetype-methods) object"
     java:
       <<: *method-asAttributeType
 
@@ -204,7 +204,7 @@ methods:
       description: Casts the concept as RelationType so that we can call the RelationType methods on it.
       method: concept.asRelationType();
       returns:
-        - "[`RelationType`](/docs/concept-api/type?tab=java#relationtype-methods) object"
+        - "[`RelationType`](../concept-api/type?tab=java#relationtype-methods) object"
     java:
       <<: *method-asRelationType
 
@@ -224,7 +224,7 @@ methods:
       description: Casts the concept as Attribute so that we can call the Attribute methods on it.
       method: concept.asAttribute();
       returns:
-        - "[`Attribute`](../04-concept-api/04-thing?tab=java#attribute-methods.md) object"
+        - "[`Attribute`](../concept-api/thing?tab=java#attribute-methods) object"
     java:
       <<: *method-asAttribute
 
@@ -234,7 +234,7 @@ methods:
       description: Casts the concept as Relation so that we can call the Relation methods on it.
       method: concept.asRelation();
       returns:
-        - "[`Relation`](../04-concept-api/04-thing?tab=java#relation-methods.md) object"
+        - "[`Relation`](../concept-api/thing?tab=java#relation-methods) object"
     java:
       <<: *method-asRelation
 
@@ -244,7 +244,7 @@ methods:
         description: Casts the concept as Relation so that we can call the Relation methods on it.
         method: concept.asRelation();
         returns:
-          - "[`Rule`](../04-concept-api/03-rule?tab=java.md) object"
+          - "[`Rule`](../concept-api/rule?tab=java) object"
       java:
         <<: *method-asRelation
 

--- a/04-concept-api/references/relation.yml
+++ b/04-concept-api/references/relation.yml
@@ -7,17 +7,17 @@ methods:
       <<: *method-rolePlayersMap
       method: relation.rolePlayersMap();
       returns:
-        - 'Map<[`Role`](/docs/concept-api/type?tab=java#role-methods), Set<[`Thing`](../04-concept-api/04-thing?tab=java#thing-methods.md)>>'
+        - 'Map<[`Role`](../concept-api/type?tab=java#role-methods), Set<[`Thing`](../concept-api/thing?tab=java#thing-methods)>>'
     javascript:
       <<: *method-rolePlayersMap
       method: await relation.rolePlayersMap();
       returns:
-        - 'Map<[`Role`](/docs/concept-api/type?tab=java#role-methods), Set<[`Thing`](../04-concept-api/04-thing?tab=java#thing-methods.md)>>'
+        - 'Map<[`Role`](../concept-api/type?tab=java#role-methods), Set<[`Thing`](../concept-api/thing?tab=java#thing-methods)>>'
     python:
       <<: *method-rolePlayersMap
       method: relation.role_players_map()
       returns:
-        - Dict[[`Role`](/docs/concept-api/type?tab=java#role-methods), set[[`Thing`](../04-concept-api/04-thing?tab=java#thing-methods.md)]]
+        - Dict[[`Role`](../concept-api/type?tab=java#role-methods), set[[`Thing`](../concept-api/thing?tab=java#thing-methods)]]
 
   - method:
     common: &method-rolePlayers
@@ -35,27 +35,27 @@ methods:
       accepts:
         param:
           <<: *accepts-rolePlayers-role
-          type: "[`Role`](/docs/concept-api/type?tab=java#role-methods)"
+          type: "[`Role`](../concept-api/type?tab=java#role-methods)"
       returns:
-        - "Stream of [`Thing`](../04-concept-api/04-thing?tab=java.md) objects"
+        - "Stream of [`Thing`](../concept-api/thing?tab=java) objects"
     javascript:
       <<: *method-rolePlayers
       method: await relation.rolePlayers(role);
       accepts:
         param:
           <<: *accepts-rolePlayers-role
-          type: "[`Role`](/docs/concept-api/type?tab=javascript#role-methods)"
+          type: "[`Role`](../concept-api/type?tab=javascript#role-methods)"
       returns:
-        - "Iterator of [`Thing`](../04-concept-api/04-thing?tab=java.md) objects"
+        - "Iterator of [`Thing`](../concept-api/thing?tab=java) objects"
     python:
       <<: *method-rolePlayers
       method: relation.role_players(role)
       accepts:
         param:
           <<: *accepts-rolePlayers-role
-          type: "[`Role`](/docs/concept-api/type?tab=python#role-methods)"
+          type: "[`Role`](../concept-api/type?tab=python#role-methods)"
       returns:
-        - "Iterator of [`Thing`](../04-concept-api/04-thing?tab=java.md) objects"
+        - "Iterator of [`Thing`](../concept-api/thing?tab=java) objects"
 
   - method:
     common: &method-assign
@@ -78,22 +78,22 @@ methods:
       accepts:
         param1:
           <<: *accepts-assign-role
-          type: "[`Role`](/docs/concept-api/type?tab=java#role-methods)"
+          type: "[`Role`](../concept-api/type?tab=java#role-methods)"
         param2:
           <<: *accepts-assign-thing
-          type: "[`Thing`](../04-concept-api/04-thing?tab=java.md)"
+          type: "[`Thing`](../concept-api/thing?tab=java)"
       returns:
-        - '[`Relation`](../04-concept-api/04-thing#relation-methods.md) object'
+        - '[`Relation`](../concept-api/thing#relation-methods) object'
     javascript:
       <<: *method-assign
       method: await relation.assign(role, thing);
       accepts:
         param1:
           <<: *accepts-assign-role
-          type: "[`Role`](/docs/concept-api/type?tab=javascript#role-methods)"
+          type: "[`Role`](../concept-api/type?tab=javascript#role-methods)"
         param2:
           <<: *accepts-assign-thing
-          type: "[`Thing`](../04-concept-api/04-thing?tab=javascript.md)"
+          type: "[`Thing`](../concept-api/thing?tab=javascript)"
       returns:
         - "`void`"
     python:
@@ -102,12 +102,12 @@ methods:
       accepts:
         param1:
           <<: *accepts-assign-role
-          type: "[`Role`](/docs/concept-api/type?tab=python#role-methods)"
+          type: "[`Role`](../concept-api/type?tab=python#role-methods)"
         param2:
           <<: *accepts-assign-thing
-          type: "[`Thing`](../04-concept-api/04-thing?tab=python.md)"
+          type: "[`Thing`](../concept-api/thing?tab=python)"
       returns:
-        - '[`Relation`](../04-concept-api/04-thing#relation-methods.md) object'
+        - '[`Relation`](../concept-api/thing#relation-methods) object'
 
   - method:
     common: &method-unassign
@@ -122,7 +122,7 @@ methods:
         param2: &accepts-unassign-thing
           name: thing
           description: The instance to no longer play the `role` in this Relation.
-          type: "[`Thing`](../04-concept-api/04-thing.md)"
+          type: "[`Thing`](../concept-api/thing)"
           required: true
           default: N/A
     java:
@@ -131,22 +131,22 @@ methods:
       accepts:
         param1:
           <<: *accepts-unassign-role
-          type: "[`Role`](/docs/concept-api/type?tab=java#role-methods)"
+          type: "[`Role`](../concept-api/type?tab=java#role-methods)"
         param2:
           <<: *accepts-unassign-thing
-          type: "[`Thing`](../04-concept-api/04-thing?tab=java.md)"
+          type: "[`Thing`](../concept-api/thing?tab=java)"
       returns:
-        - '[`Relation`](../04-concept-api/04-thing#relation-methods.md) object'
+        - '[`Relation`](../concept-api/thing#relation-methods) object'
     javascript:
       <<: *method-unassign
       method: await relation.unassign(role, thing);
       accepts:
         param1:
           <<: *accepts-unassign-role
-          type: "[`Role`](/docs/concept-api/type?tab=javascript#role-methods)"
+          type: "[`Role`](../concept-api/type?tab=javascript#role-methods)"
         param2:
           <<: *accepts-unassign-thing
-          type: "[`Thing`](../04-concept-api/04-thing?tab=javascript.md)"
+          type: "[`Thing`](../concept-api/thing?tab=javascript)"
       returns:
         - "`void`"
     python:
@@ -155,9 +155,9 @@ methods:
       accepts:
         param1:
           <<: *accepts-unassign-role
-          type: "[`Role`](/docs/concept-api/type?tab=python#role-methods)"
+          type: "[`Role`](../concept-api/type?tab=python#role-methods)"
         param2:
           <<: *accepts-unassign-thing
-          type: "[`Thing`](../04-concept-api/04-thing?tab=python.md)"
+          type: "[`Thing`](../concept-api/thing?tab=python)"
       returns:
-        - "[`Relation`](../04-concept-api/04-thing#relation-methods.md) object"
+        - "[`Relation`](../concept-api/thing#relation-methods) object"

--- a/04-concept-api/references/relation_type.yml
+++ b/04-concept-api/references/relation_type.yml
@@ -7,17 +7,17 @@ methods:
       <<: *method-create
       method: relationType.create();
       returns:
-        - "[`Relation`](../04-concept-api/04-thing?tab=java#relation-methods.md) object"
+        - "[`Relation`](../concept-api/thing?tab=java#relation-methods) object"
     javascript:
       <<: *method-create
       method: await relationType.create();
       returns:
-        - "[`Relation`](../04-concept-api/04-thing?tab=nodejs#relation-methods.md) object"
+        - "[`Relation`](../concept-api/thing?tab=nodejs#relation-methods) object"
     python:
       <<: *method-create
       method: relation_type.create()
       returns:
-        - "[`Relation`](../04-concept-api/04-thing?tab=python#relation-methods.md) object"
+        - "[`Relation`](../concept-api/thing?tab=python#relation-methods) object"
 
   - method:
     common: &method-roles
@@ -27,17 +27,17 @@ methods:
       <<: *method-roles
       method: relationType.roles();
       returns:
-        - "Stream of [`Role`](/docs/concept-api/type?javatab=#role-methods) objects"
+        - "Stream of [`Role`](../concept-api/type?javatab=#role-methods) objects"
     javascript:
       <<: *method-roles
       method: await relationType.roles();
       returns:
-        - "Iterator of [`Role`](/docs/concept-api/type?javascripttab=#role-methods) objects"
+        - "Iterator of [`Role`](../concept-api/type?javascripttab=#role-methods) objects"
     python:
       <<: *method-roles
       method: relation_type.roles()
       returns:
-        - "Iterator of [`Role`](/docs/concept-api/type?tab=python#role-methods) objects"
+        - "Iterator of [`Role`](../concept-api/type?tab=python#role-methods) objects"
 
   - method:
     common: &method-relates
@@ -54,7 +54,7 @@ methods:
       <<: *method-relates
       method: relationType.relates(Role role);
       returns:
-        - "[`RelationType`](/docs/concept-api/type?tab=java#relationtype-methods) object"
+        - "[`RelationType`](../concept-api/type?tab=java#relationtype-methods) object"
     javascript:
       <<: *method-relates
       method: await relationType.relates(role);
@@ -64,7 +64,7 @@ methods:
       <<: *method-relates
       method: relation_type.relates(role)
       returns:
-        - "[`RelationType`](/docs/concept-api/type?tab=python#relationtype-methods) object"
+        - "[`RelationType`](../concept-api/type?tab=python#relationtype-methods) object"
 
   - method:
     common: &method-unrelate
@@ -81,7 +81,7 @@ methods:
       <<: *method-unrelate
       method: relationType.unrelate(Role role);
       returns:
-        - "[`RelationType`](/docs/concept-api/type?tab=java#relationtype-methods) object"
+        - "[`RelationType`](../concept-api/type?tab=java#relationtype-methods) object"
     javascript:
       <<: *method-unrelate
       method: await relationType.unrelate(role);
@@ -91,4 +91,4 @@ methods:
       <<: *method-unrelate
       method: relation_type.unrelate(role)
       returns:
-        - "[`RelationType`](/docs/concept-api/type?tab=python#relationtype-methods) object"
+        - "[`RelationType`](../concept-api/type?tab=python#relationtype-methods) object"

--- a/04-concept-api/references/role.yml
+++ b/04-concept-api/references/role.yml
@@ -7,17 +7,17 @@ methods:
       <<: *method-relations
       method: role.relations();
       returns:
-        - "Stream of [`Relation`](../04-concept-api/04-thing?tab=java#relation-methods.md) objects"
+        - "Stream of [`Relation`](../concept-api/thing?tab=java#relation-methods) objects"
     javascript:
       <<: *method-relations
       method: await role.relations();
       returns:
-        - "Iterator of [`Relation](../04-concept-api/04-thing?tab=javascript#relation-methods.md) objects"
+        - "Iterator of [`Relation](../concept-api/thing?tab=javascript#relation-methods) objects"
     python:
       <<: *method-relations
       method: role.relations()
       returns:
-        - "Iterator of [`Relation`](../04-concept-api/04-thing?tab=python#relation-methods.md) objects"
+        - "Iterator of [`Relation`](../concept-api/thing?tab=python#relation-methods) objects"
   - method:
     common: &method-players
       title: Retrieve roleplayers

--- a/04-concept-api/references/rule.yml
+++ b/04-concept-api/references/rule.yml
@@ -2,7 +2,7 @@ methods:
   - method:
     common: &method-when
       title: Retrieve the when body
-      description: Retrieves the statements that constructs the when body of thia rule.
+      description: Retrieves the statements that constructs the when body of the rule.
       returns:
         - "`String`"
     java:
@@ -17,7 +17,7 @@ methods:
   - method:
     common: &method-then
       title: Retrieve the then body
-      description: Retrieves the single statement that constructs the then body of this rule.
+      description: Retrieves the single statement that constructs the then body of the rule.
       returns:
         - "`String`"
     java:

--- a/04-concept-api/references/thing.yml
+++ b/04-concept-api/references/thing.yml
@@ -4,7 +4,7 @@ methods:
       title: Retrieve type
       description: Retrieves the type which this Thing belongs to.
       returns:
-        - "[`Type`](/docs/concept-api/type) object"
+        - "[`Type`](../concept-api/type) object"
     java:
       <<: *method-type
       method: thing.type();
@@ -31,27 +31,27 @@ methods:
       accepts:
         param:
           <<: *accepts-relations-param-roles
-          type: "Varargs of [`Role`](/docs/concept-api/type?tab=java#role-methods) objects"
+          type: "Varargs of [`Role`](../concept-api/type?tab=java#role-methods) objects"
       returns:
-        - "Stream of [`Relation`](../04-concept-api/04-thing?tab=java#relation-methods.md) objects"
+        - "Stream of [`Relation`](../concept-api/thing?tab=java#relation-methods) objects"
     javascript:
       <<: *method-relations
       method: await thing.relations(roles);
       accepts:
         param:
           <<: *accepts-relations-param-roles
-          type: "Array of [`Role`](/docs/concept-api/type?tab=javascript#role-methods)s"
+          type: "Array of [`Role`](../concept-api/type?tab=javascript#role-methods)s"
       returns:
-        - "Iterator of [`Relation`](../04-concept-api/04-thing?tab=javascript#relation-methods.md) objects"
+        - "Iterator of [`Relation`](../concept-api/thing?tab=javascript#relation-methods) objects"
     python:
       <<: *method-relations
       method: thing.relations(roles)
       accepts:
         param:
           <<: *accepts-relations-param-roles
-          type: "List of [`Role`](/docs/concept-api/type?tab=python#role-methods)s"
+          type: "List of [`Role`](../concept-api/type?tab=python#role-methods)s"
       returns:
-        - "Iterator of [`Relation`](../04-concept-api/04-thing?tab=python#relation-methods.md) objects"
+        - "Iterator of [`Relation`](../concept-api/thing?tab=python#relation-methods) objects"
 
   - method:
     common: &method-roles
@@ -61,17 +61,17 @@ methods:
       <<: *method-roles
       method: thing.roles();
       returns:
-        - "Stream of [`Role`](/docs/concept-api/type?tab=java#role-methods) objects"
+        - "Stream of [`Role`](../concept-api/type?tab=java#role-methods) objects"
     javascript:
       <<: *method-roles
       method: await thing.roles();
       returns:
-        - "Iterator of [`Role`](/docs/concept-api/type?tab=javascript#role-methods) objects"
+        - "Iterator of [`Role`](../concept-api/type?tab=javascript#role-methods) objects"
     python:
       <<: *method-roles
       method: thing.roles()
       returns:
-        - "Iterator of [`Role`](/docs/concept-api/type?tab=python#role-methods) objects"
+        - "Iterator of [`Role`](../concept-api/type?tab=python#role-methods) objects"
 
   - method:
     common: &method-attributes
@@ -90,9 +90,9 @@ methods:
         param:
           <<: *accepts-attributes-param-types
           name: attributeTypes
-          type: "Varargs of [`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods)s"
+          type: "Varargs of [`AttributeType`](../concept-api/type?tab=java#attributetype-methods)s"
       returns:
-        - "Stream of [`Attribute`](../04-concept-api/04-thing?tab=java#attribute-methods.md) objects"
+        - "Stream of [`Attribute`](../concept-api/thing?tab=java#attribute-methods) objects"
     javascript:
       <<: *method-attributes
       method: await thing.attributes(attributeTypes);
@@ -101,9 +101,9 @@ methods:
         param:
           <<: *accepts-attributes-param-types
           name: attributeTypes
-          type: "Array of [`AttributeType`](/docs/concept-api/type?tab=javascript#attributetype-methods)s"
+          type: "Array of [`AttributeType`](../concept-api/type?tab=javascript#attributetype-methods)s"
       returns:
-        - "Iterator of [`Attribute`](../04-concept-api/04-thing?tab=javascript#attribute-methods.md) objects"
+        - "Iterator of [`Attribute`](../concept-api/thing?tab=javascript#attribute-methods) objects"
     python:
       <<: *method-attributes
       method: thing.attributes(attribute_types)
@@ -112,9 +112,9 @@ methods:
         param:
           <<: *accepts-attributes-param-types
           name: attribute_types
-          type: "List of [`AttributeType`](/docs/concept-api/type?tab=pyhthon#attributetype-methods)s"
+          type: "List of [`AttributeType`](../concept-api/type?tab=pyhthon#attributetype-methods)s"
       returns:
-        - "Iterator of [`Attribute`](../04-concept-api/04-thing?tab=pyhthon#attribute-methods.md) objects"
+        - "Iterator of [`Attribute`](../concept-api/thing?tab=pyhthon#attribute-methods) objects"
 
   - method:
     common: &method-keys
@@ -133,9 +133,9 @@ methods:
         param:
           <<: *accepts-keys-param-types
           name: attributeTypes
-          type: "Array of [`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods)s"
+          type: "Array of [`AttributeType`](../concept-api/type?tab=java#attributetype-methods)s"
       returns:
-        - "Stream of [`Attribute`](../04-concept-api/04-thing?tab=java#attribute-methods.md) objects"
+        - "Stream of [`Attribute`](../concept-api/thing?tab=java#attribute-methods) objects"
     javascript:
       <<: *method-keys
       method: await thing.keys(attributeTypes);
@@ -144,9 +144,9 @@ methods:
         param:
           <<: *accepts-keys-param-types
           name: attributeTypes
-          type: "Array of [`AttributeType`](/docs/concept-api/type?tab=javascript#attributetype-methods)s"
+          type: "Array of [`AttributeType`](../concept-api/type?tab=javascript#attributetype-methods)s"
       returns:
-        - "Iterator of [`Attribute`](../04-concept-api/04-thing?tab=javascript#attribute-methods.md) objects"
+        - "Iterator of [`Attribute`](../concept-api/thing?tab=javascript#attribute-methods) objects"
     python:
       <<: *method-keys
       method: thing.keys(attribute_types)
@@ -155,9 +155,9 @@ methods:
         param:
           <<: *accepts-keys-param-types
           name: attribute_types
-          type: "List of [`AttributeType`](/docs/concept-api/type?tab=python#attributetype-methods)s"
+          type: "List of [`AttributeType`](../concept-api/type?tab=python#attributetype-methods)s"
       returns:
-        - "Iterator of [`Attribute`](../04-concept-api/04-thing?tab=python#attribute-methods.md) objects"
+        - "Iterator of [`Attribute`](../concept-api/thing?tab=python#attribute-methods) objects"
 
   - method:
     common: &method-has
@@ -175,27 +175,27 @@ methods:
       accepts:
         param:
           <<: *accepts-has-attribute
-          type: "[`Attribute`](../04-concept-api/04-thing?tab=java#attribute-methods.md)"
+          type: "[`Attribute`](../concept-api/thing?tab=java#attribute-methods)"
       returns:
-        - "[`Thing`](../04-concept-api/04-thing?tab=java.md) object"
+        - "[`Thing`](../concept-api/thing?tab=java) object"
     javascript:
       <<: *method-has
       method: await thing.has(attribute);
       accepts:
         param:
           <<: *accepts-has-attribute
-          type: "[`Attribute`](../04-concept-api/04-thing?tab=javascript#attribute-methods.md)"
+          type: "[`Attribute`](../concept-api/thing?tab=javascript#attribute-methods)"
       returns:
-        - "[`Thing`](../04-concept-api/04-thing?tab=javascript.md) object"
+        - "[`Thing`](../concept-api/thing?tab=javascript) object"
     python:
       <<: *method-has
       method: thing.has(attribute)
       accepts:
         param:
           <<: *accepts-has-attribute
-          type: "[`Attribute`](../04-concept-api/04-thing?tab=python#attribute-methods.md)"
+          type: "[`Attribute`](../concept-api/thing?tab=python#attribute-methods)"
       returns:
-        - "[`Thing`](../04-concept-api/04-thing?tab=python.md) object"
+        - "[`Thing`](../concept-api/thing?tab=python) object"
 
   - method:
     common: &method-unhas
@@ -205,29 +205,29 @@ methods:
         param:
           name: attribute
           description: The Attribute to be disowned from this Thing.
-          type: "[`Attribute`](../04-concept-api/04-thing#attribute-methods.md)"
+          type: "[`Attribute`](../concept-api/thing#attribute-methods)"
           required: true
           default: N/A
     java:
       <<: *method-unhas
       method: thing.unhas(Attribute attribute);
       returns:
-        - "[`Thing`](../04-concept-api/04-thing?tab=java.md) object"
+        - "[`Thing`](../concept-api/thing?tab=java) object"
     javascript:
       <<: *method-unhas
       method: await thing.unhas(attribute);
       returns:
-        - "[`Thing`](../04-concept-api/04-thing?tab=javascript.md) object"
+        - "[`Thing`](../concept-api/thing?tab=javascript) object"
     python:
       <<: *method-unhas
       method: thing.unhas(attribute)
       returns:
-        - "[`Thing`](../04-concept-api/04-thing?tab=python.md) object"
+        - "[`Thing`](../concept-api/thing?tab=python) object"
 
   - method:
     common: &method-isInferred
       title: Check if inferred
-      description: Checks if this Thing is inferred by a [Reasoning Rule](../09-schema/03-rules.md).
+      description: Checks if this Thing is inferred by a [Reasoning Rule](../schema/rules).
       returns:
         - boolean
     java:

--- a/04-concept-api/references/type.yml
+++ b/04-concept-api/references/type.yml
@@ -30,7 +30,7 @@ methods:
       <<: *method-label-rename
       method: type.label(Label.of(String label));
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=java#type-methods) object"
     javascript:
       <<: *method-label-rename
       method: await type.label(label);
@@ -40,7 +40,7 @@ methods:
       <<: *method-label-rename
       method: type.label(label)
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=python#type-methods) object"
 
   - method:
     common: &method-sup-retrieve
@@ -50,19 +50,19 @@ methods:
       <<: *method-sup-retrieve
       method: type.sup();
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=java#type-methods) object"
         - "`NULL`"
     javascript:
       <<: *method-sup-retrieve
       method: await type.sup();
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=javascript#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=javascript#type-methods) object"
         - "`null`"
     python:
       <<: *method-sup-retrieve
       method: type.sup()
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=python#type-methods) object"
         - "`None`"
 
   - method:
@@ -73,14 +73,14 @@ methods:
         param:
           name: type
           description: The new type that the given type is to inherits.
-          type: "[`EntityType`](/docs/concept-api/type#entitytype-methods) &#124; [`AttributeType`](/docs/concept-api/type#attributetype-methods) &#124; [`RelationType`](...)"
+          type: "[`EntityType`](../concept-api/type#entitytype-methods) &#124; [`AttributeType`](../concept-api/type#attributetype-methods) &#124; [`RelationType`](...)"
           required: true
           default: N/A
     # java:
     #   <<: *method-sup-reset
     #   method: type.sup(Type type);
     #   returns:
-    #     - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
+    #     - "[`Type`](../concept-api/type?tab=java#type-methods) object"
     #     - "`null`"
     javascript:
       <<: *method-sup-reset
@@ -91,7 +91,7 @@ methods:
       <<: *method-sup-reset
       method: type.sup(type)
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=python) object"
+        - "[`Type`](../concept-api/type?tab=python) object"
         - "`None`"
 
   - method:
@@ -102,17 +102,17 @@ methods:
       <<: *method-sups
       method: type.sups();
       returns:
-        - "Stream of [`Type`](/docs/concept-api/type?tab=java#type-methods) objects"
+        - "Stream of [`Type`](../concept-api/type?tab=java#type-methods) objects"
     javascript:
       <<: *method-sups
       method: await type.sups()
       returns:
-        - "Iterator of [`Type`](/docs/concept-api/type?tab=java#type-methods) objects"
+        - "Iterator of [`Type`](../concept-api/type?tab=java#type-methods) objects"
     python:
       <<: *method-sups
       method: type.sups()
       returns:
-        - "Iterator of [`Type`](/docs/concept-api/type?tab=python#type-methods) objects"
+        - "Iterator of [`Type`](../concept-api/type?tab=python#type-methods) objects"
 
   - method:
     common: &method-subs
@@ -122,17 +122,17 @@ methods:
       <<: *method-subs
       method: type.subs();
       returns:
-        - "Stream of [`Type`](/docs/concept-api/type?tab=java#type-methods) objects"
+        - "Stream of [`Type`](../concept-api/type?tab=java#type-methods) objects"
     javascript:
       <<: *method-subs
       method: await type.subs()
       returns:
-        - "Iterator of [`Type`](/docs/concept-api/type?tab=nodejs#type-methods) objects"
+        - "Iterator of [`Type`](../concept-api/type?tab=nodejs#type-methods) objects"
     python:
       <<: *method-subs
       method: type.subs()
       returns:
-        - "Iterator of [`Type`](/docs/concept-api/type?tab=python#type-methods) objects"
+        - "Iterator of [`Type`](../concept-api/type?tab=python#type-methods) objects"
 
   - method:
     common: &method-isImplicit
@@ -181,7 +181,7 @@ methods:
       <<: *method-isAbstract-set
       method: type.isAbstract(Boolean abstract);
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=java#type-methods) object"
     javascript:
       <<: *method-isAbstract-set
       method: await type.isAbstract(abstract);
@@ -191,7 +191,7 @@ methods:
       <<: *method-isAbstract-set
       method: type.is_abstract(abstract)
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=python#type-methods) object"
 
   - method:
     common: &method-playing
@@ -201,17 +201,17 @@ methods:
       <<: *method-playing
       method: type.playing();
       returns:
-        - "Stream of [`Role`](/docs/concept-api/type?tab=java#role-methods) objects"
+        - "Stream of [`Role`](../concept-api/type?tab=java#role-methods) objects"
     javascript:
       <<: *method-playing
       method: await type.playing();
       returns:
-        - "Iterator of [`Role`](/docs/concept-api/type?tab=javascript#role-methods) objects"
+        - "Iterator of [`Role`](../concept-api/type?tab=javascript#role-methods) objects"
     python:
       <<: *method-playing
       method: type.playing()
       returns:
-        - "Iterator of [`Role`](/docs/concept-api/type?tab=python#role-methods) objects"
+        - "Iterator of [`Role`](../concept-api/type?tab=python#role-methods) objects"
 
   - method:
     common: &method-plays
@@ -229,16 +229,16 @@ methods:
       accepts:
         param:
           <<: *accepts-plays-role
-          type: "[`Role`](/docs/concept-api/type?tab=java#role-methods)"
+          type: "[`Role`](../concept-api/type?tab=java#role-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=java#type-methods) object"
     javascript:
       <<: *method-plays
       method: await type.plays(role);
       accepts:
         param:
           <<: *accepts-plays-role
-          type: "[`Role`](/docs/concept-api/type?tab=javascript#role-methods)"
+          type: "[`Role`](../concept-api/type?tab=javascript#role-methods)"
       returns:
         - "`void`"
     python:
@@ -247,9 +247,9 @@ methods:
       accepts:
         param:
           <<: *accepts-plays-role
-          type: "[`Role`](/docs/concept-api/type?tab=python#role-methods)"
+          type: "[`Role`](../concept-api/type?tab=python#role-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=python#type-methods) object"
 
   - method:
     common: &method-unplay
@@ -267,16 +267,16 @@ methods:
       accepts:
         param:
           <<: *accepts-unplay
-          type: "[`Role`](/docs/concept-api/type?tab=java#role-methods)"
+          type: "[`Role`](../concept-api/type?tab=java#role-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=java#type-methods) object"
     javascript:
       <<: *method-unplay
       method: await type.unplay(role);
       accepts:
         param:
           <<: *accepts-unplay
-          type: "[`Role`](/docs/concept-api/type?tab=javascript#role-methods)"
+          type: "[`Role`](../concept-api/type?tab=javascript#role-methods)"
       returns:
         - "`void`"
     python:
@@ -285,9 +285,9 @@ methods:
       accepts:
         param:
           <<: *accepts-unplay
-          type: "[`Role`](/docs/concept-api/type?tab=python#role-methods)"
+          type: "[`Role`](../concept-api/type?tab=python#role-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=python#type-methods) object"
 
   - method:
     common: &method-attributes
@@ -297,17 +297,17 @@ methods:
       <<: *method-attributes
       method: type.attributes();
       returns:
-        - "Stream of [`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods) objects"
+        - "Stream of [`AttributeType`](../concept-api/type?tab=java#attributetype-methods) objects"
     javascript:
       <<: *method-attributes
       method: await type.attributes();
       returns:
-        - "Iterator of [`AttributeType`](/docs/concept-api/type?tab=javascript#attributetype-methods) objects"
+        - "Iterator of [`AttributeType`](../concept-api/type?tab=javascript#attributetype-methods) objects"
     python:
       <<: *method-attributes
       method: type.attributes()
       returns:
-        - "Iterator of [`AttributeType`](/docs/concept-api/type?tab=python#attributetype-methods) objects"
+        - "Iterator of [`AttributeType`](../concept-api/type?tab=python#attributetype-methods) objects"
 
   - method:
     common: &method-has
@@ -325,9 +325,9 @@ methods:
         param:
           <<: *accepts-has-attributeType
           name: attributeType
-          type: "[`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods)"
+          type: "[`AttributeType`](../concept-api/type?tab=java#attributetype-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=java#type-methods) object"
     javascript:
       <<: *method-has
       method: await type.has(attributeType);
@@ -335,7 +335,7 @@ methods:
         param:
           <<: *accepts-has-attributeType
           name: attributeType
-          type: "[`AttributeType`](/docs/concept-api/type?tab=javascript#attributetype-methods)"
+          type: "[`AttributeType`](../concept-api/type?tab=javascript#attributetype-methods)"
       returns:
         - "`void`"
     python:
@@ -345,9 +345,9 @@ methods:
         param:
           <<: *accepts-has-attributeType
           name: attribute_type
-          type: "[`AttributeType`](/docs/concept-api/type?tab=python#attributetype-methods)"
+          type: "[`AttributeType`](../concept-api/type?tab=python#attributetype-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=python#type-methods) object"
 
   - method:
     common: &method-unhas
@@ -365,9 +365,9 @@ methods:
         param:
           <<: *accepts-unhas-attributeType
           name: attributeType
-          type: "[`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods)"
+          type: "[`AttributeType`](../concept-api/type?tab=java#attributetype-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=java#type-methods) object"
     javascript:
       <<: *method-unhas
       method: await type.unhas(attributeType);
@@ -375,7 +375,7 @@ methods:
         param:
           <<: *accepts-unhas-attributeType
           name: attributeType
-          type: "[`AttributeType`](/docs/concept-api/type?tab=javascript#attributetype-methods)"
+          type: "[`AttributeType`](../concept-api/type?tab=javascript#attributetype-methods)"
       returns:
         - "`void`"
     python:
@@ -385,9 +385,9 @@ methods:
         param:
           <<: *accepts-unhas-attributeType
           name: attribute_type
-          type: "[`AttributeType`](/docs/concept-api/type?tab=python#attributetype-methods)"
+          type: "[`AttributeType`](../concept-api/type?tab=python#attributetype-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=python#type-methods) object"
 
   - method:
     common: &method-keys
@@ -397,17 +397,17 @@ methods:
       <<: *method-keys
       method: type.keys();
       returns:
-        - "Stream of [`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods) objects"
+        - "Stream of [`AttributeType`](../concept-api/type?tab=java#attributetype-methods) objects"
     javascript:
       <<: *method-keys
       method: await type.keys();
       returns:
-        - "Iterator of [`AttributeType`](/docs/concept-api/type?tab=javascript#attributetype-methods) objects"
+        - "Iterator of [`AttributeType`](../concept-api/type?tab=javascript#attributetype-methods) objects"
     python:
       <<: *method-keys
       method: type.keys()
       returns:
-        - "Iterator of [`AttributeType`](/docs/concept-api/type?tab=python#attributetype-methods) objects"
+        - "Iterator of [`AttributeType`](../concept-api/type?tab=python#attributetype-methods) objects"
   - method:
     common: &method-key
       title: Add key
@@ -424,16 +424,16 @@ methods:
       accepts:
         param:
           <<: *accepts-key-key
-          type: "[`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods)"
+          type: "[`AttributeType`](../concept-api/type?tab=java#attributetype-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=java#type-methods) object"
     javascript:
       <<: *method-key
       method: await type.key(attributeType);
       accepts:
         param:
           <<: *accepts-key-key
-          type: "[`AttributeType`](/docs/concept-api/type?tab=javascript#attributetype-methods)"
+          type: "[`AttributeType`](../concept-api/type?tab=javascript#attributetype-methods)"
       returns:
         - "`void`"
     python:
@@ -442,9 +442,9 @@ methods:
       accepts:
         param:
           <<: *accepts-key-key
-          type: "[`AttributeType`](/docs/concept-api/type?tab=python#attributetype-methods)"
+          type: "[`AttributeType`](../concept-api/type?tab=python#attributetype-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=python#type-methods) object"
 
   - method:
     common: &method-unkey
@@ -462,9 +462,9 @@ methods:
         param:
           <<: *accepts-unkey-attributeType
           name: attributeType
-          type: "[`AttributeType`](/docs/concept-api/type?tab=java#attributetype-methods)"
+          type: "[`AttributeType`](../concept-api/type?tab=java#attributetype-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=java#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=java#type-methods) object"
     javascript:
       <<: *method-unkey
       method: await type.unkey(attributeType);
@@ -472,7 +472,7 @@ methods:
         param:
           <<: *accepts-unkey-attributeType
           name: attributeType
-          type: "[`AttributeType`](/docs/concept-api/type?tab=javascript#attributetype-methods)"
+          type: "[`AttributeType`](../concept-api/type?tab=javascript#attributetype-methods)"
       returns:
         - "`void`"
     python:
@@ -482,9 +482,9 @@ methods:
         param:
           <<: *accepts-unkey-attributeType
           name: attribute_type
-          type: "[`AttributeType`](/docs/concept-api/type?tab=python#attributetype-methods)"
+          type: "[`AttributeType`](../concept-api/type?tab=python#attributetype-methods)"
       returns:
-        - "[`Type`](/docs/concept-api/type?tab=python#type-methods) object"
+        - "[`Type`](../concept-api/type?tab=python#type-methods) object"
 
   - method:
     common: &method-instances
@@ -494,14 +494,14 @@ methods:
       <<: *method-instances
       method: type.instances();
       returns:
-        - "Stream of [`Thing`](../04-concept-api/04-thing?tab=java.md) objects"
+        - "Stream of [`Thing`](../concept-api/thing?tab=java) objects"
     javascript:
       <<: *method-instances
       method: await type.instances();
       returns:
-        - "Iterator of [`Thing`](../04-concept-api/04-thing?tab=javascript.md) objects"
+        - "Iterator of [`Thing`](../concept-api/thing?tab=javascript) objects"
     python:
       <<: *method-instances
       method: type.instances()
       returns:
-        - "Iterator of [`Thing`](../04-concept-api/04-thing?tab=python.md) objects"
+        - "Iterator of [`Thing`](../concept-api/thing?tab=python) objects"

--- a/06-management/01-keyspace.md
+++ b/06-management/01-keyspace.md
@@ -15,7 +15,7 @@ Keyspaces are isolated from one another. Even when running on the same Grakn Ser
 </div>
 
 ### Creating a Keyspace
-We can create a new a keyspace via the Grakn Clients [Java](../03-client-api/01-java.md#create-a-session-keyspace), [Node.js](../03-client-api/03-nodejs.md#create-a-session-keyspace) and [Python](../03-client-api/02-python.md#create-a-session-keyspace) and [Grakn Console](../02-running-grakn/02-console.md#console-options).
+We can create a new a keyspace via the Grakn Clients [Java](../03-client-api/01-java.md#create-a-sessionkeyspace), [Node.js](../03-client-api/03-nodejs.md#create-a-sessionkeyspace) and [Python](../03-client-api/02-python.md#create-a-sessionkeyspace) and [Grakn Console](../02-running-grakn/02-console.md#console-options).
 
 ### Listing All Keyspaces
 We can list all keyspaces of the running Grakn server via the Grakn Clients [Node.js](../03-client-api/03-nodejs.md#retrieve-all-keyspaces) and [Python](../03-client-api/02-python.md#retrieve-all-keyspaces), as well as [Workbase](../07-workbase/01-connection.md#select-a-keyspace).

--- a/test/links/links_test.py
+++ b/test/links/links_test.py
@@ -12,6 +12,11 @@ pattern_to_find_template_calls = '\{%\sinclude\s.*?\s%\}'
 
 pages = {}
 
+def anchorize_heading(heading):
+    anchor = heading.replace(r"^[^a-zA-Z]+", "").replace(r" ", "-").lower()
+    anchor = re.sub("[^a-zA-Z0-9 -]+", "", anchor)
+    return anchor
+
 # populate the `pages` dictionary with anchors and links of each
 for markdown_path in glob.iglob('./**/*.md'):
     title = markdown_path.replace("./", "")
@@ -27,9 +32,7 @@ for markdown_path in glob.iglob('./**/*.md'):
 
         anchor_matches = re.findall(pattern_to_find_anchors, content)
         for match in anchor_matches:
-            anchor = match.replace(r"^[^a-zA-Z]+", "").replace(r" ", "-").lower()
-            anchor = re.sub("[^a-zA-Z0-9 -]+", "", anchor)
-            pages[title]["anchors"].append(anchor)
+            pages[title]["anchors"].append(anchorize_heading(match))
 
         template_call_matches = re.findall(pattern_to_find_template_calls, content)
         for template_call in template_call_matches:
@@ -49,8 +52,7 @@ for markdown_path in glob.iglob('./**/*.md'):
                     yaml_content = yaml.load(open(yaml_file_path), Loader=yaml.CLoader)
                     # looks for the value of all keys named `title`, convert them to an id and add them as anchors
                     for found_title in nested_lookup("title", yaml_content):
-                        anchor = found_title.replace(r" ", "-").replace(r"/", "-").lower()
-                        pages[title]["anchors"].append(anchor)
+                        pages[title]["anchors"].append(anchorize_heading(found_title))
 
 
 class LinksTest(unittest.TestCase):

--- a/views/autolink-keywords.js
+++ b/views/autolink-keywords.js
@@ -212,7 +212,7 @@ codeKeywordsToLink = {
         {
             "titles": ["session"],
             "syntaxedAs": ["function"],
-            "anchor": "#create-a-session-keyspace",
+            "anchor": "#create-a-sessionkeyspace",
             "languages": ["java", "javascript", "python"]
         },
         {


### PR DESCRIPTION
## What is the goal of this PR?
The links included in Client and Concept API reference pages are now healthy and functional.

## What are the changes implemented in this PR?
As a temporary and quick solution, the links contained within the reference `.yml` files are altered to support the web platform. The change breaks the links when viewed on Github, which will be resolved once a long-term resolution is accomplished for this problem. Issued [here](https://github.com/graknlabs/docs/issues/165).
