### PR TITLE
apt-transport-https is needed on debian

### DIFF
--- a/02-running-grakn/01-install-and-run.md
+++ b/02-running-grakn/01-install-and-run.md
@@ -47,7 +47,7 @@ sudo yum install grakn-core-all
 
 As a superuser, add the repo:
 ```
-sudo apt install software-properties-common
+sudo apt install software-properties-common apt-transport-https
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 8F3DA4B5E9AEF44C
 sudo add-apt-repository 'deb [ arch=all ] https://repo.grakn.ai/repository/apt/ trusty main'
 ```


### PR DESCRIPTION
# What is the goal of this PR?

Improve debian installation doc

## What are the changes implemented in this PR?

On fresh debian 9 :

```
root@opencti:~# lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 9.9 (stretch)
Release:	9.9
Codename:	stretch
root@opencti:~# echo "deb [ arch=all ] https://repo.grakn.ai/repository/apt/ trusty main" > /etc/apt/sources.list.d/grakn.list
root@opencti:~# apt update
Lecture des listes de paquets... Fait                          
E: Le pilote pour la méthode /usr/lib/apt/methods/https n'a pu être trouvé.
N: Is the package apt-transport-https installed?
E: Impossible de récupérer https://repo.grakn.ai/repository/apt/dists/trusty/InRelease  
E: Le téléchargement de quelques fichiers d'index a échoué, ils ont été ignorés, ou les anciens ont été utilisés à la place.
root@opencti:~# apt install apt-transport-https
root@opencti:~# apt update
```
no more errors 