### PR TITLE
Update docs to grakn 1.7.0 and client-java 1.7.1

### DIFF
--- a/03-client-api/01-java.md
+++ b/03-client-api/01-java.md
@@ -10,7 +10,7 @@ templatePath: 03-client-api/references/
 
 | Client Java | Grakn Core     | Grakn KGMS     |
 | :---------: | :-------------:| :------------: |
-| 1.7.0       | 1.7.0          | N/A            |
+| 1.7.0,1.7.1 | 1.7.0          | N/A            |
 | 1.6.2       | 1.6.2          | 1.6.2          |
 | 1.6.1       | 1.6.0, 1.6.1   | N/A            |
 | 1.5.5       | 1.5.8, 1.5.9   | 1.5.8          |
@@ -43,7 +43,7 @@ templatePath: 03-client-api/references/
     <dependency>
         &lt;groupId&gt;io.grakn.client&lt;/groupId&gt;
         &lt;artifactId&gt;grakn-client&lt;/artifactId&gt;
-        <version>1.7.0</version>
+        <version>1.7.1</version>
     </dependency>
 </dependencies>
 ```
@@ -61,7 +61,7 @@ templatePath: 03-client-api/references/
     <dependency>
         &lt;groupId&gt;ai.grakn.kgms&lt;/groupId&gt;
         &lt;artifactId&gt;client&lt;/artifactId&gt;
-        <version>1.7.0</version>
+        <version>1.6.2</version>
     </dependency>
 </dependencies>
 ```

--- a/03-client-api/01-java.md
+++ b/03-client-api/01-java.md
@@ -10,6 +10,7 @@ templatePath: 03-client-api/references/
 
 | Client Java | Grakn Core     | Grakn KGMS     |
 | :---------: | :-------------:| :------------: |
+| 1.7.0       | 1.7.0          | N/A            |
 | 1.6.2       | 1.6.2          | 1.6.2          |
 | 1.6.1       | 1.6.0, 1.6.1   | N/A            |
 | 1.5.5       | 1.5.8, 1.5.9   | 1.5.8          |
@@ -42,7 +43,7 @@ templatePath: 03-client-api/references/
     <dependency>
         &lt;groupId&gt;io.grakn.client&lt;/groupId&gt;
         &lt;artifactId&gt;grakn-client&lt;/artifactId&gt;
-        <version>1.6.2</version>
+        <version>1.7.0</version>
     </dependency>
 </dependencies>
 ```
@@ -60,7 +61,7 @@ templatePath: 03-client-api/references/
     <dependency>
         &lt;groupId&gt;ai.grakn.kgms&lt;/groupId&gt;
         &lt;artifactId&gt;client&lt;/artifactId&gt;
-        <version>1.6.2</version>
+        <version>1.7.0</version>
     </dependency>
 </dependencies>
 ```

--- a/08-examples/02-phone-calls-migration-java.md
+++ b/08-examples/02-phone-calls-migration-java.md
@@ -60,7 +60,7 @@ Modify `pom.xml` to include the latest version of Grakn Core, Graql and Grakn Cl
         <dependency>
             <groupId>io.grakn.client</groupId>
             <artifactId>grakn-client</artifactId>
-            <version>1.7.0</version>
+            <version>1.7.1</version>
         </dependency>
   	</dependencies>
 </project>

--- a/08-examples/02-phone-calls-migration-java.md
+++ b/08-examples/02-phone-calls-migration-java.md
@@ -60,7 +60,7 @@ Modify `pom.xml` to include the latest version of Grakn Core, Graql and Grakn Cl
         <dependency>
             <groupId>io.grakn.client</groupId>
             <artifactId>grakn-client</artifactId>
-            <version>1.6.2</version>
+            <version>1.7.0</version>
         </dependency>
   	</dependencies>
 </project>

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -28,7 +28,7 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        tag = "1.6.2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        tag = "1.7.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_client_java():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -28,7 +28,7 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        tag = "1.7.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        tag = "1.6.2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_client_java():
@@ -51,4 +51,3 @@ def graknlabs_client_nodejs():
         remote = "https://github.com/graknlabs/client-nodejs",
         tag = "1.6.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_nodejs
     )
-


### PR DESCRIPTION
## What is the goal of this PR?

We have updated docs to grakn 1.7.0 and client-java 1.7.0

## What are the changes implemented in this PR?

- update compatibility table to include `grakn` 1.7.0 and `client-java` 1.7.0.
- update `client-java` version in the exampl
- update dependencies to use `grakn` 1.7.0 and `client-java` 1.7.0
