### PR TITLE
include concept and graql dependency declarations in client java

### DIFF
--- a/03-client-api/01-java.md
+++ b/03-client-api/01-java.md
@@ -34,6 +34,16 @@ templatePath: 03-client-api/references/
         <artifactId>api</artifactId>
         <version>1.5.2</version>
     </dependency>
+    <dependency>
+        <groupId>io.grakn.core</groupId>
+        <artifactId>concept</artifactId>
+        <version>1.5.2</version>
+    </dependency>
+    <dependency>
+        <groupId>io.graql</groupId>
+        <artifactId>lang</artifactId>
+        <version>1.0.1</version>
+    </dependency>
 </dependencies>
 ```
 [tab:end]


### PR DESCRIPTION
## What is the goal of this PR?
Although, declaring `io.grakn.client` dependency in the `pom.xml` brings in `io.grakn.core` and `io.graql` transitively, it's good practice to declare them explicitly. The _Dependencies_ section of _Client Java_ now includes the declaration of all these 3 dependencies.

## What are the changes implemented in this PR?
- adds the `concept` and `graql` dependency tags under Client Java > Dependencies 