### PR TITLE
DNF instructions for newer RPM distros

### DIFF
--- a/02-running-grakn/01-install-and-run.md
+++ b/02-running-grakn/01-install-and-run.md
@@ -12,6 +12,19 @@ Grakn runs on Mac, Linux and Windows. The only requirement is Java 8 which can b
 ## Download and Install Grakn
 <div class="tabs light">
 [tab:Linux]
+  
+#### Using RPM/DNF
+
+As a superuser, add the repo:
+```
+sudo dnf config-manager --add-repo https://repo.grakn.ai/repository/meta/rpm.repo
+```
+
+Install Grakn Server and Grakn Console:
+```
+sudo dnf install grakn-core-all
+```
+
 
 #### Using RPM/Yum
 


### PR DESCRIPTION
## What is the goal of this PR?

Enable users of newer RPM distros (eg Fedora 25+) to easily install

## What are the changes implemented in this PR?

Added DNF instructions for newer RPM distros
