### PR TITLE
Fix CI by including @graknlabs_grabl_tracing

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,8 +32,10 @@ graknlabs_client_python()
 graknlabs_build_tools()
 graknlabs_grabl_tracing()
 
-load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_graql", "graknlabs_protocol")
+load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_graql")
 graknlabs_graql()
+
+load("@graknlabs_client_java//dependencies/graknlabs:dependencies.bzl", "graknlabs_protocol")
 graknlabs_protocol()
 
 load("@graknlabs_build_tools//distribution:dependencies.bzl", "graknlabs_bazel_distribution")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,11 +23,14 @@ workspace(name = "graknlabs_docs")
 ################################
 
 load("//dependencies/graknlabs:dependencies.bzl",
-     "graknlabs_grakn_core", "graknlabs_client_java", "graknlabs_client_python", "graknlabs_build_tools")
+     "graknlabs_grakn_core", "graknlabs_client_java", "graknlabs_client_python", "graknlabs_build_tools",
+     "graknlabs_grabl_tracing"
+)
 graknlabs_grakn_core()
 graknlabs_client_java()
 graknlabs_client_python()
 graknlabs_build_tools()
+graknlabs_grabl_tracing()
 
 load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_graql", "graknlabs_protocol")
 graknlabs_graql()
@@ -36,6 +39,9 @@ graknlabs_protocol()
 load("@graknlabs_build_tools//distribution:dependencies.bzl", "graknlabs_bazel_distribution")
 graknlabs_bazel_distribution()
 
+load("@graknlabs_grabl_tracing//dependencies/maven:dependencies.bzl",
+graknlabs_grabl_tracing_dependencies = "maven_dependencies")
+graknlabs_grabl_tracing_dependencies()
 
 ###########################
 # Load Bazel Dependencies #

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -17,6 +17,14 @@
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
+# TODO(vmax): replace with version from @graknlabs_grakn_core once it's released
+def graknlabs_grabl_tracing():
+    git_repository(
+        name = "graknlabs_grabl_tracing",
+        remote = "https://github.com/graknlabs/grabl-tracing",
+        commit = "42f507d6b973cbc87d18a27ee83121c791295184"
+    )
+
 def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",


### PR DESCRIPTION
## What is the goal of this PR?

Currently, CI is broken due to `grabl-tracing` not being included

## What are the changes implemented in this PR?

Include `@graknlabs_grabl_tracing` into `dependencies/graknlabs/dependencies.bzl`
