### PR TITLE
Clean up Rules section and note valid rule forms

### DIFF
--- a/09-schema/03-rules.md
+++ b/09-schema/03-rules.md
@@ -181,7 +181,7 @@ GraqlDefine query = Graql.define(
 [tab:end]
 </div>
 
-Here, we apply a constant attribute that may or may not previously exist in the database, as a few fact that is owned by `$p`, which is any person with name "Annabelle".
+Here, we apply a constant attribute that may or may not previously exist in the database, as a new fact that is owned by `$p`, which is any person with name "Annabelle".
 
 3. Inferring an ownership of a variable attribute
 

--- a/09-schema/03-rules.md
+++ b/09-schema/03-rules.md
@@ -174,7 +174,7 @@ GraqlDefine query = Graql.define(
             var("p").isa("person").has("name", "Annabelle")
         )
     ).then(
-        var(p).has("nickname", "Anne")
+        var("p").has("nickname", "Anne")
     )
 );
 ```
@@ -213,7 +213,7 @@ GraqlDefine query = Graql.define(
             var("r").has("graduated", var("is-graduated"))
         )
     ).then(
-        var(p).has("graduated", var("is-graduated"))
+        var("p").has("graduated", var("is-graduated"))
     )
 );
 ```

--- a/09-schema/03-rules.md
+++ b/09-schema/03-rules.md
@@ -234,7 +234,7 @@ Besides conforming to one of the three patterns previously outlined, we also req
 
 ### Advanced Usage
 
-When inferring relations, it is possible variabilise any part of the `then` of the rule. For example, if we know we wanted a rule to infer many differt types of relations, we could propose a rule such as:
+When inferring relations, it is possible to variabilise any part of the `then` of the rule. For example, if we know we wanted a rule to infer many different types of relations, we could propose a rule such as:
 
 <div class="tabs dark">
 
@@ -275,9 +275,9 @@ This rule will make every relation transitive.
 
 There are two general tips for making queries with reasoning execute faster:
 1. Adding a limit to the query. Without a limit, the reasoning engine is forced to explore all possible ways to answer the query exhaustively. If you only need 1 answer, adding `limit 1` to the `match` query can improve query times.
-2. Using a transaction for multiple reasoning queries. Because inferred facts are cleared between transactions, running the same or similar queries within one transaction can reuse previously found facts. Combined with a `limit` on the query, it might be possible to avoid having to do any new reasoning at all.
+2. Using the same transaction for multiple reasoning queries. Because inferred facts are cleared between transactions, running the same or similar queries within one transaction can reuse previously found facts. Combined with a `limit` on the query, it might be possible to avoid having to do any new reasoning at all.
 
-For complex queries, it can also be benficial to add more CPU cores, as the reasoning engine is able to explore more paths in the database concurrently.
+For complex queries, it can also be beneficial to add more CPU cores, as the reasoning engine is able to explore more paths in the database concurrently.
 
 ## Delete a Rule
 

--- a/09-schema/03-rules.md
+++ b/09-schema/03-rules.md
@@ -276,7 +276,8 @@ This rule will make every relation transitive.
 There are two general tips for making queries with reasoning execute faster:
 1. Adding a limit to the query. Without a limit, the reasoning engine is forced to explore all possible ways to answer the query exhaustively. If you only need 1 answer, adding `limit 1` to the `match` query can improve query times.
 2. Using a transaction for multiple reasoning queries. Because inferred facts are cleared between transactions, running the same or similar queries within one transaction can reuse previously found facts. Combined with a `limit` on the query, it might be possible to avoid having to do any new reasoning at all.
- 
+
+For complex queries, it can also be benficial to add more CPU cores, as the reasoning engine is able to explore more paths in the database concurrently.
 
 ## Delete a Rule
 

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,5 +27,5 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "122efc258803437e8dea1aa3ab761f848494b165",
+        tag = "2.0.0-alpha-8",
     )


### PR DESCRIPTION
## What is the goal of this PR?

We update the `Rules` section to reflect the new allowed conclusion of rules, and make it clear that rules do not persist inferences or retain them past a transaction boundary. We also add sections on validation, advanced usage and optimisation.

## What are the changes implemented in this PR?
* Rewrite repetitive sections
* Update rules to not use negations for now
* Includes example of the three allowed shapes of rules
* Add section on types of rules allowed, validation, optimisation and advanced usage
