### PR TITLE
Unable to create connection to Grakn instance at localhost:48555

### DIFF
--- a/02-running-grakn/01-install-and-run.md
+++ b/02-running-grakn/01-install-and-run.md
@@ -158,7 +158,7 @@ Having started the instance, the Grakn Server is expected to be running on port 
 To interact with the [Grakn Console](../02-running-grakn/02-console.md), run:
 
 ```
-docker exec -ti grakn bash -c '/grakn-core-all-linux/grakn console'
+docker exec -ti grakn bash -c './grakn-core-all-linux/grakn console'
 ```
 [tab:end]
 </div>


### PR DESCRIPTION
Add dot comma to docker exec
```
docker exec -ti grakn bash -c './grakn-core-all-linux/grakn console'
```
