### PR TITLE
fix link in doc to workbase introduction

### DIFF
--- a/02-running-grakn/02-console.md
+++ b/02-running-grakn/02-console.md
@@ -7,7 +7,7 @@ toc: false
 ---
 
 ## What is the Grakn Console?
-The Grakn Console, along with the [Grakn Clients](../03-client-api/00-overview.md) and [Workbase](...), is an interface which we can use to read from and write to a Grakn knowledge graph. Console interacts directly with a given keyspace that contains the Grakn knowledge graph.
+The Grakn Console, along with the [Grakn Clients](../03-client-api/00-overview.md) and [Workbase](../07-workbase/00-overview.md), is an interface which we can use to read from and write to a Grakn knowledge graph. Console interacts directly with a given keyspace that contains the Grakn knowledge graph.
 
 ## Console Options
 


### PR DESCRIPTION
## What is the goal of this PR?

Correct a link in the documentation

## What are the changes implemented in this PR?

A markdown link has been modified to point to the correct location (workbase introduction). The previous link was broken
