### PR TITLE
Add "asRemote" to Remote Concept API code examples

### DIFF
--- a/04-concept-api/references/attribute.yml
+++ b/04-concept-api/references/attribute.yml
@@ -63,17 +63,17 @@ methods:
           default: N/A
     java:
       <<: *method-owners
-      method: attribute.owners(Type ownerType);
+      method: attribute.asRemote(Transaction tx).getOwners(Type ownerType);
       returns:
         - "Stream<[`Thing`](../concept-api/thing?tab=java#thing-methods)>"
     javascript:
       <<: *method-owners
-      method: attribute.owners(ownerType);
+      method: attribute.asRemote(tx).getOwners(ownerType);
       returns:
         - "[Stream](../client-api/nodejs#stream) of [`Thing`](../concept-api/thing?tab=javascript#thing-methods)"
     python:
       <<: *method-owners
-      method: attribute.owners(ownerType)
+      method: attribute.as_remote(tx).get_owners(ownerType)
       returns:
         - "Iterator of [`Thing`](../concept-api/thing?tab=python#thing-methods)"
 
@@ -104,7 +104,7 @@ methods:
 
   - method:
     common: &method-isboolean
-      title: Check if value is of type boolean
+      title: Check if value is of type boolean (Local)
       description: Returns true if the attribute value is of type boolean. Otherwise, returns false.
     java:
       <<: *method-isboolean
@@ -124,7 +124,7 @@ methods:
 
   - method:
     common: &method-islong
-      title: Check if value is of type long
+      title: Check if value is of type long (Local)
       description: Returns true if the attribute value is of type long. Otherwise, returns false.
     java:
       <<: *method-islong
@@ -144,7 +144,7 @@ methods:
 
   - method:
     common: &method-isdouble
-      title: Check if value is of type double
+      title: Check if value is of type double (Local)
       description: Returns true if the attribute value is of type double. Otherwise, returns false.
     java:
       <<: *method-isdouble
@@ -164,7 +164,7 @@ methods:
 
   - method:
     common: &method-isstring
-      title: Check if value is of type string
+      title: Check if value is of type string (Local)
       description: Returns true if the attribute value is of type string. Otherwise, returns false.
     java:
       <<: *method-isstring
@@ -184,7 +184,7 @@ methods:
 
   - method:
     common: &method-isdatetime
-      title: Check if value is of type datetime
+      title: Check if value is of type datetime (Local)
       description: Returns true if the attribute value is of type datetime. Otherwise, returns false.
     java:
       <<: *method-isdouble

--- a/04-concept-api/references/attribute_type.yml
+++ b/04-concept-api/references/attribute_type.yml
@@ -38,7 +38,7 @@ methods:
         - void
     python:
       <<: *method-setsupertype
-      method: attributeType.as_remote().set_supertype(attribute_type)
+      method: attributeType.as_remote(tx).set_supertype(attribute_type)
       accepts:
         <<: *accepts-setsupertype
         param:
@@ -63,7 +63,7 @@ methods:
         - "[`Stream`](../client-api/nodejs#stream) of [`AttributeType`](../concept-api/type?tab=javascript#attributetype-methods)"
     python:
       <<: *method-getSubtypes
