### PR TITLE
Fix excessive rebuilding

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,7 @@
+build --incompatible_strict_action_env
+run --incompatible_strict_action_env
+test --incompatible_strict_action_env
+
 build:rbe --project_id=grakn-dev
 build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
 build:rbe --remote_cache=remotebuildexecution.googleapis.com

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ commands:
           command: bazel build @graknlabs_grakn_core//:assemble-linux-targz
       - run: mkdir dist && tar -xvzf bazel-genfiles/external/graknlabs_grakn_core/grakn-core-all-linux.tar.gz -C ./dist/
       - run: nohup ./dist/grakn-core-all-linux/grakn server start
+      - run: sleep 60
 
 jobs:
   build:
@@ -84,7 +85,6 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run-grakn-server
-      - run: sleep 60
       - run: bazel test //test/example/nodejs:phone-calls --test_output=errors
       - run: bazel test //test/example/nodejs:social-network --test_output=errors
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,7 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
+      - run: pyenv global 2.7.12 3.5.2
       - run-grakn-server
       - run: bazel test //test/example/python:phone-calls --test_output=errors
       - run: bazel test //test/example/python:social-network --test_output=errors
@@ -104,6 +105,7 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
+      - run: pyenv global 2.7.12 3.5.2
       - run: bazel test //test/links:test --test_output=errors
 
   release-staging:

--- a/test/example/python/BUILD
+++ b/test/example/python/BUILD
@@ -21,7 +21,8 @@ py_test(
         test_example_requirement("ijson")
     ],
     data = ["//files:phone-calls-kg"],
-    imports = ["."]
+    imports = ["."],
+    python_version = "PY2",
 )
 
 genrule(
@@ -58,7 +59,8 @@ py_test(
     ],
     deps = ["@graknlabs_client_python//:client_python"],
     data = ["//files:social-network-kg"],
-    imports = ["."]
+    imports = ["."],
+    python_version = "PY2",
 )
 
 genrule(

--- a/test/links/BUILD
+++ b/test/links/BUILD
@@ -17,5 +17,6 @@ py_test(
         "//:content",
         "//:template",
         "//:autolink-keywords"
-    ]
+    ],
+    python_version = "PY2",
 )

--- a/test/links/links_test.py
+++ b/test/links/links_test.py
@@ -1,9 +1,12 @@
+#!/usr/bin/env python2
+
 import unittest
 import glob
 import re
 import os
 import yaml
 import ast
+from io import open
 from nested_lookup import nested_lookup
 
 pattern_to_find_links = '(\[[^\]]*?\]\(\.\.\/)((\d+-[^\/\)]*(\/|))+)\)'


### PR DESCRIPTION
## What is the goal of this PR?

Previously, when switching between IDE and terminal builds, build cache would be fully invalidated. due to changed $PATH which defeats the sole purpose of caching. As per suggestion in [this](https://github.com/bazelbuild/intellij/issues/1169) thread, we're enabling strict environment for actions (which sets PATH alongside with other variables to minimally viable preconfigured values). 

## What are the changes implemented in this PR?

Specify `--incompatible_strict_action_env` for `build`/`test`/`run`