### PR TITLE
Updated new Maven artifact IDs

### DIFF
--- a/03-client-api/references/graql.yml
+++ b/03-client-api/references/graql.yml
@@ -15,7 +15,7 @@ description:
     <dependencies>
         <dependency>
             <groupId>io.graql</groupId>
-            <artifactId>lang</artifactId>
+            <artifactId>graql-lang</artifactId>
             <version>1.0.1</version>
         </dependency>
     </dependencies>

--- a/08-examples/02-phone-calls-migration-java.md
+++ b/08-examples/02-phone-calls-migration-java.md
@@ -54,17 +54,17 @@ Modify `pom.xml` to include the latest version of Grakn Core, Graql and Grakn Cl
   	<dependencies>
     	<dependency>
             <groupId>io.grakn.core</groupId>
-            <artifactId>concept</artifactId>
+            <artifactId>grakn-concept</artifactId>
             <version>1.5.3</version>
         </dependency>
         <dependency>
             <groupId>io.graql</groupId>
-            <artifactId>lang</artifactId>
+            <artifactId>graql-lang</artifactId>
             <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>io.grakn.client</groupId>
-            <artifactId>api</artifactId>
+            <artifactId>grakn-client</artifactId>
             <version>1.5.3</version>
         </dependency>
   	</dependencies>


### PR DESCRIPTION
## What is the goal of this PR?

When deploying Maven JARs to Sonatype, the JARs are renamed to be `artifact-id-version.jar`, without the `group-id`. This is done in Sonatype because the JARs are organised into folders where the folder names represent the Group IDs. However, in certain build systems, e.g. Gradle, the JARs are collected under one directory, which means the JAR names are not unique enough to disambiguate itself from each other. We have now renamed the artifact ID of our Maven packages to be prefixed with `grakn-` to solve this problem.

## What are the changes implemented in this PR?

Prefixed artifact IDs of Maven packages with `grakn-` and `graql-`.