### PR TITLE
Fix a rule containing an invalid !=

### DIFF
--- a/files/social-network/schema.gql
+++ b/files/social-network/schema.gql
@@ -893,7 +893,9 @@ define
 		when {
 			(content: $sc, by: $sb, hidden-from: $hf) isa friends-with-exclusion-sharing;
 			(friend: $sb, $f) isa friendship;
-			$f != $hf;
+			$f has email $fe;
+			$hf has email $hfe;
+			$fe != $hfe;
 		} then {
 			(content: $sc, grantee: $f) isa content-permission;
 		};


### PR DESCRIPTION
## What is the goal of this PR?

Fix a rule that contains a `!=` between entities. This rule should not pass rule validation, as per https://github.com/graknlabs/grakn/issues/6227.

## What are the changes implemented in this PR?

- Quick fix, maintains the same behaviour.
