### PR TITLE
Add correct Migration page reference to Sidebar

### DIFF
--- a/views/sidebar.yml
+++ b/views/sidebar.yml
@@ -85,7 +85,7 @@ chapters:
             url: users
           -
             title: Migration and Backup
-            url: migration
+            url: migration-and-backup
       -
         title: Workbase
         baseUrl: /docs/workbase/


### PR DESCRIPTION
## What is the goal of this PR?
Add correct Migration page reference to Sidebar

## What are the changes implemented in this PR?
Rename from `migration` to correct `migration-and-backup`
