### PR TITLE
Documents isOpen/is_Open for Clients Java and Python + Void Answer Type

### DIFF
--- a/03-client-api/references/answer.yml
+++ b/03-client-api/references/answer.yml
@@ -105,27 +105,26 @@ types:
           <<: *method-explanation
           method: answer.explanation()
 
-  # TO BE UNCOMMENTED UPON THE RELEASE OF 1.6.0 CLIENTS
-  # - type2:
-  #   title: Void
-  #   methods:
-  #     - method:
-  #       common: &method-void-message
-  #         title: Retrieve the status message 
-  #         description: Retrieves the message describing the status of the query.
-  #         method: answer.message();
-  #       java:
-  #         <<: *method-void-message
-  #         returns:
-  #           - "`String`"
-  #       javascript:
-  #         <<: *method-void-message
-  #         returns:
-  #           - "`String`"
-  #       python:
-  #         <<: *method-void-message
-  #         returns:
-  #           - "string"
+  - type2:
+    title: Void
+    methods:
+      - method:
+        common: &method-void-message
+          title: Retrieve the status message 
+          description: Retrieves the message describing the status of the query.
+          method: answer.message();
+        java:
+          <<: *method-void-message
+          returns:
+            - "`String`"
+        javascript:
+          <<: *method-void-message
+          returns:
+            - "`String`"
+        python:
+          <<: *method-void-message
+          returns:
+            - "string"
 
   - type3:
     title: Numeric

--- a/03-client-api/references/transaction.yml
+++ b/03-client-api/references/transaction.yml
@@ -128,15 +128,15 @@ methods:
       title: Checks if the transaction is open
       returns:
         - "`boolean`"
-    # java:
-    #   <<: *method-isOpen
-    #   method: transaction.isOpen();
+    java:
+      <<: *method-isOpen
+      method: transaction.isOpen();
     javascript:
       <<: *method-isOpen
       method: await transaction.isOpen();
-    # python:
-    #   <<: *method-isOpen
-    #   method: transaction.is_open()
+    python:
+      <<: *method-isOpen
+      method: transaction.is_open()
 
   - method:
     common: &method-getConcept


### PR DESCRIPTION
## What is the goal of this PR?
`Void` has now been added as an Answer type and the newly `isOpen()` and `is_open()` methods are documented on transaction for clients Java and Python.

**Note: to be merged upon release of 1.6.0 of all clients.**