### PR TITLE
Fix CI

### DIFF
--- a/test/example/java/BUILD
+++ b/test/example/java/BUILD
@@ -36,7 +36,7 @@ genrule(
         "java_tests.py",
         "//:content" # filegroup defined in root/BUILD
     ],
-    cmd = "python $(location java_tests.py) $(OUTS) $(locations //:content)",
+    cmd = "$(location java_tests.py) $(OUTS) $(locations //:content)",
     outs = [
         ## examples/migration-java
         "PhoneCallsCSVMigration.java",
@@ -85,7 +85,7 @@ genrule(
         "java_tests.py",
         "//:content" # filegroup defined in root/BUILD
     ],
-    cmd = "python $(location java_tests.py) $(OUTS) $(locations //:content)",
+    cmd = "$(location java_tests.py) $(OUTS) $(locations //:content)",
     outs = [
         # general/quickstart
         "SocialNetworkQuickstartQuery.java",

--- a/test/example/java/java_tests.py
+++ b/test/example/java/java_tests.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import re
 import sys
 

--- a/test/example/java/java_tests.py
+++ b/test/example/java/java_tests.py
@@ -17,7 +17,7 @@ pattern_to_find_standalones = ('<!-- test-example ' +
                                '```')
 standalones = []
 for markdown_file in markdown_files:
-    with open(markdown_file) as file:
+    with open(markdown_file, encoding='utf-8') as file:
         matches = re.findall(pattern_to_find_standalones, file.read())
         for standalone in matches:
             standalone_filename = standalone[0]

--- a/test/example/nodejs/BUILD
+++ b/test/example/nodejs/BUILD
@@ -28,7 +28,7 @@ genrule(
         "PhoneCalls.template.js",
         "//:content"
     ],
-    cmd = "python $(location nodejs_tests.py) $(location PhoneCalls.template.js) $(location PhoneCalls.test.js) $(locations //:content)",
+    cmd = "$(location nodejs_tests.py) $(location PhoneCalls.template.js) $(location PhoneCalls.test.js) $(locations //:content)",
     outs = ["PhoneCalls.test.js"]
 )
 
@@ -54,6 +54,6 @@ genrule(
         "SocialNetwork.template.js",
         "//:content"
     ],
-    cmd = "python $(location nodejs_tests.py) $(location SocialNetwork.template.js) $(location SocialNetwork.test.js) $(locations //:content)",
+    cmd = "$(location nodejs_tests.py) $(location SocialNetwork.template.js) $(location SocialNetwork.test.js) $(locations //:content)",
     outs = ["SocialNetwork.test.js"]
 )

--- a/test/example/nodejs/nodejs_tests.py
+++ b/test/example/nodejs/nodejs_tests.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import re
 import sys
 

--- a/test/example/nodejs/nodejs_tests.py
+++ b/test/example/nodejs/nodejs_tests.py
@@ -16,7 +16,7 @@ with open(test_template_path, "r") as template_file:
     template_content = template_file.read()
 
 for markdown_file in markdown_files:
-    with open(markdown_file) as file:
+    with open(markdown_file, encoding='utf-8') as file:
         matches = re.findall(pattern_to_find_standalones, file.read())
         for standalone in matches:
             standalone_filename = standalone[0]

--- a/test/example/python/BUILD
+++ b/test/example/python/BUILD
@@ -30,7 +30,7 @@ genrule(
         "python_tests.py",
         "//:content"
     ],
-    cmd = "python $(location python_tests.py) $(OUTS) $(locations //:content)",
+    cmd = "$(location python_tests.py) $(OUTS) $(locations //:content)",
     outs = [
         ## examples/migration-python
         "phone_calls_csv_migration.py",
@@ -67,7 +67,7 @@ genrule(
         "python_tests.py",
         "//:content"
     ],
-    cmd = "python $(location python_tests.py) $(OUTS) $(locations //:content)",
+    cmd = "$(location python_tests.py) $(OUTS) $(locations //:content)",
     outs = [
         # general/quickstart
         "social_network_quickstart_query.py",

--- a/test/example/python/python_tests.py
+++ b/test/example/python/python_tests.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import re
 import sys
 

--- a/test/example/python/python_tests.py
+++ b/test/example/python/python_tests.py
@@ -17,7 +17,7 @@ pattern_to_find_standalones = ('<!-- test-example ' +
                                '```')
 standalones = []
 for markdown_file in markdown_files:
-    with open(markdown_file) as file:
+    with open(markdown_file, encoding='utf-8') as file:
         matches = re.findall(pattern_to_find_standalones, file.read())
         for standalone in matches:
             standalone_filename = standalone[0]

--- a/test/links/BUILD
+++ b/test/links/BUILD
@@ -10,7 +10,8 @@ py_test(
     srcs = ["links_test.py"],
     deps = [
         test_links_requirement("PyYAML"),
-        test_links_requirement("nested-lookup")
+        test_links_requirement("nested-lookup"),
+        test_links_requirement("six")
     ],
     data = [
         "//:content",

--- a/test/links/links_test.py
+++ b/test/links/links_test.py
@@ -28,7 +28,7 @@ for markdown_path in glob.iglob('./**/*.md'):
 
     pages[title] = {"links": [], "anchors": [], "invalids": []}
 
-    with open(markdown_path) as markdown_file:
+    with open(markdown_path, encoding='utf-8') as markdown_file:
         content = markdown_file.read()
         link_matches = re.findall(pattern_to_find_links, content)
         for match in link_matches:

--- a/test/links/requirements.txt
+++ b/test/links/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML==5.1
 nested-lookup==0.2.12
+six==1.12.0


### PR DESCRIPTION
## What is the goal of this PR?

Fix CI by adding a missing requirement

## What are the changes implemented in this PR?

* When upgraded to Python 3, `nested_lookup` stopped specifying `six` as a requirement — but it's still needed so we specify it explicitly
* `genrule`s that generated code for `//test/example/java:phone-calls`, `//test/example/nodejs:phone-calls` and `/test/example/python:phone-calls` explicitly used `python`, which defaults to Python 2. Instead, we move declarations to shebang line (`#!`) and assign `+x` bit so scripts can be invoked via `bash`