### PR TITLE
Updates dependencies

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -28,27 +28,27 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "7cb307c3e48bd7675445e58edd7b37044882fa44" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        tag = "1.6.2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/graknlabs/client-java",
-        commit = "b5154566e80c4a505babb615c415c86ed4f181e4" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        tag = "1.6.2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )
 
 def graknlabs_client_python():
     git_repository(
         name = "graknlabs_client_python",
         remote = "https://github.com/graknlabs/client-python",
-        commit = "7328f17ea4cc53c35845a047ca0d96cc7d0937bd" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_python
+        tag = "1.6.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_python
     )
 
 def graknlabs_client_nodejs():
     git_repository(
         name = "graknlabs_client_nodejs",
         remote = "https://github.com/graknlabs/client-nodejs",
-        commit = "75d9d1dddc2f5dc93a007c80f92f3b20a7b3b976" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_nodejs
+        tag = "1.6.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_nodejs
     )
 


### PR DESCRIPTION
## What is the goal of this PR?
Due to an incorrect configuration of `sync-dependencies`, the dependencies of this repository were wrongly set to be the snapshots, whereas they should all point to their latest release.

## What are the changes implemented in this PR?
Sets all dependencies (except `build-tools`) to point to the latest release.