### PR TITLE
Updates phone_calls tutorials (Examples)

### DIFF
--- a/08-examples/01-phone-calls-schema.md
+++ b/08-examples/01-phone-calls-schema.md
@@ -65,7 +65,7 @@ Any **relation** relates to at least one **role** that is played by at least 2 *
 In our case, a **call** relates to **caller** played by a **person** and to **callee** played by another **person**.
 
 Likewise for a **contract**. It relates to **provider** played by a **company** and to **customer** played by a **person**.
-<!-- test-ignore -->
+
 ```graql
 define
 
@@ -87,7 +87,7 @@ define
 ```
 
 To define the attributes, we use the has keyword.
-<!-- test-ignore -->
+
 ```graql
 define
 
@@ -118,7 +118,7 @@ define
 ```
 
 Lastly, we need to define the type of each attribute.
-<!-- test-ignore -->
+
 ```graql
 define
 

--- a/08-examples/02-phone-calls-migration-java.md
+++ b/08-examples/02-phone-calls-migration-java.md
@@ -95,11 +95,11 @@ Next, add a new file called `logback.xml` with the content below and place it un
 
 Pick one of the data formats below and download the files. After you download them, place the four files under the `phone_calls/data` directory. We use these to load their data into our `phone_calls` knowledge graph.
 
-**CSV** | [companies](https://raw.githubusercontent.com/graknlabs/examples/master/nodejs/migration/csv/data/companies.csv) | [people](https://raw.githubusercontent.com/graknlabs/examples/master/nodejs/migration/csv/data/people.csv) | [contracts](https://raw.githubusercontent.com/graknlabs/examples/master/nodejs/migration/csv/data/contracts.csv) | [calls](https://raw.githubusercontent.com/graknlabs/examples/master/nodejs/migration/csv/data/calls.csv)
+**CSV** | [companies](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/companies.csv) | [people](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/people.csv) | [contracts](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/contracts.csv) | [calls](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/calls.csv)
 
-**JSON** | [companies](https://raw.githubusercontent.com/graknlabs/examples/master/nodejs/migration/json/data/companies.json) | [people](https://raw.githubusercontent.com/graknlabs/examples/master/nodejs/migration/json/data/people.json) | [contracts](https://raw.githubusercontent.com/graknlabs/examples/master/nodejs/migration/json/data/contracts.json) | [calls](https://raw.githubusercontent.com/graknlabs/examples/master/nodejs/migration/json/data/calls.json)
+**JSON** | [companies](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/companies.json) | [people](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/people.json) | [contracts](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/contracts.json) | [calls](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/calls.json)
 
-**XML** | [companies](https://raw.githubusercontent.com/graknlabs/examples/master/nodejs/migration/xml/data/companies.xml) | [people](https://raw.githubusercontent.com/graknlabs/examples/master/nodejs/migration/xml/data/people.xml) | [contracts](https://raw.githubusercontent.com/graknlabs/examples/master/nodejs/migration/xml/data/contracts.xml) | [calls](https://raw.githubusercontent.com/graknlabs/examples/master/nodejs/migration/xml/data/calls.xml)
+**XML** | [companies](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/companies.xml) | [people](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/people.xml) | [contracts](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/contracts.xml) | [calls](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/calls.xml)
 
 ## Specify Details For Each Data File
 
@@ -171,7 +171,7 @@ public class PhoneCallsMigration {
 ```java
 // imports
 
