### PR TITLE
Describe how to configure Logback in client-java

### DIFF
--- a/03-client-api/01-java.md
+++ b/03-client-api/01-java.md
@@ -165,7 +165,7 @@ To view examples of running various TypeQL queries using the Java client, head o
 - [Aggregate](../11-query/06-aggregate-query.md)
 
 ## Logging
-By default, Client Java uses `logback` to print errors and debugging info to standard output. As it is quite verbose, we recommend that in most scenarios you create a Logback configuration file and set the minimum log level to ERROR. You can do so with the following steps:
+By default, Client Java uses Logback to print errors and debugging info to standard output. As it is quite verbose, we recommend that in most scenarios you create a Logback configuration file and set the minimum log level to ERROR. You can do so with the following steps:
 
 1. Create a file in your `resources` path (`src/main/resources` by default in a Maven project) named `logback.xml`.
 2. Copy the following document into `logback.xml`:

--- a/03-client-api/01-java.md
+++ b/03-client-api/01-java.md
@@ -164,6 +164,25 @@ To view examples of running various TypeQL queries using the Java client, head o
 - [Update](../11-query/05-update-query.md)
 - [Aggregate](../11-query/06-aggregate-query.md)
 
+## Logging
+By default, Client Java uses `logback` to print errors and debugging info to standard output. As it is quite verbose, we recommend that in most scenarios you create a Logback configuration file and set the minimum log level to ERROR. You can do so with the following steps:
+
+1. Create a file in your `resources` path (`src/main/resources` by default in a Maven project) named `logback.xml`.
+2. Copy the following document into `logback.xml`:
+```xml
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>
+```
 <hr style="margin-top: 40px;" />
 
 ## API Reference


### PR DESCRIPTION
## What is the goal of this PR?

A common complaint when using `typedb-client-java` is the large number of Netty and gRPC logs. They are actually easy to disable, but only if you know how. So we added brief instructions to the Client Java reference page.

## What are the changes implemented in this PR?

Describe how to configure Logback in client-java