### PR TITLE
Remove reference to Concept API

### DIFF
--- a/08-examples/05-phone-calls-queries.md
+++ b/08-examples/05-phone-calls-queries.md
@@ -590,7 +590,7 @@ package io.grakn.example.phoneCalls;
 import grakn.client.GraknClient;
 import grakn.client.answer.ConceptMap;
 import graql.lang.query.GraqlGet;
-import grakn.core.server.exception.TransactionException;
+import grakn.core.kb.server.exception.TransactionException;
 import static graql.lang.Graql.*;
 
 import java.util.*;

--- a/test/example/java/BUILD
+++ b/test/example/java/BUILD
@@ -12,7 +12,6 @@ java_test(
     deps = [
         "@graknlabs_client_java//:client-java",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//concept:concept",
         "@graknlabs_grakn_core//server:server",
         "@graknlabs_grakn_core//test-integration/rule:grakn-test-server",
         "//dependencies/maven/artifacts/org/sharegov:mjson",
@@ -65,7 +64,6 @@ java_test(
     deps = [
         "@graknlabs_client_java//:client-java",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//concept:concept",
         "@graknlabs_grakn_core//server:server",
         "@graknlabs_grakn_core//test-integration/rule:grakn-test-server",
     ],

--- a/test/example/java/BUILD
+++ b/test/example/java/BUILD
@@ -14,6 +14,7 @@ java_test(
         "@graknlabs_graql//java:graql",
         "@graknlabs_grakn_core//server:server",
         "@graknlabs_grakn_core//test-integration/rule:grakn-test-server",
+        "@graknlabs_grakn_core//kb",
         "//dependencies/maven/artifacts/org/sharegov:mjson",
         "//dependencies/maven/artifacts/com/google/code/gson:gson",
         "//dependencies/maven/artifacts/com/univocity:univocity-parsers",

--- a/test/query/BUILD
+++ b/test/query/BUILD
@@ -9,7 +9,6 @@ java_test(
     deps = [
         "@graknlabs_client_java//:client-java",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//concept:concept",
         "@graknlabs_grakn_core//server:server",
         "@graknlabs_grakn_core//test-integration/rule:grakn-test-server"
     ],
@@ -45,7 +44,6 @@ java_test(
     deps = [
         "@graknlabs_client_java//:client-java",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//concept:concept",
         "@graknlabs_grakn_core//server:server",
         "@graknlabs_grakn_core//test-integration/rule:grakn-test-server"
     ],


### PR DESCRIPTION
## What is the goal of this PR?

Remove `concept` library from dependencies as it's no longer in Core

## What are the changes implemented in this PR?

Remove `@graknlabs_grakn_core//concept:concept` from dependencies