-public class Migration {
+public class PhoneCallsMigration {
   abstract static class Input {...}
   public static void main(String[] args) {...}
 
@@ -200,7 +200,7 @@ Given the company,
 ```
 
 `input.template(company)` returns
-<!-- test-ignore -->
+
 ```graql
 insert $company isa company, has name "Telecom";
 ```
@@ -260,9 +260,9 @@ Given the person,
 ```
 
 `input.template(person)` returns
-<!-- test-ignore -->
+
 ```graql
-insert $person has phone-number "+44 091 xxx";
+insert $person isa person, has phone-number "+44 091 xxx";
 ```
 
 And given the person,
@@ -273,9 +273,9 @@ And given the person,
 ```
 
 `input.template(person)` returns
-<!-- test-ignore -->
+
 ```graql
-insert $person has phone-number "+44 091 xxx", has first-name "Jackie", has last-name "Joe", has city "Jimo", has age 77;
+insert $person isa person, has phone-number "+44 091 xxx", has first-name "Jackie", has last-name "Joe", has city "Jimo", has age 77;
 ```
 
 ## Input Instance For a Contract
@@ -321,7 +321,7 @@ Given the contract,
 ```
 
 `input.template(contract)` returns
-<!-- test-ignore -->
+
 ```graql
 match $company isa company, has name "Telecom"; $customer isa person, has phone-number "+00 091 xxx"; insert (provider: $company, customer: $customer) isa contract;
 ```
@@ -371,7 +371,7 @@ Given the call,
 ```
 
 `input.template(call)` returns
-<!-- test-ignore -->
+
 ```graql
 match $caller isa person, has phone-number "+44 091 xxx"; $callee isa person, has phone-number "+00 091 xxx"; insert $call(caller: $caller, callee: $callee) isa call; $call has started-at 2018-08-10T07:57:51; $call has duration 148;
 ```
@@ -387,7 +387,7 @@ import grakn.client.GraknClient;
 import static graql.lang.Graql.*;
 import graql.lang.query.GraqlInsert;
 
-public class Migration {
+public class PhoneCallsMigration {
 	abstract static class Input {...}
 
   	public static void main(String[] args) {
@@ -757,7 +757,7 @@ Here is how our `Migrate.java` looks like for each data format.
 [tab:CSV]
 <!-- test-example PhoneCallsCSVMigration.java -->
 ```java
-package grakn.example.phoneCalls;
+package io.grakn.example.phoneCalls;
 
 import grakn.client.GraknClient;
 import static graql.lang.Graql.*;
@@ -955,7 +955,7 @@ public class PhoneCallsCSVMigration {
 [tab:JSON]
 <!-- test-example PhoneCallsJSONMigration.java -->
 ```java
-package grakn.example.phoneCalls;
+package io.grakn.example.phoneCalls;
 
 import grakn.client.GraknClient;
 import static graql.lang.Graql.*;
@@ -1159,7 +1159,7 @@ public class PhoneCallsJSONMigration {
 [tab:XML]
 <!-- test-example PhoneCallsXMLMigration.java -->
 ```java
-package grakn.example.phoneCalls;
+package io.grakn.example.phoneCalls;
 
 import grakn.client.GraknClient;
 import graql.lang.query.GraqlInsert;

--- a/08-examples/03-phone-calls-migration-nodejs.md
+++ b/08-examples/03-phone-calls-migration-nodejs.md
@@ -29,8 +29,8 @@ Before moving on, make sure you have **npm** installed and the [**Grakn Server**
 ## Get Started
 
 1.  Create a directory named `phone_calls` on your desktop.
-2.  cd to the `phone_calls` directory via terminal.
-3.  Run `npm install grakn` to install the Grakn [Client Node.js](../03-client-api/03-nodejs.md).
+2.  `cd` to the `phone_calls` directory via terminal.
+3.  Run `npm install grakn-client` to install the Grakn [Client Node.js](../03-client-api/03-nodejs.md).
 4.  Open the `phone_calls` directory in your favourite text editor.
 5.  Create a `migrate.js` file in the root directory. This is where we’re going to write all our code.
 
@@ -38,7 +38,7 @@ Before moving on, make sure you have **npm** installed and the [**Grakn Server**
 
 Pick one of the data formats below and download the files. After you download them, place the four files under the `files/phone-calls/data` directory. We use these to load their data into our `phone_calls` knowledge graph.
 
-**CSV** | [companies](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/companies.csv) | [people](https://raw.githubusercontent.com/graknlabs/examples/master/nodejs/migration/csv/data/people.csv) | [contracts](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/contracts.csv) | [calls](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/calls.csv)
+**CSV** | [companies](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/companies.csv) | [people](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/people.csv) | [contracts](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/contracts.csv) | [calls](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/calls.csv)
 
 **JSON** | [companies](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/companies.json) | [people](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/people.json) | [contracts](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/contracts.json) | [calls](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/calls.json)
 
@@ -91,7 +91,8 @@ async function buildPhoneCallGraph(inputs) {
     for (input of inputs) {
         await loadDataIntoGrakn(input, session);
     }
-    session.close();
+    await session.close();
+    client.close();
 }
 ```
 
@@ -149,12 +150,14 @@ function companyTemplate(company) {
 Example:
 
 - Goes in:
+
 ```javascript
 { name: "Telecom" }
 ```
 
 - Comes out:
-```javascript
+
+```graql
 insert $company isa company, has name "Telecom";
 ```
 
@@ -193,8 +196,9 @@ Example:
 ```
 
 - Comes out:
-```javascript
-insert $person has phone-number "+44 091 xxx";
+
+```graql
+insert $person isa person, has phone-number "+44 091 xxx";
 ```
 
 or:
@@ -205,8 +209,9 @@ or:
 ```
 
 - Comes out:
-```javascript
-insert $person has phone-number "+44 091 xxx", has first-name "Jackie", has last-name "Joe", has city "Jimo", has age 77;
+
+```graql
+insert $person isa person, has phone-number "+44 091 xxx", has first-name "Jackie", has last-name "Joe", has city "Jimo", has age 77;
 ```
 
 ### contractTemplate
@@ -233,7 +238,8 @@ Example:
 ```
 
 - Comes out:
-```javascript
+
+```graql
 match $company isa company, has name "Telecom"; $customer isa person, has phone-number "+00 091 xxx"; insert (provider: $company, customer: $customer) isa contract;
 ```
 
@@ -263,7 +269,8 @@ Example:
 ```
 
 - Comes out:
-```javascript
+
+```graql
 match $caller isa person, has phone-number "+44 091 xxx"; $callee isa person, has phone-number "+00 091 xxx"; insert $call(caller: $caller, callee: $callee) isa call; $call has started-at 2018-08-10T07:57:51; $call has duration 148;
 ```
 

--- a/08-examples/04-phone-calls-migration-python.md
+++ b/08-examples/04-phone-calls-migration-python.md
@@ -30,7 +30,7 @@ Before moving on, make sure you have **Python3** and **Pip3** installed and the 
 
 1.  Create a directory named `phone_calls` on your desktop.
 2.  cd to the phone_calls directory via terminal.
-3.  Run `pip3 install grakn` to install the Grakn [Client Python](../03-client-api/02-python.md).
+3.  Run `pip3 install grakn-client` to install the Grakn [Client Python](../03-client-api/02-python.md).
 4.  Open the `phone_calls` directory in your favourite text editor.
 5.  Create a `migrate.py` file in the root directory. This is where we’re going to write all our code.
 
@@ -38,7 +38,7 @@ Before moving on, make sure you have **Python3** and **Pip3** installed and the 
 
 Pick one of the data formats below and download the files. After you download them, place the four files under the `files/phone-calls/data` directory. We need these to load their data into our `phone_calls` knowledge graph.
 
-**CSV** | [companies](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/companies.csv) | [people](https://raw.githubusercontent.com/graknlabs/examples/master/nodejs/migration/csv/data/people.csv) | [contracts](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/contracts.csv) | [calls](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/calls.csv)
+**CSV** | [companies](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/companies.csv) | [people](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/people.csv) | [contracts](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/contracts.csv) | [calls](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/calls.csv)
 
 **JSON** | [companies](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/companies.json) | [people](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/people.json) | [contracts](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/contracts.json) | [calls](https://raw.githubusercontent.com/graknlabs/examples/master/datasets/phone-calls/calls.json)
 
@@ -155,7 +155,8 @@ Example:
 ```
 
 - Comes out:
-```python
+
+```graql
 insert $company isa company, has name "Telecom";
 ```
 
@@ -187,8 +188,9 @@ Example:
 ```
 
 - Comes out:
-```python
-insert $person isa person has phone-number "+44 091 xxx";
+
+```graql
+insert $person isa person, has phone-number "+44 091 xxx";
 ```
 
 or:
@@ -199,8 +201,9 @@ or:
 ```
 
 - Comes out:
-```python
-insert $person has phone-number "+44 091 xxx", has first-name "Jackie", has last-name "Joe", has city "Jimo", has age 77;
+
+```graql
+insert $person isa person, has phone-number "+44 091 xxx", has first-name "Jackie", has last-name "Joe", has city "Jimo", has age 77;
 ```
 
 ### contractTemplate
@@ -231,7 +234,8 @@ Example:
 ```
 
 - Comes out:
-```python
+
+```graql
 match $company isa company, has name "Telecom"; $customer isa person, has phone-number "+00 091 xxx"; insert (provider: $company, customer: $customer) isa contract;
 ```
 
@@ -256,7 +260,8 @@ Example:
 ```
 
 - Comes out:
-```python
+
+```graql
 match $caller isa person, has phone-number "+44 091 xxx"; $callee isa person, has phone-number "+00 091 xxx"; insert $call(caller: $caller, callee: $callee) isa call; $call has started-at 2018-08-10T07:57:51; $call has duration 148;
 ```
 

--- a/08-examples/05-phone-calls-queries.md
+++ b/08-examples/05-phone-calls-queries.md
@@ -24,7 +24,7 @@ For the rest of this post, we go through each of these questions to:
 - write them in [Graql](http://dev.grakn.ai/academy/graql-intro.html), and
 - assess their result.
 
-Make sure you have the [Visualisation Dashboard](http://dev.grakn.ai/docs/visualisation-dashboard/visualiser) (at [localhost:4567](http://localhost:4567/)) opened in your browser, while phone_calls selected as the keyspace (in the top-right hand corner).
+Make sure you have [Grakn Workbase](../07-workbase/00-overview.md) installed, [connected](../07-workbase/01-connection.md#configure-connection) to the running [Grakn Server](../02-running-grakn/01-install-and-run.md#start-the-grakn-server) and `phone_calls` is the [selected keyspace](../07-workbase/01-connection.md#select-a-keyspace).
 
 Let’s begin.
 
@@ -68,9 +68,10 @@ get $phone-number;
 
 <div class="tabs dark">
 [tab:Java]
+
 <!-- test-example PhoneCallsFirstQuery.java -->
 ```java
-package grakn.example.phoneCalls;
+package io.grakn.example.phoneCalls;
 
 import grakn.client.GraknClient;
 import grakn.core.concept.answer.ConceptMap;
@@ -239,9 +240,10 @@ get $phone-number;
 
 <div class="tabs dark">
 [tab:Java]
+
 <!-- test-example PhoneCallsSecondQuery.java -->
 ```java
-package grakn.example.phoneCalls;
+package io.grakn.example.phoneCalls;
 
 import grakn.client.GraknClient;
 import grakn.core.concept.answer.ConceptMap;
@@ -358,14 +360,14 @@ with GraknClient(uri="localhost:48555") as client:
           '  $target-call-date > $pattern-call-date;',
           'get $phone-number;'
         ]
-    
+
         print("\nQuery:\n", "\n".join(query))
         query = "".join(query)
-    
+
         iterator = transaction.query(query)
         answers = iterator.collect_concepts()
         result = [ answer.value() for answer in answers ]
-    
+
         print("\nResult:\n", result)
 ```
 [tab:end]
@@ -410,9 +412,10 @@ get $phone-number;
 
 <div class="tabs dark">
 [tab:Java]
+
 <!-- test-example PhoneCallsThirdQuery.java -->
 ```java
-package grakn.example.phoneCalls;
+package io.grakn.example.phoneCalls;
 
 import grakn.client.GraknClient;
 import grakn.core.concept.answer.ConceptMap;
@@ -579,9 +582,10 @@ get $phone-number-a, $phone-number-b;
 
 <div class="tabs dark">
 [tab:Java]
+
 <!-- test-example PhoneCallsForthQuery.java -->
 ```java
-package grakn.example.phoneCalls;
+package io.grakn.example.phoneCalls;
 
 import grakn.client.GraknClient;
 import grakn.core.concept.answer.ConceptMap;
@@ -774,9 +778,10 @@ get $duration; mean $duration;
 
 <div class="tabs dark">
 [tab:Java]
+
 <!-- test-example PhoneCallsFifthQuery.java -->
 ```java
-package grakn.example.phoneCalls;
+package io.grakn.example.phoneCalls;
 
 import grakn.client.GraknClient;
 import grakn.core.concept.answer.Numeric;


### PR DESCRIPTION
## What is the goal of this PR?
The `phone_calls` tutorial found in the _Examples_ section now 1) is tested with more coverage, 2) is more consistent with their counterpart in `graknlabs/examples`, and 3) is up-to-date with the latest state of Grakn.

## What are the changes implemented in this PR?
- removes the `test-ignore` flag from code blocks that are actually testable.
- corrects the language name for proper syntax highlighting
- references the correct links to the `phone_calls` dataset (hosted in `graknlabs/examples`)
- replaces references to Dashboard with those to Workbase
- renames the package name to be consistent with the standard (i.e. `io.grakn.example.phoneCalls`)
- provides the correct commands (module name) for installing clients Nodejs and Python.