### PR TITLE
Add getRules to LogicManager API

### DIFF
--- a/04-concept-api/references/logic_manager.yml
+++ b/04-concept-api/references/logic_manager.yml
@@ -2,6 +2,26 @@
 title: "LogicManager"
 methods:
   - method:
+      common: &method-getRules
+        title: Retrieve rules
+        description: Retrieves all defined rules
+      java:
+        <<: *method-getRules
+        method: transaction.logic().getRules();
+        returns:
+          - "Stream<[`Rule`](../concept-api/rule?tab=java#rule-methods)>"
+      javascript:
+        <<: *method-getRules
+        method: await transaction.logic().getRules();
+        returns:
+          - "Stream of [`Rule`](../concept-api/rule?tab=javascript#rule-methods)"
+      python:
+        <<: *method-getRules
+        method: transaction.logic().get_rules()
+        returns:
+          - "Iterator of [`Rule`](../concept-api/rule?tab=python#rule-methods)"
+
+  - method:
     common: &method-getRule
       title: Retrieve a Rule
       description: Retrieves the Rule that has the given label.


### PR DESCRIPTION
## What is the goal of this PR?

Document the missing method `getRules()` to retrieve all rules from the LogicManager in the client API

## What are the changes implemented in this PR?
* Add method `getRules()` as LogicManager documentation