### PR TITLE
Fixes dependency issues

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -35,7 +35,7 @@ def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/graknlabs/client-java",
-        tag = "1.7.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        tag = "1.6.2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )
 
 def graknlabs_client_python():


### PR DESCRIPTION
## What is the goal of this PR?
Due to the latest versions of clients Python and Node.js not supporting the latest version of `grakn-core`, we have temporarily rolled back the client-java dependency to version `1.6.2`, so that all clients can be tested against `grakn-core 1.6.2`. 