-      method: attributeType.as_remote().get_subtypes()
+      method: attributeType.as_remote(tx).get_subtypes()
       returns:
         - Iterator of [`AttributeType`](../concept-api/type?tab=python#attributetype-methods)
 
@@ -83,7 +83,7 @@ methods:
         - "[`Stream`](../client-api/nodejs#stream) of [`Attribute`](../concept-api/thing?tab=javascript#attribute-methods)"
     python:
       <<: *method-getInstances
-      method: attributeType.as_remote().get_instances()
+      method: attributeType.as_remote(tx).get_instances()
       returns:
         - Iterator of [`Attribute`](../concept-api/thing?tab=python#attribute-methods)
 
@@ -110,7 +110,7 @@ methods:
         - "[`Stream`](../client-api/nodejs#stream) of [`Thing`](../concept-api/thing?tab=javascript#thing-methods)"
     python:
       <<: *method-getOwners
-      method: attributeType.as_remote().getOwners(onlyKey)
+      method: attributeType.as_remote(tx).get_owners(onlyKey)
       returns:
         - Iterator of [`Thing`](../concept-api/thing?tab=python#thing-methods)
 

--- a/04-concept-api/references/attribute_type.yml
+++ b/04-concept-api/references/attribute_type.yml
@@ -28,17 +28,17 @@ methods:
           default: N/A
     java:
       <<: *method-setsupertype
-      method: attributeType.setSupertype(AttributeType attributeType);
+      method: attributeType.asRemote(Transaction tx).setSupertype(AttributeType attributeType);
       returns:
         - void
     javascript:
       <<: *method-setsupertype
-      method: attributeType.setSupertype(attributeType);
+      method: attributeType.asRemote(tx).setSupertype(attributeType);
       returns:
         - void
     python:
       <<: *method-setsupertype
-      method: attributeType.set_supertype(attribute_type)
+      method: attributeType.as_remote().set_supertype(attribute_type)
       accepts:
         <<: *accepts-setsupertype
         param:
@@ -53,17 +53,17 @@ methods:
       description: Retrieves all direct and indirect subtypes of the AttributeType.
     java:
       <<: *method-getSubtypes
-      method: type.getSubtypes();
+      method: attributeType.asRemote(Transaction tx).getSubtypes();
       returns:
         - Stream<[`AttributeType`](../concept-api/type?tab=java#attributetype-methods)>
     javascript:
       <<: *method-getSubtypes
-      method: type.getSubtypes()
+      method: attributeType.asRemote(tx).getSubtypes()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`AttributeType`](../concept-api/type?tab=javascript#attributetype-methods)"
     python:
       <<: *method-getSubtypes
-      method: type.get_subtypes()
+      method: attributeType.as_remote().get_subtypes()
       returns:
         - Iterator of [`AttributeType`](../concept-api/type?tab=python#attributetype-methods)
 
@@ -73,17 +73,17 @@ methods:
       description: Retrieves all Attributes that are instances of this Type.
     java:
       <<: *method-getInstances
-      method: type.getInstances();
+      method: attributeType.asRemote(Transaction tx).getInstances();
       returns:
         - Stream<[`Attribute`](../concept-api/thing?tab=java#attribute-methods)>
     javascript:
       <<: *method-getInstances
-      method: type.getInstances()
+      method: attributeType.asRemote(tx).getInstances()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`Attribute`](../concept-api/thing?tab=javascript#attribute-methods)"
     python:
       <<: *method-getInstances
-      method: type.get_instances()
+      method: attributeType.as_remote().get_instances()
       returns:
         - Iterator of [`Attribute`](../concept-api/thing?tab=python#attribute-methods)
 
@@ -100,17 +100,17 @@ methods:
           default: false
     java:
       <<: *method-getOwners
-      method: type.getOwners(boolean onlyKey);
+      method: attributeType.asRemote(Transaction tx).getOwners(boolean onlyKey);
       returns:
         - Stream<[`Thing`](../concept-api/thing?tab=java#thing-methods)>
     javascript:
       <<: *method-getOwners
-      method: type.getOwners(onlyKey)
+      method: attributeType.asRemote(tx).getOwners(onlyKey)
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`Thing`](../concept-api/thing?tab=javascript#thing-methods)"
     python:
       <<: *method-getOwners
-      method: type.getOwners(onlyKey)
+      method: attributeType.as_remote().getOwners(onlyKey)
       returns:
         - Iterator of [`Thing`](../concept-api/thing?tab=python#thing-methods)
 
@@ -147,13 +147,13 @@ methods:
         - boolean
     java:
       <<: *method-isboolean
-      method: attribute.isBoolean();
+      method: attributeType.isBoolean();
     javascript:
       <<: *method-isboolean
-      method: attribute.isBoolean();
+      method: attributeType.isBoolean();
     python:
       <<: *method-isboolean
-      method: attribute.is_boolean()
+      method: attributeType.is_boolean()
 
   - method:
     common: &method-islong
@@ -163,13 +163,13 @@ methods:
         - boolean
     java:
       <<: *method-islong
-      method: attribute.isLong();
+      method: attributeType.isLong();
     javascript:
       <<: *method-islong
-      method: attribute.isLong();
+      method: attributeType.isLong();
     python:
       <<: *method-islong
-      method: attribute.is_long()
+      method: attributeType.is_long()
 
   - method:
     common: &method-isdouble
@@ -179,13 +179,13 @@ methods:
         - boolean
     java:
       <<: *method-isdouble
-      method: attribute.isDouble();
+      method: attributeType.isDouble();
     javascript:
       <<: *method-isdouble
-      method: attribute.isDouble();
+      method: attributeType.isDouble();
     python:
       <<: *method-isdouble
-      method: attribute.is_double()
+      method: attributeType.is_double()
 
   - method:
     common: &method-isstring
@@ -195,13 +195,13 @@ methods:
         - boolean
     java:
       <<: *method-isstring
-      method: attribute.isString();
+      method: attributeType.isString();
     javascript:
       <<: *method-isstring
-      method: attribute.isString();
+      method: attributeType.isString();
     python:
       <<: *method-isstring
-      method: attribute.is_string()
+      method: attributeType.is_string()
 
   - method:
     common: &method-isdatetime
@@ -211,10 +211,10 @@ methods:
         - boolean
     java:
       <<: *method-isdatetime
-      method: attribute.isDateTime();
+      method: attributeType.isDateTime();
     javascript:
       <<: *method-isdatetime
-      method: attribute.isDateTime();
+      method: attributeType.isDateTime();
     python:
       <<: *method-isdatetime
-      method: attribute.is_datetime()
+      method: attributeType.is_datetime()

--- a/04-concept-api/references/boolean_attribute_type.yml
+++ b/04-concept-api/references/boolean_attribute_type.yml
@@ -14,13 +14,13 @@ methods:
           default: N/A
     java:
       <<: *method-put
-      method: booleanAttributeType.put(boolean value);
+      method: booleanAttributeType.asRemote(Transaction tx).put(boolean value);
     javascript:
       <<: *method-put
-      method: await booleanAttributeType.put(value);
+      method: await booleanAttributeType.asRemote(tx).put(value);
     python:
       <<: *method-put
-      method: booleanAttributeType.put(value)
+      method: booleanAttributeType.as_remote(tx).put(value)
 
   - method:
     common: &method-get
@@ -37,13 +37,13 @@ methods:
           default: N/A
     java:
       <<: *method-get
-      method: booleanAttributeType.get(Boolean value);
+      method: booleanAttributeType.asRemote(Transaction tx).get(Boolean value);
     javascript:
       <<: *method-get
-      method: await booleanAttributeType.get(value);
+      method: await booleanAttributeType.asRemote(tx).get(value);
     python:
       <<: *method-get
-      method: booleanAttributeType.get(value)
+      method: booleanAttributeType.as_remote(tx).get(value)
 
   - method:
     common: &method-setsupertype
@@ -58,17 +58,17 @@ methods:
           default: N/A
     java:
       <<: *method-setsupertype
-      method: attributeType.setSupertype(AttributeType.Boolean booleanAttributeType);
+      method: booleanAttributeType.asRemote(Transaction tx).setSupertype(AttributeType.Boolean booleanAttributeType);
       returns:
         - void
     javascript:
       <<: *method-setsupertype
-      method: attributeType.setSupertype(booleanAttributeType);
+      method: booleanAttributeType.asRemote(tx).setSupertype(booleanAttributeType);
       returns:
         - void
     python:
       <<: *method-setsupertype
-      method: attributeType.set_supertype(boolean_attribute_type)
+      method: booleanAttributeType.as_remote(tx).set_supertype(boolean_attribute_type)
       accepts:
         <<: *accepts-setsupertype
         param:
@@ -83,17 +83,17 @@ methods:
       description: Retrieves all direct and indirect subtypes of the BooleanAttributeType.
     java:
       <<: *method-getSubtypes
-      method: type.getSubtypes();
+      method: booleanAttributeType.asRemote(Transaction tx).getSubtypes();
       returns:
         - Stream<[`AttributeType.Boolean`](../concept-api/type?tab=java#booleanattributetype-methods)>
     javascript:
       <<: *method-getSubtypes
-      method: type.getSubtypes()
+      method: booleanAttributeType.asRemote(tx).getSubtypes()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`BooleanAttributeType`](../concept-api/type?tab=javascript#booleanattributetype-methods)>"
     python:
       <<: *method-getSubtypes
-      method: type.get_subtypes()
+      method: booleanAttributeType.as_remote(tx).get_subtypes()
       returns:
         - Iterator of [`BooleanAttributeType`](../concept-api/type?tab=python#booleanattributetype-methods)
 
@@ -103,17 +103,17 @@ methods:
       description: Retrieves all BooleanAttributes that are instances of this Type.
     java:
       <<: *method-getInstances
-      method: type.getInstances();
+      method: booleanAttributeType.asRemote(Transaction tx).getInstances();
       returns:
         - Stream<[`BooleanAttribute`](../concept-api/thing?tab=java#attribute-methods)>
     javascript:
       <<: *method-getInstances
-      method: type.getInstances()
+      method: booleanAttributeType.asRemote(tx).getInstances()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`BooleanAttribute`](../concept-api/thing?tab=javascript#attribute-methods)"
     python:
       <<: *method-getInstances
-      method: type.get_instances()
+      method: booleanAttributeType.as_remote(tx).get_instances()
       returns:
         - Iterator of [`BooleanAttribute`](../concept-api/thing?tab=python#attribute-methods)
 

--- a/04-concept-api/references/concept.yml
+++ b/04-concept-api/references/concept.yml
@@ -342,32 +342,31 @@ methods:
   - method:
     common: &method-delete
       title: Delete concept
-      method: concept.delete();
+      method: concept.asRemote(Transaction tx).delete();
       returns:
         - void
     java:
       <<: *method-delete
     javascript:
       <<: *method-delete
-      method: await concept.delete();
+      method: await concept.asRemote(tx).delete();
     python:
       <<: *method-delete
-      method: concept.delete()
+      method: concept.as_remote(tx).delete()
       returns:
         - None
         
   - method:
     common: &method-isDeleted
       title: Check if the concept has been deleted
-      method: concept.isDeleted();
       returns:
         - boolean
     java:
       <<: *method-isDeleted
-      method: concept.isDeleted()
+      method: concept.asRemote(Transaction tx).isDeleted()
     javascript:
       <<: *method-isDeleted
-      method: await concept.isDeleted();
+      method: await concept.asRemote(tx).isDeleted();
     python:
       <<: *method-isDeleted
-      method: concept.is_deleted()
+      method: concept.as_remote(tx).is_deleted()

--- a/04-concept-api/references/datetime_attribute_type.yml
+++ b/04-concept-api/references/datetime_attribute_type.yml
@@ -13,7 +13,7 @@ methods:
           default: N/A
     java:
       <<: *method-put
-      method: datetimeAttributeType.put(LocalDateTime value);
+      method: datetimeAttributeType.asRemote(Transaction tx).put(LocalDateTime value);
       accepts:
         <<: *method-put-accepts
         param:
@@ -21,7 +21,7 @@ methods:
           type: LocalDateTime
     javascript:
       <<: *method-put
-      method: await dateTimeAttributeType.put(value);
+      method: await dateTimeAttributeType.asRemote(tx).put(value);
       accepts:
         <<: *method-put-accepts
         param:
@@ -29,7 +29,7 @@ methods:
           type: Date
     python:
       <<: *method-put
-      method: dateTimeAttributeType.put(value)
+      method: dateTimeAttributeType.as_remote(tx).put(value)
       accepts:
         <<: *method-put-accepts
         param:
@@ -50,7 +50,7 @@ methods:
           default: N/A
     java:
       <<: *method-get
-      method: datetimeAttributeType.get(LocalDateTime value);
+      method: datetimeAttributeType.asRemote(Transaction tx).get(LocalDateTime value);
       accepts:
         <<: *method-get-accepts
         param:
@@ -58,7 +58,7 @@ methods:
           type: LocalDateTime
     javascript:
       <<: *method-get
-      method: await dateTimeAttributeType.get(value);
+      method: await dateTimeAttributeType.asRemote(tx).get(value);
       accepts:
         <<: *method-get-accepts
         param:
@@ -66,7 +66,7 @@ methods:
           type: number
     python:
       <<: *method-get
-      method: dateTimeAttributeType.get(value)
+      method: dateTimeAttributeType.as_remote(tx).get(value)
       accepts:
         <<: *method-get-accepts
         param:
@@ -86,17 +86,17 @@ methods:
           default: N/A
     java:
       <<: *method-setsupertype
-      method: attributeType.setSupertype(AttributeType.DateTime datetimeAttributeType);
+      method: attributeType.asRemote(Transaction tx).setSupertype(AttributeType.DateTime datetimeAttributeType);
       returns:
         - void
     javascript:
       <<: *method-setsupertype
-      method: attributeType.setSupertype(datetimeAttributeType);
+      method: attributeType.asRemote(tx).setSupertype(datetimeAttributeType);
       returns:
         - void
     python:
       <<: *method-setsupertype
-      method: attributeType.set_supertype(datetime_attribute_type)
+      method: attributeType.as_remote(tx).set_supertype(datetime_attribute_type)
       accepts:
         <<: *accepts-setsupertype
         param:
@@ -111,17 +111,17 @@ methods:
       description: Retrieves all direct and indirect subtypes of the DateTimeAttributeType.
     java:
       <<: *method-getSubtypes
-      method: type.getSubtypes();
+      method: type.asRemote(Transaction tx).getSubtypes();
       returns:
         - Stream<[`AttributeType.DateTime`](../concept-api/type?tab=java#datetimeattributetype-methods)>
     javascript:
       <<: *method-getSubtypes
-      method: type.getSubtypes()
+      method: type.asRemote(tx).getSubtypes()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`DateTimeAttributeType`](../concept-api/type?tab=javascript#datetimeattributetype-methods)"
     python:
       <<: *method-getSubtypes
-      method: type.get_subtypes()
+      method: type.as_remote(tx).get_subtypes()
       returns:
         - Iterator of [`DateTimeAttributeType`](../concept-api/type?tab=python#datetimeattributetype-methods)
 
@@ -131,17 +131,17 @@ methods:
       description: Retrieves all DateTimeAttributes that are instances of this Type.
     java:
       <<: *method-getInstances
-      method: type.getInstances();
+      method: type.asRemote(Transaction tx).getInstances();
       returns:
         - Stream<[`DateTimeAttribute`](../concept-api/thing?tab=java#attribute-methods)>
     javascript:
       <<: *method-getInstances
-      method: type.getInstances()
+      method: type.asRemote(tx).getInstances()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`DateTimeAttribute`](../concept-api/thing?tab=javascript#attribute-methods)>"
     python:
       <<: *method-getInstances
-      method: type.get_instances()
+      method: type.as_remote(tx).get_instances()
       returns:
         - Iterator of [`DateTimeAttribute`](../concept-api/thing?tab=python#attribute-methods)
 

--- a/04-concept-api/references/double_attribute_type.yml
+++ b/04-concept-api/references/double_attribute_type.yml
@@ -13,7 +13,7 @@ methods:
           default: N/A
     java:
       <<: *method-put
-      method: doubleAttributeType.put(double value);
+      method: doubleAttributeType.asRemote(Transaction tx).put(double value);
       accepts:
         <<: *method-put-accepts
         param:
@@ -21,7 +21,7 @@ methods:
           type: double
     javascript:
       <<: *method-put
-      method: await doubleAttributeType.put(value);
+      method: await doubleAttributeType.asRemote(tx).put(value);
       accepts:
         <<: *method-put-accepts
         param:
@@ -29,7 +29,7 @@ methods:
           type: number
     python:
       <<: *method-put
-      method: doubleAttributeType.put(value)
+      method: doubleAttributeType.as_remote(tx).put(value)
       accepts:
         <<: *method-put-accepts
         param:
@@ -50,7 +50,7 @@ methods:
           default: N/A
     java:
       <<: *method-get
-      method: doubleAttributeType.get(double value);
+      method: doubleAttributeType.asRemote(Transaction tx).get(double value);
       accepts:
         <<: *method-get-accepts
         param:
@@ -58,7 +58,7 @@ methods:
           type: long
     javascript:
       <<: *method-get
-      method: await doubleAttributeType.get(value);
+      method: await doubleAttributeType.asRemote(tx).get(value);
       accepts:
         <<: *method-get-accepts
         param:
@@ -66,7 +66,7 @@ methods:
           type: number
     python:
       <<: *method-get
-      method: doubleAttributeType.get(value)
+      method: doubleAttributeType.as_remote(tx).get(value)
       accepts:
         <<: *method-get-accepts
         param:
@@ -86,17 +86,17 @@ methods:
           default: N/A
     java:
       <<: *method-setsupertype
-      method: attributeType.setSupertype(AttributeType.Double doubleAttributeType);
+      method: attributeType.asRemote(Transaction tx).setSupertype(AttributeType.Double doubleAttributeType);
       returns:
         - void
     javascript:
       <<: *method-setsupertype
-      method: attributeType.setSupertype(doubleAttributeType);
+      method: attributeType.asRemote(tx).setSupertype(doubleAttributeType);
       returns:
         - void
     python:
       <<: *method-setsupertype
-      method: attributeType.set_supertype(doubleAttributeType)
+      method: attributeType.as_remote(tx).set_supertype(doubleAttributeType)
       accepts:
         <<: *accepts-setsupertype
         param:
@@ -111,17 +111,17 @@ methods:
       description: Retrieves all direct and indirect subtypes of the DoubleAttributeType.
     java:
       <<: *method-getSubtypes
-      method: type.getSubtypes();
+      method: type.asRemote(Transaction tx).getSubtypes();
       returns:
         - Stream<[`AttributeType.Double`](../concept-api/type?tab=java#doubleattributetype-methods)>
     javascript:
       <<: *method-getSubtypes
-      method: type.getSubtypes()
+      method: type.asRemote(tx).getSubtypes()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`DoubleAttributeType`](../concept-api/type?tab=javascript#doubleattributetype-methods)>"
     python:
       <<: *method-getSubtypes
-      method: type.get_subtypes()
+      method: type.as_remote(tx).get_subtypes()
       returns:
         - Iterator of [`DoubleAttributeType`](../concept-api/type?tab=python#doubleattributetype-methods)
 
@@ -131,17 +131,17 @@ methods:
       description: Retrieves all DoubleAttributes that are instances of this Type.
     java:
       <<: *method-getInstances
-      method: type.getInstances();
+      method: type.asRemote(Transaction tx).getInstances();
       returns:
         - Stream<[`DoubleAttribute`](../concept-api/thing?tab=java#attribute-methods)>
     javascript:
       <<: *method-getInstances
-      method: type.getInstances()
+      method: type.asRemote(tx).getInstances()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`DoubleAttribute`](../concept-api/thing?tab=javascript#attribute-methods)>"
     python:
       <<: *method-getInstances
-      method: type.get_instances()
+      method: type.as_remote(tx).get_instances()
       returns:
         - Iterator of [`DoubleAttribute`](../concept-api/thing?tab=python#attribute-methods)
 

--- a/04-concept-api/references/entity_type.yml
+++ b/04-concept-api/references/entity_type.yml
@@ -5,17 +5,17 @@ methods:
       description: Creates and returns a new instance of this EntityType.
     java:
       <<: *method-create
-      method: entityType.create();
+      method: entityType.asRemote(Transaction tx).create();
       returns:
         - "[`Entity`](../concept-api/thing?tab=java#entity-methods)"
     javascript:
       <<: *method-create
-      method: await entityType.create();
+      method: await entityType.asRemote(tx).create();
       returns:
         - "[`Entity`](../concept-api/thing?tab=javascript#entity-methods)"
     python:
       <<: *method-create
-      method: entity_type.create()
+      method: entity_type.as_remote(tx).create()
       returns:
         - "[`Entity`](../concept-api/thing?tab=python#entity-methods)"
       
@@ -32,17 +32,17 @@ methods:
           default: N/A
     java:
       <<: *method-setsupertype
-      method: entityType.setSupertype(EntityType entityType);
+      method: entityType.asRemote(Transaction tx).setSupertype(EntityType entityType);
       returns:
         - void
     javascript:
       <<: *method-setsupertype
-      method: entityType.setSupertype(entityType);
+      method: entityType.asRemote(tx).setSupertype(entityType);
       returns:
         - void
     python:
       <<: *method-setsupertype
-      method: entity_type.set_supertype(entity_type)
+      method: entity_type.as_remote(tx).set_supertype(entity_type)
       returns:
         - None
 
@@ -52,17 +52,17 @@ methods:
       description: Retrieves all direct and indirect subtypes of the EntityType.
     java:
       <<: *method-getSubtypes
-      method: type.getSubtypes();
+      method: type.asRemote(Transaction tx).getSubtypes();
       returns:
         - Stream<[`EntityType`](#entitytype-methods)>
     javascript:
       <<: *method-getSubtypes
-      method: type.getSubtypes()
+      method: type.asRemote(tx).getSubtypes()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`EntityType`](#entitytype-methods)"
     python:
       <<: *method-getSubtypes
-      method: type.get_subtypes()
+      method: type.as_remote(tx).get_subtypes()
       returns:
         - Iterator of [`EntityType`](#entitytype-methods)
 
@@ -72,17 +72,17 @@ methods:
       description: Retrieves all Entity objects that are instances of this Type.
     java:
       <<: *method-getInstances
-      method: type.getInstances();
+      method: type.asRemote(Transaction tx).getInstances();
       returns:
         - Stream<[`Entity`](../concept-api/thing?tab=java#entity-methods)>
     javascript:
       <<: *method-getInstances
-      method: type.getInstances()
+      method: type.asRemote(tx).getInstances()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`Entity`](../concept-api/thing?tab=javascript#entity-methods)"
     python:
       <<: *method-getInstances
-      method: type.get_instances()
+      method: type.as_remote(tx).get_instances()
       returns:
         - Iterator of [`Entity`](../concept-api/thing?tab=python#entity-methods)
 

--- a/04-concept-api/references/long_attribute_type.yml
+++ b/04-concept-api/references/long_attribute_type.yml
@@ -13,7 +13,7 @@ methods:
           default: N/A
     java:
       <<: *method-put
-      method: longAttributeType.put(long value);
+      method: longAttributeType.asRemote(Transaction tx).put(long value);
       accepts:
         <<: *method-put-accepts
         param:
@@ -21,7 +21,7 @@ methods:
           type: long
     javascript:
       <<: *method-put
-      method: await longAttributeType.put(value);
+      method: await longAttributeType.asRemote(tx).put(value);
       accepts:
         <<: *method-put-accepts
         param:
@@ -29,7 +29,7 @@ methods:
           type: number
     python:
       <<: *method-put
-      method: longAttributeType.put(value)
+      method: longAttributeType.as_remote(tx).put(value)
       accepts:
         <<: *method-put-accepts
         param:
@@ -50,7 +50,7 @@ methods:
           default: N/A
     java:
       <<: *method-get
-      method: longAttributeType.get(long value);
+      method: longAttributeType.asRemote(Transaction tx).get(long value);
       accepts:
         <<: *method-get-accepts
         param:
@@ -58,7 +58,7 @@ methods:
           type: long
     javascript:
       <<: *method-get
-      method: await longAttributeType.get(value);
+      method: await longAttributeType.asRemote(tx).get(value);
       accepts:
         <<: *method-get-accepts
         param:
@@ -66,7 +66,7 @@ methods:
           type: number
     python:
       <<: *method-get
-      method: longAttributeType.get(value)
+      method: longAttributeType.as_remote(tx).get(value)
       accepts:
         <<: *method-get-accepts
         param:
@@ -86,17 +86,17 @@ methods:
           default: N/A
     java:
       <<: *method-setsupertype
-      method: attributeType.setSupertype(AttributeType.Long longAttributeType);
+      method: attributeType.asRemote(Transaction tx).setSupertype(AttributeType.Long longAttributeType);
       returns:
         - void
     javascript:
       <<: *method-setsupertype
-      method: attributeType.setSupertype(longAttributeType);
+      method: attributeType.asRemote(tx).setSupertype(longAttributeType);
       returns:
         - void
     python:
       <<: *method-setsupertype
-      method: attributeType.set_supertype(longAttributeType)
+      method: attributeType.as_remote(tx).set_supertype(longAttributeType)
       accepts:
         <<: *accepts-setsupertype
         param:
@@ -111,17 +111,17 @@ methods:
       description: Retrieves all direct and indirect subtypes of the LongAttributeType.
     java:
       <<: *method-getSubtypes
-      method: type.getSubtypes();
+      method: type.asRemote(Transaction tx).getSubtypes();
       returns:
         - Stream<[`AttributeType.Long`](../concept-api/type?tab=java#longattributetype-methods)>
     javascript:
       <<: *method-getSubtypes
-      method: type.getSubtypes()
+      method: type.asRemote(tx).getSubtypes()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`LongAttributeType`](../concept-api/type?tab=javascript#longattributetype-methods)"
     python:
       <<: *method-getSubtypes
-      method: type.get_subtypes()
+      method: type.as_remote(tx).get_subtypes()
       returns:
         - Iterator of [`LongAttributeType`](../concept-api/type?tab=python#longattributetype-methods)
 
@@ -131,17 +131,17 @@ methods:
       description: Retrieves all LongAttributes that are instances of this Type.
     java:
       <<: *method-getInstances
-      method: type.getInstances();
+      method: type.asRemote(Transaction tx).getInstances();
       returns:
         - Stream<[`LongAttribute`](../concept-api/thing?tab=java#attribute-methods)>
     javascript:
       <<: *method-getInstances
-      method: type.getInstances()
+      method: type.asRemote(tx).getInstances()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`LongAttribute`](../concept-api/thing?tab=javascript#attribute-methods)>"
     python:
       <<: *method-getInstances
-      method: type.get_instances()
+      method: type.as_remote(tx).get_instances()
       returns:
         - Iterator of [`LongAttribute`](../concept-api/thing?tab=python#attribute-methods)
 

--- a/04-concept-api/references/relation.yml
+++ b/04-concept-api/references/relation.yml
@@ -25,17 +25,17 @@ methods:
       description: Retrieves a map of all instances involved in the Relation and the role each play.
     java:
       <<: *method-rolePlayersMap
-      method: relation.getPlayersByRoleType();
+      method: relation.asRemote(Transaction tx).getPlayersByRoleType();
       returns:
         - 'Map<[`RoleType`](../concept-api/type?tab=java#roletype-methods), List<[`Thing`](../concept-api/thing?tab=java#thing-methods)>>'
     javascript:
       <<: *method-rolePlayersMap
-      method: await relation.getPlayersByRoleType();
+      method: await relation.asRemote(tx).getPlayersByRoleType();
       returns:
         - 'Map<[`RoleType`](../concept-api/type?tab=javascript#roletype-methods), Array of [`Thing`](../concept-api/thing?tab=javascript#thing-methods)>'
     python:
       <<: *method-rolePlayersMap
-      method: relation.get_players_by_role_type()
+      method: relation.as_remote(tx).get_players_by_role_type()
       returns:
         - "Dictionary of [`Role`](../concept-api/type?tab=python#roletype-methods) to List of [`Thing`](../concept-api/thing?tab=python#thing-methods)"
 
@@ -45,17 +45,17 @@ methods:
       description: Retrieves all role types currently played in this Relation.
     java:
       <<: *method-relating
-      method: relation.getRelating();
+      method: relation.asRemote(Transaction tx).getRelating();
       returns:
         - "Stream<[`RoleType`](../concept-api/type?tab=java#roletype-methods)>"
     javascript:
       <<: *method-relating
-      method: relation.getRelating();
+      method: relation.asRemote(tx).getRelating();
       returns:
         - "[Stream](../client-api/nodejs#stream) of [`RoleType`](../concept-api/type?tab=javascript#roletype-methods)"
     python:
       <<: *method-relating
-      method: relation.get_relating()
+      method: relation.as_remote(tx).get_relating()
       returns:
         - "Iterator of [`RoleType`](../concept-api/type?tab=python#roletype-methods)"
 
@@ -71,7 +71,7 @@ methods:
           default: N/A
     java:
       <<: *method-rolePlayers
-      method: relation.getPlayers(RoleType role);
+      method: relation.asRemote(Transaction tx).getPlayers(RoleType role);
       accepts:
         param:
           <<: *accepts-rolePlayers-role
@@ -80,7 +80,7 @@ methods:
         - "Stream<[`Thing`](../concept-api/thing?tab=java#thing-methods)>"
     javascript:
       <<: *method-rolePlayers
-      method: relation.getPlayers(role);
+      method: relation.asRemote(tx).getPlayers(role);
       accepts:
         param:
           <<: *accepts-rolePlayers-role
@@ -89,7 +89,7 @@ methods:
         - "[Stream](../client-api/nodejs#stream) of [`Thing`](../concept-api/thing?tab=javascript)"
     python:
       <<: *method-rolePlayers
-      method: relation.get_players(role)
+      method: relation.as_remote(tx).get_players(role)
       accepts:
         param:
           <<: *accepts-rolePlayers-role
@@ -114,7 +114,7 @@ methods:
           default: N/A
     java:
       <<: *method-assign
-      method: relation.addPlayer(RoleType role, Thing thing);
+      method: relation.asRemote(Transaction tx).addPlayer(RoleType role, Thing thing);
       accepts:
         <<: *accepts-assign
         param1:
@@ -127,7 +127,7 @@ methods:
         - void
     javascript:
       <<: *method-assign
-      method: await relation.addPlayer(role, thing);
+      method: await relation.asRemote(tx).addPlayer(role, thing);
       accepts:
         <<: *accepts-assign
         param1:
@@ -140,7 +140,7 @@ methods:
         - void
     python:
       <<: *method-assign
-      method: relation.add_player(role, thing)
+      method: relation.as_remote(tx).add_player(role, thing)
       accepts:
         <<: *accepts-assign
         param1:
@@ -169,7 +169,7 @@ methods:
           default: N/A
     java:
       <<: *method-unassign
-      method: relation.removePlayer(RoleType role, Thing thing);
+      method: relation.asRemote(Transaction tx).removePlayer(RoleType role, Thing thing);
       accepts:
         param1:
           <<: *accepts-unassign-role
@@ -181,7 +181,7 @@ methods:
         - void
     javascript:
       <<: *method-unassign
-      method: await relation.removePlayer(role, thing);
+      method: await relation.asRemote(tx).removePlayer(role, thing);
       accepts:
         param1:
           <<: *accepts-unassign-role
@@ -193,7 +193,7 @@ methods:
         - void
     python:
       <<: *method-unassign
-      method: relation.remove_player(role, thing)
+      method: relation.as_remote(tx).remove_player(role, thing)
       accepts:
         param1:
           <<: *accepts-unassign-role

--- a/04-concept-api/references/relation_type.yml
+++ b/04-concept-api/references/relation_type.yml
@@ -5,17 +5,17 @@ methods:
       description: Creates and returns an instance of this RelationType.
     java:
       <<: *method-create
-      method: relationType.create();
+      method: relationType.asRemote(Transaction tx).create();
       returns:
         - "[`Relation`](../concept-api/thing?tab=java#relation-methods)"
     javascript:
       <<: *method-create
-      method: await relationType.create();
+      method: await relationType.asRemote(tx).create();
       returns:
         - "[`Relation`](../concept-api/thing?tab=nodejs#relation-methods)"
     python:
       <<: *method-create
-      method: relation_type.create()
+      method: relation_type.as_remote(tx).create()
       returns:
         - "[`Relation`](../concept-api/thing?tab=python#relation-methods)"
 
@@ -25,17 +25,17 @@ methods:
       description: Retrieve roles that this RelationType relates to.
     java:
       <<: *method-getrelates
-      method: relationType.getRelates();
+      method: relationType.asRemote(Transaction tx).getRelates();
       returns:
         - "[Stream](../client-api/nodejs#stream)<[`RoleType`](../concept-api/type?tab=java#roletype-methods)>"
     javascript:
       <<: *method-getrelates
-      method: relationType.getRelates();
+      method: relationType.asRemote(tx).getRelates();
       returns:
         - "[Stream](../client-api/nodejs#stream) of [`RoleType`](../concept-api/type?tab=javascript#roletype-methods)"
     python:
       <<: *method-getrelates
-      method: relation_type.get_relates()
+      method: relation_type.as_remote(tx).get_relates()
       returns:
         - "Iterator of [`RoleType`](../concept-api/type?tab=python#roletype-methods)"
 
@@ -51,17 +51,17 @@ methods:
           required: true
     java:
       <<: *method-getrelates-label
-      method: relationType.getRelates(String label);
+      method: relationType.asRemote(Transaction tx).getRelates(String label);
       returns:
         - "[`RoleType`](../concept-api/type?tab=java#roletype-methods)"
     javascript:
       <<: *method-getrelates-label
-      method: await relationType.getRelates(label);
+      method: await relationType.asRemote(tx).getRelates(label);
       returns:
         - "[`RoleType`](../concept-api/type?tab=javascript#roletype-methods)"
     python:
       <<: *method-getrelates-label
-      method: relation_type.get_relates(label)
+      method: relation_type.as_remote(tx).get_relates(label)
       returns:
         - "[`RoleType`](../concept-api/type?tab=python#roletype-methods)"
 
@@ -84,17 +84,17 @@ methods:
           default: N/A
     java:
       <<: *method-relates
-      method: relationType.setRelates(String label, String overriddenRoleLabel);
+      method: relationType.asRemote(Transaction tx).setRelates(String label, String overriddenRoleLabel);
       returns:
         - void
     javascript:
       <<: *method-relates
-      method: await relationType.setRelates(label, overriddenRoleLabel);
+      method: await relationType.asRemote(tx).setRelates(label, overriddenRoleLabel);
       returns:
         - void
     python:
       <<: *method-relates
-      method: relation_type.set_relates(label, overriddenRoleLabel)
+      method: relation_type.as_remote(tx).set_relates(label, overriddenRoleLabel)
       returns:
         - None
 
@@ -111,17 +111,17 @@ methods:
           default: N/A
     java:
       <<: *method-unrelate
-      method: relationType.unsetRelates(RoleType role);
+      method: relationType.asRemote(Transaction tx).unsetRelates(RoleType role);
       returns:
         - void
     javascript:
       <<: *method-unrelate
-      method: await relationType.unsetRelates(role);
+      method: await relationType.asRemote(tx).unsetRelates(role);
       returns:
         - void
     python:
       <<: *method-unrelate
-      method: relation_type.unset_relates(role)
+      method: relation_type.as_remote(tx).unset_relates(role)
       returns:
         - None
 
@@ -138,17 +138,17 @@ methods:
           default: N/A
     java:
       <<: *method-setsupertype
-      method: relationType.setSupertype(RelationType relationType);
+      method: relationType.asRemote(Transaction tx).setSupertype(RelationType relationType);
       returns:
         - void
     javascript:
       <<: *method-setsupertype
-      method: relationType.setSupertype(relationType);
+      method: relationType.asRemote(tx).setSupertype(relationType);
       returns:
         - void
     python:
       <<: *method-setsupertype
-      method: relation_type.set_supertype(relation_type)
+      method: relation_type.as_remote(tx).set_supertype(relation_type)
       accepts:
         <<: *accepts-setsupertype
         param:
@@ -163,17 +163,17 @@ methods:
       description: Retrieves all direct and indirect subtypes of the RelationType.
     java:
       <<: *method-getSubtypes
-      method: type.getSubtypes();
+      method: type.asRemote(Transaction tx).getSubtypes();
       returns:
         - Stream<[`RelationType`](../concept-api/type?tab=java#relationtype-methods)>
     javascript:
       <<: *method-getSubtypes
-      method: type.getSubtypes()
+      method: type.asRemote(tx).getSubtypes()
       returns:
         - "[`Stream`](../client-api/nodejs#stream)<[`RelationType`](../concept-api/type?tab=javascript#relationtype-methods)>"
     python:
       <<: *method-getSubtypes
-      method: type.get_subtypes()
+      method: type.as_remote(tx).get_subtypes()
       returns:
         - Iterator of [`RelationType`](../concept-api/type?tab=python#relationtype-methods)
 
@@ -183,17 +183,17 @@ methods:
       description: Retrieves all Relations that are instances of this Type.
     java:
       <<: *method-getInstances
-      method: type.getInstances();
+      method: type.asRemote(Transaction tx).getInstances();
       returns:
         - Stream<[`Relation`](../concept-api/thing?tab=java#relation-methods)>
     javascript:
       <<: *method-getInstances
-      method: type.getInstances()
+      method: type.asRemote(tx).getInstances()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`Relation`](../concept-api/thing?tab=javascript#relation-methods)>"
     python:
       <<: *method-getInstances
-      method: type.get_instances()
+      method: type.as_remote(tx).get_instances()
       returns:
         - Iterator of [`Relation`](../concept-api/thing?tab=python#relation-methods)
 

--- a/04-concept-api/references/role_type.yml
+++ b/04-concept-api/references/role_type.yml
@@ -62,19 +62,19 @@ methods:
       description: Retrieves the most immediate supertype of the role type.
     java:
       <<: *method-getSupertype
-      method: type.getSupertype();
+      method: type.asRemote(Transaction tx).getSupertype();
       returns:
         - "[`RoleType`](../concept-api/type?tab=java#roletype-methods)"
         - "`null`"
     javascript:
       <<: *method-getSupertype
-      method: await type.getSupertype();
+      method: await type.asRemote(tx).getSupertype();
       returns:
         - "[`RoleType`](../concept-api/type?tab=javascript#roletype-methods)"
         - "`null`"
     python:
       <<: *method-getSupertype
-      method: type.get_supertype()
+      method: type.as_remote(tx).get_supertype()
       returns:
         - "[`RoleType`](../concept-api/type?tab=python#roletype-methods)"
         - None
@@ -85,17 +85,17 @@ methods:
       description: Retrieves all supertypes of the role type.
     java:
       <<: *method-getSupertypes
-      method: type.getSupertypes();
+      method: type.asRemote(Transaction tx).getSupertypes();
       returns:
         - Stream<[`RoleType`](../concept-api/type?tab=java#roletype-methods)>
     javascript:
       <<: *method-getSupertypes
-      method: type.getSupertypes()
+      method: type.asRemote(tx).getSupertypes()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`RoleType`](../concept-api/type?tab=javascript#roletype-methods)"
     python:
       <<: *method-getSupertypes
-      method: type.get_supertypes()
+      method: type.as_remote(tx).get_supertypes()
       returns:
         - Iterator of [`RoleType`](../concept-api/type?tab=python#roletype-methods)
 
@@ -105,17 +105,17 @@ methods:
       description: Retrieves all direct and indirect subtypes of the type.
     java:
       <<: *method-getSubtypes
-      method: type.getSubtypes();
+      method: type.asRemote(Transaction tx).getSubtypes();
       returns:
         - Stream<[`RoleType`](../concept-api/type?tab=java#roletype-methods)>
     javascript:
       <<: *method-getSubtypes
-      method: type.getSubtypes()
+      method: type.asRemote(tx).getSubtypes()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`RoleType`](../concept-api/type?tab=javascript#roletype-methods)"
     python:
       <<: *method-getSubtypes
-      method: type.get_subtypes()
+      method: type.as_remote(tx).get_subtypes()
       returns:
         - Iterator of [`RoleType`](../concept-api/type?tab=python#roletype-methods)
 
@@ -125,19 +125,19 @@ methods:
       description: Retrieves the Relation instance that this role is directly related to.
     java:
       <<: *method-getRelationType
-      method: role.getRelationType();
+      method: role.asRemote(Transaction tx).getRelationType();
       returns:
-        - "Stream<[`RelationType`](../concept-api/thing?tab=java#relationtype-methods)>"
+        - "[`RelationType`](../concept-api/thing?tab=java#relationtype-methods)>"
     javascript:
       <<: *method-getRelationType
-      method: await role.getRelationType();
+      method: await role.asRemote(tx).getRelationType();
       returns:
-        - "[`Stream`](../client-api/nodejs#stream) of [`RelationType`](../concept-api/thing?tab=javascript#relationtype-methods)"
+        - "[`RelationType`](../concept-api/thing?tab=javascript#relationtype-methods)"
     python:
       <<: *method-getRelationType
-      method: role.get_relation_type()
+      method: role.as_remote(tx).get_relation_type()
       returns:
-        - "Iterator of [`RelationType`](../concept-api/thing?tab=python#relationtype-methods)"
+        - "[`RelationType`](../concept-api/thing?tab=python#relationtype-methods)"
 
   - method:
     common: &method-getRelationTypes
@@ -145,17 +145,17 @@ methods:
       description: Retrieves the RelationTypes that this role is related to.
     java:
       <<: *method-getRelationTypes
-      method: role.getRelationTypes();
+      method: role.asRemote(Transaction tx).getRelationTypes();
       returns:
         - "Stream<[`RelationType`](../concept-api/thing?tab=java#relationtype-methods)>"
     javascript:
       <<: *method-getRelationTypes
-      method: await role.getRelationTypes();
+      method: await role.asRemote(tx).getRelationTypes();
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`RelationType`](../concept-api/thing?tab=javascript#relationtype-methods)"
     python:
       <<: *method-getRelationTypes
-      method: role.get_relation_types()
+      method: role.as_remote(tx).get_relation_types()
       returns:
         - "Iterator of [`RelationType`](../concept-api/thing?tab=python#relationtype-methods)"
 
@@ -165,16 +165,16 @@ methods:
       description: Retrieves the ThingTypes whose instances play this role.
     java:
       <<: *method-getPlayers
-      method: role.getPlayers();
+      method: role.asRemote(Transaction tx).getPlayers();
       returns:
         - "Stream<[`ThingType`](/docs/concept-api/type?tab=java)>"
     javascript:
       <<: *method-getPlayers
-      method: await role.getPlayers();
+      method: await role.asRemote(tx).getPlayers();
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`ThingType`](/docs/concept-api/type?tab=nodejs)"
     python:
       <<: *method-getPlayers
-      method: role.get_players()
+      method: role.as_remote(tx).get_players()
       returns:
         - "Iterator of [`ThingType`](/docs/concept-api/type?tab=python)"

--- a/04-concept-api/references/rule.yml
+++ b/04-concept-api/references/rule.yml
@@ -85,17 +85,17 @@ methods:
           default: N/A
     java:
       <<: *method-setLabel
-      method: rule.setLabel(String label);
+      method: rule.asRemote(Transaction tx).setLabel(String label);
       returns:
         - void
     javascript:
       <<: *method-setLabel
-      method: await rule.setLabel(label);
+      method: await rule.asRemote(tx).setLabel(label);
       returns:
         - void
     python:
       <<: *method-setLabel
-      method: rule.set_label(label)
+      method: rule.as_remote(tx).set_label(label)
       returns:
         - None
 
@@ -109,7 +109,7 @@ methods:
       <<: *method-delete
     javascript:
       <<: *method-delete
-      method: await rule.delete();
+      method: await rule.asRemote(Transaction tx).delete();
       returns:
         - void
     python:
@@ -120,14 +120,14 @@ methods:
   - method:
     common: &method-isDeleted
       title: Check if the rule has been deleted
-      method: rule.isDeleted();
+      method: rule.asRemote(Transaction tx).isDeleted();
       returns:
         - boolean
     java:
       <<: *method-isDeleted
     javascript:
       <<: *method-isDeleted
-      method: await rule.isDeleted();
+      method: await rule.asRemote(tx).isDeleted();
     python:
       <<: *method-isDeleted
-      method: rule.is_deleted()
+      method: rule.as_remote(tx).is_deleted()

--- a/04-concept-api/references/rule.yml
+++ b/04-concept-api/references/rule.yml
@@ -102,29 +102,30 @@ methods:
   - method:
     common: &method-delete
       title: Delete rule
-      method: rule.delete();
-      returns:
-        - "`null`"
     java:
       <<: *method-delete
+      method: rule.asRemote(Transaction tx).delete();
+      returns:
+        - "`null`"
     javascript:
       <<: *method-delete
-      method: await rule.asRemote(Transaction tx).delete();
+      method: await rule.asRemote(tx).delete();
       returns:
         - void
     python:
       <<: *method-delete
+      method: rule.as_remote(tx).delete();
       returns:
         - None
 
   - method:
     common: &method-isDeleted
       title: Check if the rule has been deleted
-      method: rule.asRemote(Transaction tx).isDeleted();
       returns:
         - boolean
     java:
       <<: *method-isDeleted
+      method: rule.asRemote(Transaction tx).isDeleted();
     javascript:
       <<: *method-isDeleted
       method: await rule.asRemote(tx).isDeleted();

--- a/04-concept-api/references/string_attribute_type.yml
+++ b/04-concept-api/references/string_attribute_type.yml
@@ -14,13 +14,13 @@ methods:
           default: N/A
     java:
       <<: *method-put
-      method: stringAttributeType.put(String value);
+      method: stringAttributeType.asRemote(Transaction tx).put(String value);
     javascript:
       <<: *method-put
-      method: await stringAttributeType.put(value);
+      method: await stringAttributeType.asRemote(tx).put(value);
     python:
       <<: *method-put
-      method: string_attribute_type.put(value)
+      method: string_attribute_type.as_remote(tx).put(value)
 
   - method:
     common: &method-get
@@ -37,32 +37,32 @@ methods:
           default: N/A
     java:
       <<: *method-get
-      method: stringAttributeType.get(String value);
+      method: stringAttributeType.asRemote(Transaction tx).get(String value);
     javascript:
       <<: *method-get
-      method: await stringAttributeType.get(value);
+      method: await stringAttributeType.asRemote(tx).get(value);
     python:
       <<: *method-get
-      method: stringAttributeType.get(value)
+      method: stringAttributeType.as_remote(tx).get(value)
   - method:
     common: &method-regex-retrieve
       title: Retrieve regex
       description: Retrieves the regex that all instances of this StringAttributeType must conform to.
     java:
       <<: *method-regex-retrieve
-      method: stringAttributeType.getRegex();
+      method: stringAttributeType.asRemote(Transaction tx).getRegex();
       returns:
         - string
         - "`null`"
     javascript:
       <<: *method-regex-retrieve
-      method: await stringAttributeType.getRegex();
+      method: await stringAttributeType.asRemote(tx).getRegex();
       returns:
         - string
         - None
     python:
       <<: *method-regex-retrieve
-      method: string_attribute_type.get_regex()
+      method: string_attribute_type.as_remote(tx).get_regex()
       returns:
         - string
         - "`null`"
@@ -80,17 +80,17 @@ methods:
           default: N/A
     java:
       <<: *method-regex-set
-      method: stringAttributeType.setRegex(String regex);
+      method: stringAttributeType.asRemote(Transaction tx).setRegex(String regex);
       returns:
         - void
     javascript:
       <<: *method-regex-set
-      method: await stringAttributeType.setRegex(regex);
+      method: await stringAttributeType.asRemote(tx).setRegex(regex);
       returns:
         - void
     python:
       <<: *method-regex-set
-      method: string_attribute_type.set_regex(regex)
+      method: string_attribute_type.as_remote(tx).set_regex(regex)
       returns:
         - void
 
@@ -107,17 +107,17 @@ methods:
           default: N/A
     java:
       <<: *method-setsupertype
-      method: attributeType.setSupertype(AttributeType.String stringAttributeType);
+      method: attributeType.asRemote(Transaction tx).setSupertype(AttributeType.String stringAttributeType);
       returns:
         - void
     javascript:
       <<: *method-setsupertype
-      method: attributeType.setSupertype(stringAttributeType);
+      method: attributeType.asRemote(tx).setSupertype(stringAttributeType);
       returns:
         - void
     python:
       <<: *method-setsupertype
-      method: attributeType.set_supertype(string_attribute_type)
+      method: attributeType.as_remote(tx).set_supertype(string_attribute_type)
       accepts:
         <<: *accepts-setsupertype
         param:
@@ -132,17 +132,17 @@ methods:
       description: Retrieves all direct and indirect subtypes of the StringAttributeType.
     java:
       <<: *method-getSubtypes
-      method: type.getSubtypes();
+      method: type.asRemote(Transaction tx).getSubtypes();
       returns:
         - Stream<[`AttributeType.String`](../concept-api/type?tab=java#stringattributetype-methods)>
     javascript:
       <<: *method-getSubtypes
-      method: type.getSubtypes()
+      method: type.asRemote(tx).getSubtypes()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`StringAttributeType`](../concept-api/type?tab=javascript#stringattributetype-methods)"
     python:
       <<: *method-getSubtypes
-      method: type.get_subtypes()
+      method: type.as_remote(tx).get_subtypes()
       returns:
         - Iterator of [`StringAttributeType`](../concept-api/type?tab=python#stringattributetype-methods)
 
@@ -152,17 +152,17 @@ methods:
       description: Retrieves all StringAttributes that are instances of this Type.
     java:
       <<: *method-getInstances
-      method: type.getInstances();
+      method: type.asRemote(Transaction tx).getInstances();
       returns:
         - Stream<[`StringAttribute`](../concept-api/thing?tab=java#attribute-methods)>
     javascript:
       <<: *method-getInstances
-      method: type.getInstances()
+      method: type.asRemote(tx).getInstances()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`StringAttribute`](../concept-api/thing?tab=javascript#attribute-methods)"
     python:
       <<: *method-getInstances
-      method: type.get_instances()
+      method: type.as_remote(tx).get_instances()
       returns:
         - Iterator of [`StringAttribute`](../concept-api/thing?tab=python#attribute-methods)
 

--- a/04-concept-api/references/thing.yml
+++ b/04-concept-api/references/thing.yml
@@ -88,7 +88,7 @@ methods:
           default: N/A
     java:
       <<: *method-setHas
-      method: thing.setHas(Attribute<?> attribute);
+      method: thing.asRemote(Transaction tx).setHas(Attribute<?> attribute);
       accepts:
         param:
           <<: *accepts-setHas-attribute
@@ -97,7 +97,7 @@ methods:
         - "[`Thing`](../concept-api/thing?tab=java#thing-methods)"
     javascript:
       <<: *method-setHas
-      method: await thing.setHas(attribute);
+      method: await thing.asRemote(tx).setHas(attribute);
       accepts:
         param:
           <<: *accepts-setHas-attribute
@@ -106,7 +106,7 @@ methods:
         - "[`Thing`](../concept-api/thing?tab=javascript#thing-methods)"
     python:
       <<: *method-setHas
-      method: thing.set_has(attribute)
+      method: thing.as_remote(tx).set_has(attribute)
       accepts:
         param:
           <<: *accepts-setHas-attribute
@@ -127,17 +127,17 @@ methods:
           default: N/A
     java:
       <<: *method-unsetHas
-      method: thing.unsetHas(Attribute<?> attribute);
+      method: thing.asRemote(Transaction tx).unsetHas(Attribute<?> attribute);
       returns:
         - "[`Thing`](../concept-api/thing?tab=java#thing-methods)"
     javascript:
       <<: *method-unsetHas
-      method: await thing.unsetHas(attribute);
+      method: await thing.asRemote(tx).unsetHas(attribute);
       returns:
         - "[`Thing`](../concept-api/thing?tab=javascript#thing-methods)"
     python:
       <<: *method-unsetHas
-      method: thing.unset_has(attribute)
+      method: thing.as_remote(tx).unset_has(attribute)
       returns:
         - "[`Thing`](../concept-api/thing?tab=python#thing-methods)"
 
@@ -154,12 +154,12 @@ methods:
           default: false
     java:
       <<: *method-getHasWithOnlyKey
-      method: thing.getHas(boolean onlyKey));
+      method: thing.asRemote(Transaction tx).getHas(boolean onlyKey));
       returns:
         - Stream<[`Attribute<?>`](../concept-api/thing?tab=java#attribute-methods)>
     javascript:
       <<: *method-getHasWithOnlyKey
-      method: await thing.getHas(onlyKey);
+      method: await thing.asRemote(tx).getHas(onlyKey);
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`Attribute`](../concept-api/thing?tab=javascript#attribute-methods)"
 
@@ -175,7 +175,7 @@ methods:
           default: null
     java:
       <<: *method-getHasWithOneAttributeType
-      method: thing.getHas(AttributeType attributeType);
+      method: thing.asRemote(Transaction tx).getHas(AttributeType attributeType);
       accepts:
         <<: *accepts-getHasWithOneAttributeType
         param:
@@ -185,7 +185,7 @@ methods:
         - "Stream<[`Attribute`](../concept-api/thing?tab=java#attribute-methods)>"
     javascript:
       <<: *method-getHasWithOneAttributeType
-      method: await thing.getHas(attributeType);
+      method: await thing.asRemote(tx).getHas(attributeType);
       accepts:
         <<: *accepts-getHasWithOneAttributeType
         param:
@@ -206,7 +206,7 @@ methods:
           default: "(empty array)"
     java:
       <<: *method-getHasWithAttributeTypes
-      method: thing.getHas(AttributeType... attributeTypes);
+      method: thing.asRemote(Transaction tx).getHas(AttributeType... attributeTypes);
       accepts:
         <<: *accepts-getHasWithAttributeTypes
         param:
@@ -216,7 +216,7 @@ methods:
         - "Stream<[`Attribute`](../concept-api/thing?tab=java#attribute-methods)>"
     javascript:
       <<: *method-getHasWithAttributeTypes
-      method: await thing.getHas(attributeTypes);
+      method: await thing.asRemote(tx).getHas(attributeTypes);
       accepts:
         <<: *accepts-getHasWithAttributeTypes
         param:
@@ -229,7 +229,7 @@ methods:
     python:
       title: Retrieve attributes
       description: Retrieves the Attributes that this Thing owns, optionally filtered by one or more AttributeTypes.
-      method: thing.get_has(attribute_type=None, attribute_types=[], only_key=False)
+      method: thing.as_remote(tx).get_has(attribute_type=None, attribute_types=[], only_key=False)
       accepts:
         param1:
           name: attribute_type
@@ -258,17 +258,17 @@ methods:
       description: Retrieves the roles that this Thing is currently playing.
     java:
       <<: *method-getPlays
-      method: thing.getPlaying();
+      method: thing.asRemote(Transaction tx).getPlaying();
       returns:
         - "Stream of [`RoleType`](../concept-api/type?tab=java#roletype-methods)"
     javascript:
       <<: *method-getPlays
-      method: await thing.getPlaying();
+      method: await thing.asRemote(tx).getPlaying();
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`RoleType`](../concept-api/type?tab=javascript#roletype-methods)"
     python:
       <<: *method-getPlays
-      method: thing.get_playing()
+      method: thing.as_remote(tx).get_playing()
       returns:
         - "Iterator of [`RoleType`](../concept-api/type?tab=python#roletype-methods)"
 
@@ -284,7 +284,7 @@ methods:
           default: N/A
     java:
       <<: *method-getRelations
-      method: thing.getRelations(RoleType... roleTypes);
+      method: thing.asRemote(Transaction tx).getRelations(RoleType... roleTypes);
       accepts:
         <<: *accepts-getRelations
         param:
@@ -294,7 +294,7 @@ methods:
         - Stream<[`Relation`](../concept-api/thing?tab=java#relation-methods)>
     javascript:
       <<: *method-getRelations
-      method: await thing.getRelations(roleTypes);
+      method: await thing.asRemote(tx).getRelations(roleTypes);
       accepts:
         <<: *accepts-getRelations
         param:
@@ -304,7 +304,7 @@ methods:
         - "[`Stream`](../client-api/nodejs#stream) of [`Relation`](../concept-api/thing?tab=javascript#relation-methods)"
     python:
       <<: *method-getRelations
-      method: thing.get_relations(role_types)
+      method: thing.as_remote(tx).get_relations(role_types)
       accepts:
         param:
           <<: *accepts-getRelations-param-roleTypes

--- a/04-concept-api/references/thing_type.yml
+++ b/04-concept-api/references/thing_type.yml
@@ -30,19 +30,19 @@ methods:
       description: Retrieves the most immediate supertype of the ThingType.
     java:
       <<: *method-getSupertype
-      method: thingType.getSupertype();
+      method: thingType.asRemote(Transaction tx).getSupertype();
       returns:
         - "[`ThingType`](../concept-api/type?tab=java#thingtype-methods)"
         - "`null`"
     javascript:
       <<: *method-getSupertype
-      method: await thingType.getSupertype();
+      method: await thingType.asRemote(tx).getSupertype();
       returns:
         - "[`ThingType`](../concept-api/type?tab=javascript#thingtype-methods)"
         - "`null`"
     python:
       <<: *method-getSupertype
-      method: thing_type.get_supertype()
+      method: thing_type.as_remote(tx).get_supertype()
       returns:
         - "[`ThingType`](../concept-api/type?tab=python#thingtype-methods)"
         - None
@@ -53,17 +53,17 @@ methods:
       description: Retrieves all supertypes of the ThingType.
     java:
       <<: *method-getSupertypes
-      method: thingType.getSupertypes();
+      method: thingType.asRemote(Transaction tx).getSupertypes();
       returns:
         - Stream<[`ThingType`](../concept-api/type?tab=java#thingtype-methods)>
     javascript:
       <<: *method-getSupertypes
-      method: thingType.getSupertypes()
+      method: thingType.asRemote(tx).getSupertypes()
       returns:
         - "[`Stream`](../client-api/nodejs#stream)<[`ThingType`](../concept-api/type?tab=javascript#thingtype-methods)>"
     python:
       <<: *method-getSupertypes
-      method: thing_type.get_supertypes()
+      method: thing_type.as_remote(tx).get_supertypes()
       returns:
         - Iterator of [`ThingType`](../concept-api/type?tab=python#thingtype-methods)
 
@@ -73,17 +73,17 @@ methods:
       description: Retrieves all direct and indirect subtypes of the ThingType.
     java:
       <<: *method-getSubtypes
-      method: thingType.getSubtypes();
+      method: thingType.asRemote(Transaction tx).getSubtypes();
       returns:
         - Stream<[`ThingType`](../concept-api/type?tab=java#thingtype-methods)>
     javascript:
       <<: *method-getSubtypes
-      method: thingType.getSubtypes()
+      method: thingType.asRemote(tx).getSubtypes()
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`ThingType`](../concept-api/type?tab=javascript#thingtype-methods)"
     python:
       <<: *method-getSubtypes
-      method: thing_type.get_subtypes()
+      method: thing_type.as_remote(tx).get_subtypes()
       returns:
         - Iterator of [`ThingType`](../concept-api/type?tab=python#thingtype-methods)
 
@@ -93,17 +93,17 @@ methods:
       descriptions: Retrieve all instances of this ThingType.
     java:
       <<: *method-getInstances
-      method: thingType.getInstances();
+      method: thingType.asRemote(Transaction tx).getInstances();
       returns:
         - Stream<[`Thing`](../concept-api/thing?tab=java#thing-methods)>
     javascript:
       <<: *method-getInstances
-      method: thingType.getInstances();
+      method: thingType.asRemote(tx).getInstances();
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`Thing`](../concept-api/thing?tab=javascript#thing-methods)"
     python:
       <<: *method-getInstances
-      method: thing_type.get_instances()
+      method: thing_type.as_remote(tx).get_instances()
       returns:
         - Iterator of [`Thing`](../concept-api/thing?tab=python#thing-methods)
 
@@ -113,17 +113,17 @@ methods:
       description: Set a ThingType to be abstract, meaning it cannot have instances.
     java:
       <<: *method-setAbstract
-      method: thingType.setAbstract();
+      method: thingType.asRemote(Transaction tx).setAbstract();
       returns:
         - void
     javascript:
       <<: *method-setAbstract
-      method: await thingType.setAbstract();
+      method: await thingType.asRemote(tx).setAbstract();
       returns:
         - void
     python:
       <<: *method-setAbstract
-      method: thing_type.set_abstract()
+      method: thing_type.as_remote(tx).set_abstract()
       returns:
         - None
 
@@ -133,17 +133,17 @@ methods:
       description: Set a ThingType to be non-abstract, meaning it can have instances.
     java:
       <<: *method-unsetAbstract
-      method: thingType.unsetAbstract();
+      method: thingType.asRemote(Transaction tx).unsetAbstract();
       returns:
         - void
     javascript:
       <<: *method-unsetAbstract
-      method: await thingType.unsetAbstract();
+      method: await thingType.asRemote(tx).unsetAbstract();
       returns:
         - void
     python:
       <<: *method-unsetAbstract
-      method: thing_type.unset_abstract()
+      method: thing_type.as_remote(tx).unset_abstract()
       returns:
         - None
 
@@ -163,7 +163,7 @@ methods:
           required: false
     java:
       <<: *method-setPlays
-      method: thingType.setPlays(RoleType roleType, RoleType overriddenType);
+      method: thingType.asRemote(Transaction tx).setPlays(RoleType roleType, RoleType overriddenType);
       accepts:
         param1:
           <<: *accepts-setPlays-roleType
@@ -176,7 +176,7 @@ methods:
         - void
     javascript:
       <<: *method-setPlays
-      method: await thingType.setPlays(roleType, overriddenType);
+      method: await thingType.asRemote(tx).setPlays(roleType, overriddenType);
       accepts:
         param1:
           <<: *accepts-setPlays-roleType
@@ -189,7 +189,7 @@ methods:
         - void
     python:
       <<: *method-setPlays
-      method: thing_type.set_plays(role_type, overridden_type=None)
+      method: thing_type.as_remote(tx).set_plays(role_type, overridden_type=None)
       accepts:
         param1:
           <<: *accepts-setPlays-roleType
@@ -223,7 +223,7 @@ methods:
         - void
     java:
       <<: *method-setOwns
-      method: thingType.setOwns(AttributeType attributeType, boolean isKey);
+      method: thingType.asRemote(Transaction tx).setOwns(AttributeType attributeType, boolean isKey);
       accepts:
         param1:
           <<: *accepts-setOwns-attributeType
@@ -232,7 +232,7 @@ methods:
           <<: *accepts-setOwns-isKey
     javascript:
       <<: *method-setOwns
-      method: await thingType.setOwns(attributeType, isKey);
+      method: await thingType.asRemote(tx).setOwns(attributeType, isKey);
       accepts:
         param1:
           <<: *accepts-setOwns-attributeType
@@ -265,7 +265,7 @@ methods:
         - void
     java:
       <<: *method-setOwnsOverridden
-      method: thingType.setOwns(AttributeType attributeType, AttributeType overriddenType, boolean isKey);
+      method: thingType.asRemote(Transaction tx).setOwns(AttributeType attributeType, AttributeType overriddenType, boolean isKey);
       accepts:
         param1:
           <<: *accepts-setOwnsOverridden-attributeType
@@ -277,7 +277,7 @@ methods:
           <<: *accepts-setOwnsOverridden-isKey
     javascript:
       <<: *method-setOwnsOverridden
-      method: await thingType.setOwns(attributeType, overriddenType, isKey);
+      method: await thingType.asRemote(tx).setOwns(attributeType, overriddenType, isKey);
       accepts:
         param1:
           <<: *accepts-setOwnsOverridden-attributeType
@@ -292,7 +292,7 @@ methods:
     python:
       title: Add attribute ownership
       description: Allows the instances of this type to own the given `AttributeType`.
-      method: thing_type.set_owns(attribute_type, overridden_type=None, is_key=False);
+      method: thing_type.as_remote(tx).set_owns(attribute_type, overridden_type=None, is_key=False);
       accepts:
         param1:
           name: attributeType
@@ -321,17 +321,17 @@ methods:
       description: Retrieves all direct and inherited roles that are allowed to be played by the instances of this type.
     java:
       <<: *method-getPlays
-      method: thingType.getPlays();
+      method: thingType.asRemote(Transaction tx).getPlays();
       returns:
         - Stream<[`RoleType`](../concept-api/type?tab=java#roletype-methods)>
     javascript:
       <<: *method-getPlays
-      method: await thingType.getPlays();
+      method: await thingType.asRemote(tx).getPlays();
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`RoleType`](../concept-api/type?tab=javascript#roletype-methods)"
     python:
       <<: *method-getPlays
-      method: thing_type.get_plays()
+      method: thing_type.as_remote(tx).get_plays()
       returns:
         - Iterator of [`RoleType`](../concept-api/type?tab=python#roletype-methods)
 
@@ -348,12 +348,12 @@ methods:
           default: false
     java:
       <<: *method-getOwns
-      method: thingType.getOwns(boolean keysOnly);
+      method: thingType.asRemote(Transaction tx).getOwns(boolean keysOnly);
       returns:
         - Stream<[`AttributeType`](../concept-api/type?tab=java#attributetype-methods)>
     javascript:
       <<: *method-getOwns
-      method: await thingType.getOwns(keysOnly);
+      method: await thingType.asRemote(tx).getOwns(keysOnly);
       returns:
         - "[`Stream`](../client-api/nodejs#stream) of [`AttributeType`](../concept-api/type?tab=javascript#attributetype-methods)"
 
@@ -376,7 +376,7 @@ methods:
           default: false
     java:
       <<: *method-getOwnsForValueType
-      method: thingType.getOwns(AttributeType.ValueType valueType, boolean keysOnly);
+      method: thingType.asRemote(Transaction tx).getOwns(AttributeType.ValueType valueType, boolean keysOnly);
       accepts:
         param1:
           <<: *accepts-getOwnsForValueType-valueType
@@ -386,7 +386,7 @@ methods:
         - Stream<[`AttributeType`](../concept-api/type?tab=java#attributetype-methods)>
     javascript:
       <<: *method-getOwnsForValueType
-      method: await thingType.getOwns(valueType, keysOnly);
+      method: await thingType.asRemote(tx).getOwns(valueType, keysOnly);
       accepts:
         param1:
           <<: *accepts-getOwnsForValueType-valueType
@@ -399,7 +399,7 @@ methods:
     python:
       title: Retrieve attributes
       description: Retrieves attribute types that the instances of this type are allowed to own.
-      method: thing_type.get_owns(value_type=None, keys_only=False)
+      method: thing_type.as_remote(tx).get_owns(value_type=None, keys_only=False)
       accepts:
         param1:
           name: value_type
@@ -428,7 +428,7 @@ methods:
           default: N/A
     java:
       <<: *method-unsetPlays
-      method: thingType.unsetPlays(RoleType role);
+      method: thingType.asRemote(Transaction tx).unsetPlays(RoleType role);
       accepts:
         param:
           <<: *accepts-unsetPlays
@@ -437,7 +437,7 @@ methods:
         - void
     javascript:
       <<: *method-unsetPlays
-      method: await thingType.unsetPlays(role);
+      method: await thingType.asRemote(tx).unsetPlays(role);
       accepts:
         param:
           <<: *accepts-unsetPlays
@@ -446,7 +446,7 @@ methods:
         - void
     python:
       <<: *method-unsetPlays
-      method: thing_type.unset_plays(role)
+      method: thing_type.as_remote(tx).unset_plays(role)
       accepts:
         param:
           <<: *accepts-unsetPlays
@@ -466,7 +466,7 @@ methods:
           default: N/A
     java:
       <<: *method-unsetOwns
-      method: thingType.unsetOwns(AttributeType attributeType);
+      method: thingType.asRemote(Transaction tx).unsetOwns(AttributeType attributeType);
       accepts:
         param:
           <<: *accepts-unsetOwns-attributeType
@@ -475,7 +475,7 @@ methods:
         - void
     javascript:
       <<: *method-unsetOwns
-      method: await thingType.unsetOwns(attributeType);
+      method: await thingType.asRemote(tx).unsetOwns(attributeType);
       accepts:
         param:
           <<: *accepts-unsetOwns-attributeType
@@ -484,7 +484,7 @@ methods:
         - void
     python:
       <<: *method-unsetOwns
-      method: thing_type.unset_owns(attribute_type)
+      method: thing_type.as_remote(tx).unset_owns(attribute_type)
       accepts:
         param:
           <<: *accepts-unsetOwns-attributeType

--- a/04-concept-api/references/type.yml
+++ b/04-concept-api/references/type.yml
@@ -69,17 +69,17 @@ methods:
           default: N/A
     java:
       <<: *method-setLabel
-      method: type.setLabel(String label);
+      method: type.asRemote(Transaction tx).setLabel(String label);
       returns:
         - void
     javascript:
       <<: *method-setLabel
-      method: await type.setLabel(label);
+      method: await type.asRemote(tx).setLabel(label);
       returns:
         - void
     python:
       <<: *method-setLabel
-      method: type.set_label(label)
+      method: type.as_remote(tx).set_label(label)
       returns:
         - None
 
@@ -91,13 +91,13 @@ methods:
         - boolean
     java:
       <<: *method-isAbstract
-      method: type.isAbstract();
+      method: type.asRemote(Transaction tx).isAbstract();
     javascript:
       <<: *method-isAbstract
-      method: await type.isAbstract();
+      method: await type.asRemote(tx).isAbstract();
     python:
       <<: *method-isAbstract
-      method: type.is_abstract()
+      method: type.as_remote(tx).is_abstract()
 
   - method:
     common: &method-getSupertype
@@ -105,19 +105,19 @@ methods:
       description: Retrieves the most immediate supertype of the type.
     java:
       <<: *method-getSupertype
-      method: type.getSupertype();
+      method: type.asRemote(Transaction tx).getSupertype();
       returns:
         - "[`Type`](../concept-api/type?tab=java#type-methods)"
         - "`null`"
     javascript:
       <<: *method-getSupertype
-      method: await type.getSupertype();
+      method: await type.asRemote(tx).getSupertype();
       returns:
         - "[`Type`](../concept-api/type?tab=javascript#type-methods)"
         - "`null`"
     python:
       <<: *method-getSupertype
-      method: type.get_supertype()
+      method: type.as_remote(tx).get_supertype()
       returns:
         - "[`Type`](../concept-api/type?tab=python#type-methods)"
         - None
@@ -128,17 +128,17 @@ methods:
       description: Retrieves all supertypes of the type.
     java:
       <<: *method-getSupertypes
-      method: type.getSupertypes();
+      method: type.asRemote(Transaction tx).getSupertypes();
       returns:
         - Stream<[`Type`](../concept-api/type?tab=java#type-methods)>
     javascript:
       <<: *method-getSupertypes
-      method: type.getSupertypes()
+      method: type.asRemote(tx).getSupertypes()
       returns:
         - "[`Stream`](../client-api/nodejs#stream)<[`Type`](../concept-api/type?tab=javascript#type-methods)>"
     python:
       <<: *method-getSupertypes
-      method: type.get_supertypes()
+      method: type.as_remote(tx).get_supertypes()
       returns:
         - Iterator of [`Type`](../concept-api/type?tab=python#type-methods)
 
@@ -148,16 +148,16 @@ methods:
       description: Retrieves all direct and indirect subtypes of the type.
     java:
       <<: *method-getSubtypes
-      method: type.getSubtypes();
+      method: type.asRemote(Transaction tx).getSubtypes();
       returns:
         - Stream<[`Type`](../concept-api/type?tab=java#type-methods)>
     javascript:
       <<: *method-getSubtypes
-      method: type.getSubtypes()
+      method: type.asRemote(tx).getSubtypes()
       returns:
         - "[`Stream`](../client-api/nodejs#stream)<[`Type`](../concept-api/type?tab=javascript#type-methods)>"
     python:
       <<: *method-getSubtypes
-      method: type.get_subtypes()
+      method: type.as_remote(tx).get_subtypes()
       returns:
         - Iterator of [`Type`](../concept-api/type?tab=python#type-methods)


### PR DESCRIPTION
## What is the goal of this PR?

We've added "asRemote" to all our code examples for the Remote Concept API. We often had users ask why the documented method was not available on the Concept, the answer being that they weren't using `asRemote`.

## What are the changes implemented in this PR?

Add "asRemote" to Remote Concept API code examples