### PR TITLE
Removes `execute` from documentation of clients python and node.js

### DIFF
--- a/03-client-api/references/transaction.yml
+++ b/03-client-api/references/transaction.yml
@@ -91,12 +91,6 @@ methods:
     java:
       <<: *method-execute
       method: 'transaction.execute(GraqlQuery query, Options queryOptions);'
-    python:
-      <<: *method-execute
-      method: 'transaction.execute(query, infer=True, explain=False, batch_size=50);'
-    javascript:
-      <<: *method-execute
-      method: 'transaction.execute(query, queryOptions);'
 
   - method:
     common: &method-commit


### PR DESCRIPTION
## What is the goal of this PR?
`execute` was mistakenly documented as a method of transaction for client python and node.js. It's now been removed.

resolves #334 