### PR TITLE
Add console scripting, database schema, and transaction options

### DIFF
--- a/02-console/01-console.md
+++ b/02-console/01-console.md
@@ -61,6 +61,7 @@ Give any of these commands inside a console at the `>` prompt.
 | `database create <db>`                    | Create a database with name `<db>` on the server.                                                                      |
 | `database list`                           | List the databases on the server                                                                                       |
 | `database delete <db>`                    | Delete a database with name `<db>` on the server                                                                       |
+| `database schema <db>`                    | Print schema of a database with name `<db>` on the server                                                              |
 | `transaction <db> schema|data read|write` | Start a transaction to database `<db>` with session type `schema` or `data`, and transaction type `write` or `read`.   |
 | `help`                                    | Print help menu                                                                                                        |
 | `clear`                                   | Clear console screen                                                                                                   |

--- a/02-console/01-console.md
+++ b/02-console/01-console.md
@@ -108,6 +108,56 @@ When connecting to Grakn Cluster, the following flags are additionally available
 | `--read-any-replica` | true|false     | Allow or disallow reads from any replica |
 
 
+### Non-interactive mode
+
+To invoke console in a non-interactive manner, we can define a script file that contains the list of commands to run, then invoke console with `./grakn console --script=<script>`. We can also specify the commands to run directly from the command line using `./grakn console --command=<command1> --command=<command2> ...`.
+
+For example given the following command script file:
+
+```
+database create test
+transaction test schema write
+    define person sub entity;
+    commit
+transaction test data write
+    insert $x isa person;
+    commit
+transaction test data read
+    match $x isa person;
+    close
+database delete test
+```
+
+You will see the following output:
+
+```
+> ./grakn console --script=script                                                                                                                                                                                                                    73.830s
++ database create test
+Database 'test' created
++ transaction test schema write
+++ define person sub entity;
+Concepts have been defined
+++ commit
+Transaction changes committed
++ transaction test data write
+++ insert $x isa person;
+{ $x iid 0x966e80017fffffffffffffff isa person; }
+answers: 1, duration: 87 ms
+++ commit
+Transaction changes committed
++ transaction test data read
+++ match $x isa person;
+{ $x iid 0x966e80018000000000000000 isa person; }
+answers: 1, duration: 25 ms
+++ close
+Transaction closed without committing changes
++ database delete test
+Database 'test' deleted
+```
+
+The indentation in the script file are only for visual guide and will be ignored by the console. Each line in the script is interpreted as one command, so multiline query is not available in this mode.
+
+
 ## Examples
 
 The following example illustrates how to create a database, define a schema, and insert some data into Grakn.

--- a/02-console/01-console.md
+++ b/02-console/01-console.md
@@ -82,6 +82,32 @@ Give any of these commands inside a console at the `>` prompt.
 | `clear`         | Clear console screen                                                                                                                            |
 | `exit`          | Exit console                                                                                                                                    |
 
+### Transaction options
+
+The following flags can be passed to the `transaction <db> schema|data read|write` command, for example:
+
+```
+transaction grakn data read --infer=true
+```
+
+| Option                          | Allowed values | Description                                   |
+|---------------------------------|----------------|-----------------------------------------------|
+| `--infer`                       | `true|false`   | Enable or disable inference                   |
+| `--trace-inference`             | `true|false`   | Enable or disable inference tracing           |
+| `--explain`                     | `true|false`   | Enable or disable inference explanations      |
+| `--parallel`                    | `true|false`   | Enable or disable parallel query execution    |
+| `--batch-size`                  | `1..[max int]` | Set RPC answer batch size                     |
+| `--prefetch`                    | `true|false`   | Enable or disable RPC answer prefetch         |
+| `--session-idle-timeout`        | `1..[max int]` | Kill idle session timeout (ms)                |
+| `--schema-lock-acquire-timeout` | `1..[max int]` | Acquire exclusive schema session timeout (ms) |
+
+When connecting to Grakn Cluster, the following flags are additionally available:
+
+| Option               | Allowed values | Description                              |
+|----------------------|----------------|------------------------------------------|
+| `--read-any-replica` | true|false     | Allow or disallow reads from any replica |
+
+
 ## Examples
 
 The following example illustrates how to create a database, define a schema, and insert some data into Grakn.

--- a/03-client-api/02-python.md
+++ b/03-client-api/02-python.md
@@ -138,7 +138,7 @@ To view examples of running various Graql queries using the Grakn Client Python,
 
 | Client Python  | Grakn Core                  | Grakn Cluster  | Python         |
 | :------------: | :-------------------------: | :----------:   | :------------: |
-| 2.0.0          | 2.0.0                       | N/A            | \>= 3.6        |
+| 2.0.0          | 2.0.0                       | 2.0.0          | \>= 3.6        |
 | 1.8.0          | 1.8.0 to 1.8.4              | N/A            | \>= 3.5, < 3.8 |
 | 1.7.2          | 1.7.1, 1.7.2                | N/A            | \>= 2.7        |
 | 1.7.1          | 1.7.1                       | N/A            | \>= 2.7        |      

--- a/03-client-api/03-nodejs.md
+++ b/03-client-api/03-nodejs.md
@@ -156,7 +156,7 @@ To view examples of running various Graql queries using the Grakn Client Node.js
 
 | Client Node.js | Grakn Core                  | Grakn Cluster  |  Node     |
 | :------------: | :-------------------------: | :------------: | :-------: |
-| 2.0.0          | 2.0.0                       | N/A            | \>= 14.15 |
+| 2.0.0          | 2.0.0                       | 2.0.0          | \>= 14.15 |
 | 1.8.0          | 1.8.0 to 1.8.4              | N/A            | \>= 6.5   |
 | 1.7.0          | 1.7.1, 1.7.2                | N/A            | \>= 6.5   |
 | 1.6.0          | 1.6.0 to 1.6.2              | 1.6.2          | \>= 6.5   |

--- a/06-management/03-migration-and-backup.md
+++ b/06-management/03-migration-and-backup.md
@@ -45,12 +45,15 @@ Importing a backup will not delete existing data in the database, so you should 
 
 ### Schema Migration
 
-The first step of migration is to migrate your schema. The  `grakn server schema` command allows you to get the current schema of a Grakn database as a single Graql `define` query. This schema query can then be loaded via `grakn console` to the new server.
+The first step of migration is to migrate your schema. The `database schema my-database-name` command in Grakn Console allows you to get the current schema of a Grakn database as a single Graql `define` query. This schema query can then be loaded via the Console to the new server.
 
 Export the old schema:
 ```
-old/grakn server schema [database] > schema.gql
+old/grakn console
+database schema [database]
 ```
+
+Copy the schema into a file named `schema.gql`.
 
 You can skip the step of exporting schema if you already have a copy of your schema to import.
 


### PR DESCRIPTION
## What is the goal of this PR?

We've added the command "database schema", a set of configurable Options when opening a transaction, and a description of non-interactive mode to the API reference for Console.

## What are the changes implemented in this PR?

Add "database schema", transaction options & non-interactive mode to Console reference
