### PR TITLE
Remove dependency on @graknlabs_grakn_core//concept

### DIFF
--- a/08-examples/05-phone-calls-queries.md
+++ b/08-examples/05-phone-calls-queries.md
@@ -590,7 +590,7 @@ package io.grakn.example.phoneCalls;
 import grakn.client.GraknClient;
 import grakn.client.answer.ConceptMap;
 import graql.lang.query.GraqlGet;
-import grakn.core.server.exception.TransactionException;
+import grakn.core.kb.server.exception.TransactionException;
 import static graql.lang.Graql.*;
 
 import java.util.*;

--- a/test/example/java/BUILD
+++ b/test/example/java/BUILD
@@ -12,7 +12,6 @@ java_test(
     deps = [
         "@graknlabs_client_java//:client-java",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//concept:concept",
         "@graknlabs_grakn_core//server:server",
         "@graknlabs_grakn_core//test-integration/rule:grakn-test-server",
         "//dependencies/maven/artifacts/org/sharegov:mjson",
@@ -65,7 +64,6 @@ java_test(
     deps = [
         "@graknlabs_client_java//:client-java",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//concept:concept",
         "@graknlabs_grakn_core//server:server",
         "@graknlabs_grakn_core//test-integration/rule:grakn-test-server",
     ],

--- a/test/example/java/BUILD
+++ b/test/example/java/BUILD
@@ -13,6 +13,7 @@ java_test(
         "@graknlabs_client_java//:client-java",
         "@graknlabs_graql//java:graql",
         "@graknlabs_grakn_core//server:server",
+        "@graknlabs_grakn_core//kb",
         "@graknlabs_grakn_core//test-integration/rule:grakn-test-server",
         "//dependencies/maven/artifacts/org/sharegov:mjson",
         "//dependencies/maven/artifacts/com/google/code/gson:gson",

--- a/test/query/BUILD
+++ b/test/query/BUILD
@@ -9,7 +9,6 @@ java_test(
     deps = [
         "@graknlabs_client_java//:client-java",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//concept:concept",
         "@graknlabs_grakn_core//server:server",
         "@graknlabs_grakn_core//test-integration/rule:grakn-test-server"
     ],
@@ -45,7 +44,6 @@ java_test(
     deps = [
         "@graknlabs_client_java//:client-java",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//concept:concept",
         "@graknlabs_grakn_core//server:server",
         "@graknlabs_grakn_core//test-integration/rule:grakn-test-server"
     ],


### PR DESCRIPTION
## What is the goal of this PR?

Concept API library was removed from Grakn Core so `docs` need to be adapted

## What are the changes implemented in this PR?

Remove `@graknlabs_grakn_core//concept` from `deps` of all Java libraries
