### PR TITLE
Fixed erroneous template reference in python migration call documentation 

### DIFF
--- a/08-examples/04-phone-calls-migration-python.md
+++ b/08-examples/04-phone-calls-migration-python.md
@@ -195,7 +195,7 @@ or:
 
 - Goes in:
 ```python
-{ "firs_name": "Jackie", "last_name": "Joe", "city": "Jimo", "age": 77, "phone_number": "+00 091 xxx"}
+{ "first_name": "Jackie", "last_name": "Joe", "city": "Jimo", "age": 77, "phone_number": "+00 091 xxx"}
 ```
 
 - Comes out:
@@ -206,20 +206,13 @@ insert $person has phone-number "+44 091 xxx", has first-name "Jackie", has last
 ### contractTemplate
 
 ```python
-def person_template(person):
-    # insert person
-    graql_insert_query = 'insert $person isa person, has phone-number "' + person["phone_number"] + '"'
-    if "first_name" in person:
-        # person is a customer
-        graql_insert_query += ", has is-customer true"
-        graql_insert_query += ', has first-name "' + person["first_name"] + '"'
-        graql_insert_query += ', has last-name "' + person["last_name"] + '"'
-        graql_insert_query += ', has city "' + person["city"] + '"'
-        graql_insert_query += ", has age " + str(person["age"])
-    else:
-        # person is not a customer
-        graql_insert_query += ", has is-customer false"
-    graql_insert_query += ";"
+def contract_template(contract):
+    # match company
+    graql_insert_query = 'match $company isa company, has name "' + contract["company_name"] + '";'
+    # match person
+    graql_insert_query += ' $customer isa person, has phone-number "' + contract["person_id"] + '";'
+    # insert contract
+    graql_insert_query += " insert (provider: $company, customer: $customer) isa contract;"
     return graql_insert_query
 ```
 


### PR DESCRIPTION
## What is the goal of this PR?

Fixes the misplacement of `person_template` under `contract_template` heading, in the tutorial for migrating with Python.

## What are the changes implemented in this PR?

`contractTemplate` code section contained `personTemplate` definition; updated to correct code from long-form section. Fixed typo in json input in `personTemplate` section.
