### PR TITLE
Fix incorrect data in quickstart

### DIFF
--- a/11-query/03-insert-query.md
+++ b/11-query/03-insert-query.md
@@ -138,13 +138,13 @@ We can add role players to a relation by `match`ing the relation and the concept
 [tab:TypeQL]
 <!-- test-ignore -->
 ```TypeQL
-## inserting the new friend to a friendship list
+## inserting the new friendship to a friendship list
 match
   $julie isa person, has full-name "Julie Hutchinson";
   $miriam isa person, has full-name "Miriam Morton";
-  ($julie, $miriam) isa friendship;
+  $f ($julie, $miriam) isa friendship;
   $list (owner: $miriam) isa friendship-list, has title "best friends";
-insert $list (listed: $julie);
+insert $list (listed: $f);
 ```
 [tab:end]
 
@@ -154,10 +154,10 @@ insert $list (listed: $julie);
 TypeQLInsert insert_query = TypeQL.match(
   var("julie").isa("person").has("name", "Julie Hutchinson"),
   var("miriam").isa("person").has("name", "Miriam Hutchinson"),
-  var().rel(var("julie")).rel(var("miriam")).isa("friendship"),
+  var("f").rel(var("julie")).rel(var("miriam")).isa("friendship"),
   var(list).rel("owner", var("miriam")).isa("friendship-list").has("title", "best friends")
 ).insert(
-  var("list").rel("listed", var("julie"))
+  var("list").rel("listed", var("f"))
 );
 ```
 [tab:end]

--- a/files/social-network/data.tql
+++ b/files/social-network/data.tql
@@ -338,7 +338,7 @@ $fri-req-14 (friend-requester: $per-14, friend-respondent: $per-16, friendship: 
 $fri-14 (friend: $per-14, friend: $per-16) isa friendship;
 
 ## FRIENDSHIP LIST
-(owner: $per-1, listed: $per-2) isa friendship-list, has title "best friends";
+(owner: $per-1, listed: $fri-1) isa friendship-list, has title "best friends";
 
 ## TIMELINES
 


### PR DESCRIPTION
## What is the goal of this PR?

Docs quickstart as of #543 contains an error in the data - this PR uses the correct role players for the `friendship-list` data point that was added.

## What are the changes implemented in this PR?

* fix the example data
* update the example that utilised the example data