### PR TITLE
Exclude bazel generated files from test runfiles

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -15,6 +15,7 @@ filegroup(
             "bazel-bin/**/*.md",
             "bazel-out/**/*.md",
             "bazel-docs/**/*.md",
+            "bazel-genfiles/**/*.md",
             ".runfiles/**/*.md"
         ]
     ),


### PR DESCRIPTION
## What is the goal of this PR?

Test `//test/example/nodejs:social-network` failed because it picked up files from `bazel-genfiles`, which, e.g., included `README`s from NodeJS packages. This PR prevents test from failing by excluding irrelevant files.

## What are the changes implemented in this PR?

- Added `bazel-genfiles` to `exclude` of `glob` that captures files for parsing tests from.