### PR TITLE
Refer to Homebrew formula by full name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run-grakn-server
+      - run: sleep 60
       - run: bazel test //test/example/nodejs:phone-calls --test_output=errors
       - run: bazel test //test/example/nodejs:social-network --test_output=errors
 

--- a/02-running-grakn/01-install-and-run.md
+++ b/02-running-grakn/01-install-and-run.md
@@ -75,8 +75,7 @@ Having installed or downloaded Grakn, we can now start the [Server](#start-the-g
 #### Using Homebrew
 ```
 brew tap graknlabs/tap
-brew tap-pin graknlabs/tap
-brew install grakn-core
+brew install graknlabs/tap/grakn-core
 ```
 
 #### Manual Download

--- a/test/query/graql-java-tests.py
+++ b/test/query/graql-java-tests.py
@@ -1,5 +1,6 @@
 import re
 import sys
+from io import open
 
 output_path, markdown_files = sys.argv[1], sys.argv[2:]
 
@@ -101,7 +102,7 @@ pattern_to_find_snippets = ('<!-- test-(delay|ignore|example.*) -->\n```java\n((
 
 snippets = []
 for markdown_file in markdown_files:
-    with open(markdown_file) as file:
+    with open(markdown_file, encoding='utf-8') as file:
         matches = re.findall(pattern_to_find_snippets, file.read())
         for snippet in matches:
             flag_type = snippet[0]

--- a/test/query/graql-lang-tests.py
+++ b/test/query/graql-lang-tests.py
@@ -1,5 +1,6 @@
 import re
 import sys
+from io import open
 
 output_path, markdown_files = sys.argv[1], sys.argv[2:]
 
@@ -98,7 +99,7 @@ pattern_to_find_snippets = ('<!-- test-(delay|ignore|example.*) -->\n```graql\n(
 
 snippets = []
 for markdown_file in markdown_files:
-    with open(markdown_file) as file:
+    with open(markdown_file, encoding='utf-8') as file:
         matches = re.findall(pattern_to_find_snippets, file.read())
         for snippet in matches:
             flag_type = snippet[0]


### PR DESCRIPTION
## What is the goal of this PR?

* Replacement of #226 -- Make the documentation more accurate. 
* Fix CI: read Markdown files with utf-8
* Fix CI: add a sleep before nodejs example tests

## What are the changes implemented in this PR?

When running `brew tap-pin graknlabs/tap` your action is declined and you get this message 

> "Warning: Calling brew tap-pin user/tap is deprecated! Use fully-scoped user/tap/formula naming instead."

The documentation was updated to a working solution. 