### PR TITLE
Fix grabl's sync-dependencies for NodeJS package

### DIFF
--- a/test/example/nodejs/package.json
+++ b/test/example/nodejs/package.json
@@ -8,5 +8,7 @@
         "papaparse": "^4.6.0",
         "stream-json": "^1.1.4",
         "xml-stream": "^0.4.5"
-    }
+    },
+    "name": "grakn-docs-test-example-nodejs",
+    "version": "1.0.0"
 }


### PR DESCRIPTION
## What is the goal of this PR?

Fix graknlabs/grabl#29
Allow upgrading version of `grakn-client` in `docs` (`test/example/nodejs`) by `@grabl`

## What are the changes implemented in this PR?

Previously, `yarn generate-lock-entry` failed to generate a lockfile due to following errors:
```
error Package doesn't have a name.
error Package doesn't have a version.
```

This PR addresses issues by supplying package `name` and `version` in `test/example/nodejs/package.json`
