### PR TITLE
Update 01-connection.md

### DIFF
--- a/07-workbase/01-connection.md
+++ b/07-workbase/01-connection.md
@@ -14,6 +14,8 @@ Workbase connects to a running [Grakn Server](/docs/running-grakn/install-and-ru
 ![Connection](/docs/images/workbase/preferences_core-login.png)
 [caption: We can specify the host and port when we start workbase.]
 
+FIXME: need to state how to start workbase and which port it runs on by default
+
 
 ### Start Workbase for Grakn KGMS [KGMS ONLY]
 


### PR DESCRIPTION
there is missing info on how to start workbase.
actually I thought it was a web app and was looking for which port, and how to start it.

seems now it's a standalone application, and you run it normally.
probably worth clarifying?

added a FIXME note