### PR TITLE
Update ownership deletion syntax

### DIFF
--- a/11-query/04-delete-query.md
+++ b/11-query/04-delete-query.md
@@ -84,8 +84,6 @@ GraqlDelete query = Graql.match(
 [tab:end]
 </div>
 
-Note also that you must not specify a type for the attribute when deleting, as this creates a derived isa. You must use `delete $t has $st`, _not_  `delete $t has startdate $st`.
-
 This looks for a `travel` that owns the attribute `start-date` with the value of `2013-12-22` in the `match` clause. 
 We then disassociate the `travel` instance `$t` from the attribute `$st` with the `delete $t has start-date $st` clause.
 
@@ -93,6 +91,8 @@ This will _not_ delete the entire instance of type `start-date` and value `2013-
 
 If we had instead written the query as `match $t isa travel, has start-date $st;  $st == 2013-12-22"; delete $st isa start-date;`, 
 we would have deleted the instance of `start-date` with value `2013-12-22` and its association with all other concept types that previously owned it.
+
+Note also that you must not specify a type for the attribute when deleting, as this creates a derived isa. You must use `delete $t has $st`, _not_  `delete $t has startdate $st`.
 
 ## Delete Role Players from Relations
 

--- a/11-query/04-delete-query.md
+++ b/11-query/04-delete-query.md
@@ -70,7 +70,7 @@ Note that attributes with the same value and type are shared among their owners.
 
 [tab:Graql]
 ```graql
-match $t isa travel, has start-date $st; $d 2013-12-22; delete $t has start-date $st;
+match $t isa travel, has start-date $st; $d 2013-12-22; delete $t has $st;
 ```
 [tab:end]
 
@@ -79,13 +79,15 @@ match $t isa travel, has start-date $st; $d 2013-12-22; delete $t has start-date
 GraqlDelete query = Graql.match(
   var("t").isa("travel").has("start-date", var("st")),
   var("st").eq(LocalDate.of(2013, 12, 22).atStartOfDay())
-).delete(var("t").has("start-date", var("st")));
+).delete(var("t").has(var("st")));
 ```
 [tab:end]
 </div>
 
+Note also that you must not specify a type for the attribute when deleting, as this creates a derived isa. You must use `delete $t has $st`, _not_  `delete $t has startdate $st`.
+
 This looks for a `travel` that owns the attribute `start-date` with the value of `2013-12-22` in the `match` clause. 
-We then disassociate the `travel` instance `$t` from the `start-date` attribute `$st` with the `delete $t has start-date $st` clause.
+We then disassociate the `travel` instance `$t` from the attribute `$st` with the `delete $t has start-date $st` clause.
 
 This will _not_ delete the entire instance of type `start-date` and value `2013-12-22` - it remains associated with any other instance that may own it.
 

--- a/11-query/04-delete-query.md
+++ b/11-query/04-delete-query.md
@@ -85,14 +85,14 @@ GraqlDelete query = Graql.match(
 </div>
 
 This looks for a `travel` that owns the attribute `start-date` with the value of `2013-12-22` in the `match` clause. 
-We then disassociate the `travel` instance `$t` from the attribute `$st` with the `delete $t has start-date $st` clause.
+We then disassociate the `travel` instance `$t` from the attribute `$st` with the `delete $t has $st` clause.
 
 This will _not_ delete the entire instance of type `start-date` and value `2013-12-22` - it remains associated with any other instance that may own it.
 
 If we had instead written the query as `match $t isa travel, has start-date $st;  $st == 2013-12-22"; delete $st isa start-date;`, 
 we would have deleted the instance of `start-date` with value `2013-12-22` and its association with all other concept types that previously owned it.
 
-Note also that you must not specify a type for the attribute when deleting, as this creates a derived isa. You must use `delete $t has $st`, _not_  `delete $t has startdate $st`.
+Note also that you must not specify a type for the attribute when deleting, as this creates a derived `isa` constraint on the attribute. You must use `delete $t has $st`, _not_ `delete $t has start-date $st`.
 
 ## Delete Role Players from Relations
 


### PR DESCRIPTION
## What is the goal of this PR?

Specifying a type in the deletion of an ownership constraint is no longer legal, due to creating a derived isa constraint. We updated the documentation to reflect this.

## What are the changes implemented in this PR?

- Changed syntax of delete in documentation examples
- Added line to clarify this change.