### PR TITLE
Adding instructions to upgrade to 1.6.x

### DIFF
--- a/02-running-grakn/01-install-and-run.md
+++ b/02-running-grakn/01-install-and-run.md
@@ -10,6 +10,26 @@ toc: false
 Grakn runs on Mac, Linux and Windows. The only requirement is Java 8 which can be downloaded from [OpenJDK](http://openjdk.java.net/install/) or [Oracle Java](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
 
 ## Download and Install Grakn
+
+<div class="note">
+[Warning]
+Upgrading an existing installation to Grakn Core 1.6.x.
+
+There has been an internal storage change in Grakn Core 1.6.x. Please back up your existing data and run the following step before doing the upgrade:
+</div>
+
+1. Download [Apache Cassandra 3.11.x](http://www.apache.org/dyn/closer.lua/cassandra/3.11.5/apache-cassandra-3.11.5-bin.tar.gz) and untar it
+2. Start Grakn: `grakn server start`
+3. Update Storage's setting and flush the change:
+```
+$ cd apache-cassandra-<version>
+$ bin/cqlsh localhost -e "update system.local set cluster_name = 'Grakn Cluster' where key='local';"
+$ bin/nodetool flush -- system
+```
+3. Stop Grakn: `grakn server stop`
+
+Once done, you are safe to upgrade as described in the next section.
+
 <div class="tabs light">
 [tab:Linux]
   

--- a/02-running-grakn/01-install-and-run.md
+++ b/02-running-grakn/01-install-and-run.md
@@ -11,12 +11,9 @@ Grakn runs on Mac, Linux and Windows. The only requirement is Java 8 which can b
 
 ## Download and Install Grakn
 
-<div class="note">
-[Warning]
-Upgrading an existing installation to Grakn Core 1.6.x.
+### Upgrading an Existing Installation to Grakn Core 1.6.x.
 
 There has been an internal storage change in Grakn Core 1.6.x. Please back up your existing data and run the following step before doing the upgrade:
-</div>
 
 1. Download [Apache Cassandra 3.11.x](http://www.apache.org/dyn/closer.lua/cassandra/3.11.5/apache-cassandra-3.11.5-bin.tar.gz) and untar it
 2. Start Grakn: `grakn server start`


### PR DESCRIPTION
## What is the goal of this PR?

We have changed the cluster name to `Grakn Cluster` from `Grakn Example Cluster` in `cassandra.yaml`. The cluster name is persisted in the data and would cause an issue if you're upgrading an existing installation.

Therefore, this PR provides the instruction for people to update the cluster name of an existing data so that they can upgrade to Grakn Core 1.6.x.