### PR TITLE
Remove usage of .collect_concepts from Python code

### DIFF
--- a/03-client-api/02-python.md
+++ b/03-client-api/02-python.md
@@ -90,7 +90,7 @@ with GraknClient(uri="localhost:48555") as client:
         ## Insert a Person using a WRITE transaction
         with session.transaction().write() as write_transaction:
             insert_iterator = write_transaction.query('insert $x isa person, has email "x@email.com";')
-            concepts = insert_iterator.collect_concepts()
+            concepts = [ans.get("x") for ans in insert_iterator]
             print("Inserted a person with ID: {0}".format(concepts[0].id))
             ## to persist changes, write transaction must always be committed (closed)
             write_transaction.commit()
@@ -106,7 +106,7 @@ with GraknClient(uri="localhost:48555") as client:
         ## Or query and consume the iterator immediately collecting all the results
         with session.transaction().read() as read_transaction:
             answer_iterator = read_transaction.query("match $x isa person; get; limit 10;")
-            persons = answer_iterator.collect_concepts()
+            persons = [ans.get("x") for ans in answer_iterator]
             for person in persons:
                 print("Retrieved person with id "+ person.id)
 

--- a/03-client-api/references/iterator.yml
+++ b/03-client-api/references/iterator.yml
@@ -22,9 +22,4 @@ methods:
       method: await iterator.collectConcepts();
       returns:
         - "Array of [Concept](../concept-api/concept)"
-    python:
-      <<: *method-collectConcepts
-      description: Consumes the iterator and collects all Concepts into a list.
-      method: iterator.collect_concepts();
-      returns:
-        - "List of [Concept](../concept-api/concept)"
+

--- a/08-examples/05-phone-calls-queries.md
+++ b/08-examples/05-phone-calls-queries.md
@@ -187,7 +187,7 @@ with GraknClient(uri="localhost:48555") as client:
             query = "".join(query)
 
             iterator = transaction.query(query)
-            answers = iterator.collect_concepts()
+            answers = [ans.get("phone-number") for ans in iterator]
             result = [ answer.value() for answer in answers ]
 
             print("\nResult:\n", result)
@@ -365,7 +365,7 @@ with GraknClient(uri="localhost:48555") as client:
         query = "".join(query)
 
         iterator = transaction.query(query)
-        answers = iterator.collect_concepts()
+        answers = [ans.get("phone-number") for ans in iterator]
         result = [ answer.value() for answer in answers ]
 
         print("\nResult:\n", result)
@@ -528,7 +528,7 @@ with GraknClient(uri="localhost:48555") as client:
             query = "".join(query)
 
             iterator = transaction.query(query)
-            answers = iterator.collect_concepts()
+            answers = [ans.get("phone-number") for ans in iterator]
             result = [ answer.value() for answer in answers ]
 
             print("\nResult:\n", result)
@@ -709,7 +709,9 @@ with GraknClient(uri="localhost:48555") as client:
             query = "".join(query)
 
             iterator = transaction.query(query)
-            answers = iterator.collect_concepts()
+            answers = []
+            for answer in iterator:
+                answers.extend(answer.map().values())
             result = [ answer.value() for answer in answers ]
 
             print("\nResult:\n", result)

--- a/views/autolink-keywords.js
+++ b/views/autolink-keywords.js
@@ -70,10 +70,10 @@ codeKeywordsToLink = {
             "languages": ["java", "javascript", "python"]
         },
         {
-            "titles": ["collectConcepts", "collect_concepts"],
+            "titles": ["collectConcepts"],
             "syntaxedAs": ["function"],
             "anchor": "#consume-the-iterator-eagerly",
-            "languages": ["javascript", "python"]
+            "languages": ["javascript"]
         },
         {
             "titles": ["commit"],


### PR DESCRIPTION
**MERGE UPON NEXT RELEASE OF CLIENT PYTHON**

## What is the goal of this PR?

Currently, Python examples in the documentation are wrong because they use `.collect_concepts` method no longer present in Grakn Client Python (see graknlabs/client-python#77)

## What are the changes implemented in this PR?

Replace usage of `.collect_concepts` with list comprehensions