### PR TITLE
Fix CI by synchronizing .bazelrc with @graknlabs_build_tools

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,12 +7,12 @@ build:rbe --bes_results_url="https://source.cloud.google.com/results/invocations
 build:rbe --host_platform=@graknlabs_build_tools//:rbe-ubuntu1604-network-standard
 build:rbe --platforms=@graknlabs_build_tools//:rbe-ubuntu1604-network-standard
 build:rbe --extra_execution_platforms=@graknlabs_build_tools//:rbe-ubuntu1604-network-standard
-build:rbe --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:jdk8
-build:rbe --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:jdk8
+build:rbe --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/9.0.0/bazel_0.25.2/java:jdk
+build:rbe --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/9.0.0/bazel_0.25.2/java:jdk
 build:rbe --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 build:rbe --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:rbe --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.20.0/cpp:cc-toolchain-clang-x86_64-default
-build:rbe --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.20.0/default:toolchain
+build:rbe --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/9.0.0/bazel_0.25.2/config:cc-toolchain
+build:rbe --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/9.0.0/bazel_0.25.2/cc:toolchain
 build:rbe --jobs=50
 build:rbe --remote_timeout=3600
 build:rbe --bes_timeout=60s
@@ -25,11 +25,3 @@ build:rbe --genrule_strategy=remote
 build:rbe --define=EXECUTOR=remote
 build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:rbe --experimental_strict_action_env=true
-
-# The following configuration forces Bazel to execute rules which depends on pkg_rpm() locally instead of in RBE.
-# The distribution_rpm() macro uses pkg_rpm() which uses the 'rpmbuild' binary under the hood.
-# It won't be available in some distributions and therefore can't be ran in RBE.
-# When executed, the pkg_rpm() rule will produce the "MakeRpm" Bazel actions
-# (you can look at what actions are produced when a target is executed by adding -s: bazel build -s //target:name).
-# Here we configure Bazel to execute "MakeRpm" actions locally:
-build:rbe --strategy_regexp=MakeRpm=local

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GRAKN.AI Documentation
 
+[![CircleCI](https://circleci.com/gh/graknlabs/docs/tree/master.svg?style=shield)](https://circleci.com/gh/graknlabs/docs)
+
 This repository contains all content that powers the Grakn Documentation Portal, accessible at [dev.grakn.ai](http://dev.grakn.ai).
 
 ---

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "a8c117758461368bff9841f9659bff11afbf02a1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "b5014777d50d35ef39ebf1aafe53d3d4254d2b63", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():


### PR DESCRIPTION
## What is the goal of this PR?

Recent upgrade of `bazel` version in `@graknlabs_build_tools` broke CI for `client-nodejs`. This PR aims to fix it by synchronizing `.bazelrc` with latest version in `build-tools`. Additionally, CI status is now visible on README page so it draws attention if it is not successful.

## What are the changes implemented in this PR?

* Update `@graknlabs_build_tools` to the latest version
* Copy `.bazelrc` over from `@graknlabs_build_tools`
* Add CircleCI badge