### PR TITLE
Update Type.getLabel

### DIFF
--- a/04-concept-api/references/role_type.yml
+++ b/04-concept-api/references/role_type.yml
@@ -27,34 +27,34 @@ methods:
   - method:
     common: &method-getScope
       title: Retrieve scope (Local)
-      description: Retrieves the scope of the role type.
+      description: Retrieves the scope (defined relation label) of the role type.
       returns:
         - String
     java:
       <<: *method-getScope
-      method: type.getScope();
+      method: roleType.getLabel().scope();
     javascript:
       <<: *method-getScope
-      method: type.getScope();
+      method: roleType.getLabel().scope();
     python:
       <<: *method-getScope
-      method: type.get_scope()
+      method: role_type.get_label().scope()
 
   - method:
     common: &method-getScopedLabel
       title: Retrieve scoped label (Local)
-      description: Retrieves the scoped label of the role type.
+      description: Retrieves the scoped label (relation:role) of the role type.
       returns:
         - String
     java:
       <<: *method-getScopedLabel
-      method: type.getScopedLabel();
+      method: roleType.getLabel().scopedName();
     javascript:
       <<: *method-getScopedLabel
-      method: type.getScopedLabel();
+      method: roleType.getLabel().scopedName();
     python:
       <<: *method-getScopedLabel
-      method: type.get_scoped_label()
+      method: role_type.get_label().scoped_name()
 
   - method:
     common: &method-getSupertype

--- a/04-concept-api/references/type.yml
+++ b/04-concept-api/references/type.yml
@@ -32,13 +32,13 @@ methods:
         - String
     java:
       <<: *method-getLabel
-      method: type.getLabel();
+      method: type.getLabel().name();
     javascript:
       <<: *method-getLabel
-      method: type.getLabel();
+      method: type.getLabel().name();
     python:
       <<: *method-getLabel
-      method: type.get_label()
+      method: type.get_label().name()
 
   - method:
     common: &method-isRoot


### PR DESCRIPTION
## What is the goal of this PR?

We updated Type.getLabel, which now returns a `Label` object that provides `name` (applicable to all `Type`) and `scope` and `scopedName` (applicable to `RoleType`)

## What are the changes implemented in this PR?

Update Type.getLabel
