### PR TITLE
Fixes the incorrect condition in the person_template for Python CSV migration

### DIFF
--- a/08-examples/04-phone-calls-migration-python.md
+++ b/08-examples/04-phone-calls-migration-python.md
@@ -296,7 +296,7 @@ Given the nature of CSV files, the dictionary produced has all the columns of th
 
 For this reason, we need to change one line in our `person_template` function.
 
-`if "first_name" in person` becomes `if person["first_name"] == ""`.
+`if "first_name" in person` becomes `if person["first_name"] != ""`.
 [tab:end]
 
 [tab:JSON]


### PR DESCRIPTION
## What is the goal of this PR?
Fixes the incorrect condition in the `person_template` for Python CSV migration.

## What are the changes implemented in this PR?
`==` changed to `!=`