### PR TITLE
improves implementation of links_test.py + corrects links

### DIFF
--- a/02-running-grakn/02-console.md
+++ b/02-running-grakn/02-console.md
@@ -7,7 +7,7 @@ toc: false
 ---
 
 ## What is the Grakn Console?
-The Grakn Console, along with the [Grakn Clients](../03-client-api/00-overview.md) and [Workbase](...), is an interface which we can use to read from and write to a Grakn knowledge graph. Console interacts directly with a given keyspace that contains the Grakn knowledge graph.
+The Grakn Console, along with the [Grakn Clients](../03-client-api/00-overview.md) and [Workbase](../07-workbase/00-overview.md), is an interface which we can use to read from and write to a Grakn knowledge graph. Console interacts directly with a given keyspace that contains the Grakn knowledge graph.
 
 ## Console Options
 
@@ -21,36 +21,6 @@ The options accepted by the `grakn console` command are as follows.
 | `--no-infer`         | `-n`  | interactive     | - -keyspace | Enters the console connected to the given keyspace with inference disabled.             |
 | `--version`          | `-v`  | non-interactive | -           | Prints version of the running Grakn.                                                    |
 
-<!-- ### Selecting/creating a keyspace
-To enter an existing or new keyspace, we use the `--keyspace` (or `-k`) option followed by the name of the keyspace. The name may only contain alphanumeric values and underscores.
-
-```
-./grakn console --keyspace keyspace_name
-```
-
-### Loading a schema into a keyspace
-To load a [schema](../09-schema/00-overview.md) into a keyspace, we use the `--file` (or `-f`) option followed by the path to the schema (`.gql`) file. In addition, we need to [select the keyspace](#selecting/creating-a-keyspace) into which the schema should be loaded. Note that if the keyspace has not yet been created, this command also creates a new keyspace with the given name.
-
-```
-./grakn console -k keyspace_name --file path/to/schema.gql
-```
-
-### Entering a remote keyspace
-If the keyspace of interest is hosted remotely, we use the `--uri` (or `r`) option followed by the target URI. In addition, we need to [select the keyspace](#selecting/creating-a-keyspace) that we would like to enter.
-
-```
-./grakn console -k keyspace_name --uri the-uri-hosting-the-keyspace
-```
-
-### Disabling inference
-If we intend to ignore [inferred instances of data](...) when querying the knowledge graph, we use the `-no-infer` (or `-n`).
-
-```
-./grakn console -k keyspace_name --no-infer
-```
-
-### Viewing the Grakn's version
-To find out which version of Grakn is installed, we use the `--version` (or `-v`) option. -->
 
 ## Console Commands
 
@@ -64,21 +34,3 @@ Once inside the console, besides [Graql queries](../11-query/00-overview.md), we
 | `clear`    | Clears the console from any previous queries, answers and commands.                                                                                                                   |
 | `clean`    | Meant to be used with caution, removes not only the data but also the schema of the knowledge graph contained within the keyspace.                                                    |
 | `exit`     | Exists the console.                                                                                                                                                                   |
-
-<!-- ### Committing changes
-Any write operations executed via the console affects only a _local_ copy of the keyspace that contains the altered knowledge graph. In order for these changes to be reflected on the original keyspace running on the Grakn Server, we use the `commit` command.
-
-### Rolling back changes
-As the name suggests, we use the `rollback` command to undo any uncommitted changes. This rolls the state of the knowledge graph back to how it was right after the last `commit` was made.
-
-### Running multiline queries
-The Grakn Console, at the moment, does not support multiline entries. However, we can use the `edit` command to open the text editor specified by the $EDITOR environment variable (vim by default). This will then allows us to write one or more queries in multiple lines and have them run as soon as we exit the text editor.
-
-### Clearing the console
-In order to clear the console from any previous queries, answers and commands, we use the `clear` command.
-
-### Deleting the entire knowledge graph
-Meant to be used with caution, the `clean` command removes not only the data but also the schema of the knowledge graph contained within the entered keyspace. This is an irreversible act that results in an empty keyspace.
-
-### Exiting the console
-To exit the console, we use the `exit` command. -->

--- a/03-client-api/00-overview.md
+++ b/03-client-api/00-overview.md
@@ -41,7 +41,7 @@ Grakn currently supports clients for:
 - [Python](../03-client-api/02-python.md)
 
 ## Building Your Own Grakn Client
-Creating a new Grakn client is discussed [here](04-new-client.md).
+Creating a new Grakn client is discussed [here](../03-client-api/04-new-client.md).
 
 ## Summary
 A Grakn Client is meant to be used at the application layer for the purpose of managing and performing operations over keyspaces that live on the Grakn server.

--- a/03-client-api/04-new-client.md
+++ b/03-client-api/04-new-client.md
@@ -27,7 +27,7 @@ In this case, please get in touch!
  
 ## Architecture
 
-As touched on in the [Overview page](00-overview.md), Grakn clients have the following central components the user interacts with
+As touched on in the [Overview page](../03-client-api/00-overview.md), Grakn clients have the following central components the user interacts with
 
 * `GraknClient`
 * `Session`

--- a/07-workbase/02-visualisation.md
+++ b/07-workbase/02-visualisation.md
@@ -166,7 +166,7 @@ To navigate between Graql queries that we have previously executed, while in the
 <!-- -->
 [slide:start]
 [body:start]![Graql editor](/docs/images/workbase/visualise_query-settings-neighbour-limit.png)[body:end]
-[footer:start]For the same reason, we may want to limit the number of neighbours to view when [investigating nodes](...). For this, we specify the **Neighbour Limit**.[footer:end]
+[footer:start]For the same reason, we may want to limit the number of neighbours to view when [investigating nodes](../07-workbase/03-investigation.md). For this, we specify the **Neighbour Limit**.[footer:end]
 [slide:end]
 <!-- -->
 [slide:start]

--- a/08-examples/03-phone-calls-migration-nodejs.md
+++ b/08-examples/03-phone-calls-migration-nodejs.md
@@ -274,7 +274,7 @@ Example:
 match $caller isa person, has phone-number "+44 091 xxx"; $callee isa person, has phone-number "+00 091 xxx"; insert $call(caller: $caller, callee: $callee) isa call; $call has started-at 2018-08-10T07:57:51; $call has duration 148;
 ```
 
-We’ve now created a template for each and all four concepts that were [previously](./defining-the-schema) defined in the schema.
+We’ve now created a template for each and all four concepts that were [previously](../defining-the-schema) defined in the schema.
 
 It’s time for the implementation of `parseDataToObjects(input)`.
 

--- a/08-examples/04-phone-calls-migration-python.md
+++ b/08-examples/04-phone-calls-migration-python.md
@@ -265,7 +265,7 @@ Example:
 match $caller isa person, has phone-number "+44 091 xxx"; $callee isa person, has phone-number "+00 091 xxx"; insert $call(caller: $caller, callee: $callee) isa call; $call has started-at 2018-08-10T07:57:51; $call has duration 148;
 ```
 
-We’ve now created a template for each and all four concepts that were [previously](./defining-the-schema) defined in the schema.
+We’ve now created a template for each and all four concepts that were [previously](../defining-the-schema) defined in the schema.
 
 It’s time for the implementation of `parse_data_to_dictionaries(input)`.
 

--- a/08-examples/05-phone-calls-queries.md
+++ b/08-examples/05-phone-calls-queries.md
@@ -7,7 +7,7 @@ Summary: Learn how to obtain insights by writing expressive Graql queries.
 
 ## Goal
 
-When we [modelled and loaded the schema into Grakn](./defining-the-schema), we had some insights in mind that we wanted to obtain from `phone_calls`; the knowledge graph.
+When we [modelled and loaded the schema into Grakn](../defining-the-schema), we had some insights in mind that we wanted to obtain from `phone_calls`; the knowledge graph.
 
 Let’s revise:
 

--- a/09-schema/03-rules.md
+++ b/09-schema/03-rules.md
@@ -94,8 +94,6 @@ GraqlDefine query = Graql.define(
 
 Please note that facts defined via rules are in general not stored in the knowledge graph. In this example, siblings data is not explicitly stored anywhere in the knowledge graph. However by defining the rule in the schema, at query time the extra fact will be generated so that we can always know who the siblings are.
 
-<!-- This is a basic example of how Graql rules can be useful. In a dedicated section, we learn about rules by looking at more examples of [rule-based automated reasoning](...). -->
-
 ## Retrieve a Rule
 
 If you find the Graql code above unfamiliar, don't be concerned. We soon learn about [using Graql to describe patterns](../11-query/01-match-clause.md).

--- a/11-query/07-compute-query.md
+++ b/11-query/07-compute-query.md
@@ -15,8 +15,6 @@ In this section, we learn how to use the `compute` queries in a Grakn knowledge 
 
 To try the following examples with one of the Grakn clients, follows these [Clients Guide](#clients-guide).
 
-<!-- In a dedicated section, we learn more about the significance and use cases of [Distributed Analaytics]() in a Grakn knowledge graph. -->
-
 ## Compute Statistics
 Computing simple statistics, such as the mean and standard deviations of small datasets, is an easy task given isolated instances. But what about when the knowledge graph becomes so large that it has to be distributed across many machines? What if the values to be calculated correspond to many different types?
 


### PR DESCRIPTION
## What is the goal of this PR?
The coverage of testing links within docs is expanded to spot markdown links with an invalid format.
This means, a link found in a `.md` file that has a format other than what follows, fails the test.
- `[link](../path)`
- `[link](#anchor)`
- `[link](http://path)`
- `[link](https://path)`

## What are the changes implemented in this PR?
The regex to spot invalid link formats is checked on every `.md` file. If any invalid link is found, the test fails and the error messages are printed out to help the contributor find the invalid links.

To expand the coverage of this test further, we should also verify that the path of an internal link, always contains `.md`. 
