### PR TITLE
brew tap-pin is depreciated

### DIFF
--- a/02-running-grakn/01-install-and-run.md
+++ b/02-running-grakn/01-install-and-run.md
@@ -75,7 +75,7 @@ Having installed or downloaded Grakn, we can now start the [Server](#start-the-g
 #### Using Homebrew
 ```
 brew tap graknlabs/tap
-brew tap-pin graknlabs/tap
+cd /usr/local/Homebrew/Library/Taps/graknlabs/homebrew-tap/formula
 brew install grakn-core
 ```
 


### PR DESCRIPTION
## What is the goal of this PR?

To make the documentation more accurate. 

## What are the changes implemented in this PR?

When running `brew tap-pin graknlabs/tap` your action is declined and you get this message 

> "Warning: Calling brew tap-pin user/tap is deprecated! Use fully-scoped user/tap/formula naming instead."

The documentation was updated to a working solution. 
