### PR TITLE
Fix incorrectly named options

### DIFF
--- a/03-client-api/references/options.yml
+++ b/03-client-api/references/options.yml
@@ -10,11 +10,11 @@ description:
     - `infer`: whether to enable inference for the provided query (only settable at transaction level and above) (default: `false`)
     - `explain`: whether to enable explanations for the provided query (default: `false`)
     - `parallel`: whether the server should use parallel or single-threaded execution (default: `true`)
-    - `batchSize`: a guideline number of answers that the server should send before the client issues a fresh request (default: `50`)
+    - `prefetchSize`: a guideline number of answers that the server should send before the client issues a fresh request (default: `50`)
     - `traceInference`: if enabled, outputs reasoning tracing graphs in the logging directory. Should be used with `parallel = false`. (default: `false`)
     - `prefetch`: if enabled, the first batch of answers is streamed to the client even without an explicit request for it (default: `true` if query type is `match`, otherwise `false`)
     - `sessionIdleTimeoutMillis`: this timeout allows the server to close sessions if a client terminates or becomes unresponsive (default: `10000`)
-    - `schemaLockTimeoutAcquireMillis`: how long the client should wait if opening a session or transaction is blocked by a schema write lock (default: `10000`)
+    - `schemaLockAcquireTimeoutMillis`: how long the client should wait if opening a session or transaction is blocked by a schema write lock (default: `10000`)
 
     `TypeDBClusterOptions` has an additional option:
 
@@ -29,11 +29,11 @@ description:
     - `infer`: whether to enable inference for the provided query (only settable at transaction level and above) (default: `False`)
     - `explain`: whether to enable explanations for the provided query (default: `False`)
     - `parallel`: whether the server should use parallel or single-threaded execution (default: `True`)
-    - `batch_size`: a guideline number of answers that the server should send before the client issues a fresh request (default: `50`)
+    - `prefetch_size`: a guideline number of answers that the server should send before the client issues a fresh request (default: `50`)
     - `trace_inference`: if enabled, outputs reasoning tracing graphs in the logging directory. Should be used with `parallel = False`. (default: `False`)
     - `prefetch`: if enabled, the first batch of answers is streamed to the client even without an explicit request for it (default: `True` if query type is `match`, otherwise `False`)
     - `session_idle_timeout_millis`: this timeout allows the server to close sessions if a client terminates or becomes unresponsive (default: `10000`)
-    - `schema_lock_timeout_acquire_millis`: how long the client should wait if opening a session or transaction is blocked by a schema write lock (default: `10000`)
+    - `schema_lock_acquire_timeout_millis`: how long the client should wait if opening a session or transaction is blocked by a schema write lock (default: `10000`)
 
     `TypeDBClusterOptions` has an additional option:
 
@@ -48,11 +48,11 @@ description:
     - `infer`: whether to enable inference for the provided query (only settable at transaction level and above) (default: `false`)
     - `explain`: whether to enable explanations for the provided query (default: `false`)
     - `parallel`: whether the server should use parallel or single-threaded execution (default: `true`)
-    - `batchSize`: a guideline number of answers that the server should send before the client issues a fresh request (default: `50`)
+    - `prefetchSize`: a guideline number of answers that the server should send before the client issues a fresh request (default: `50`)
     - `traceInference`: if enabled, outputs reasoning tracing graphs in the logging directory. Should be used with `parallel = false`. (default: `false`)
     - `prefetch`: if enabled, the first batch of answers is streamed to the client even without an explicit request for it (default: `true` if query type is `match`, otherwise `false`)
     - `sessionIdleTimeoutMillis`: this timeout allows the server to close sessions if a client terminates or becomes unresponsive (default: `10000`)
-    - `schemaLockTimeoutAcquireMillis`: how long the client should wait if opening a session or transaction is blocked by a schema write lock (default: `10000`)
+    - `schemaLockAcquireTimeoutMillis`: how long the client should wait if opening a session or transaction is blocked by a schema write lock (default: `10000`)
 
     `TypeDBClusterOptions` has an additional option:
 
@@ -100,8 +100,8 @@ methods:
         - "[TypeDBOptions](#options)"
   - method:
     java:
-      method: options.setBatchSize(int size)
-      title: Explicitly set query batch iteration to a certain size
+      method: options.setPrefetchSize(int size)
+      title: Explicitly set query prefetch to a certain size
       description: >
         Override the server defaults for answer batch streaming. This tells the server to pre-compute and stream this
         number of answers at a time. These are buffered in the client until read. A larger batch size causes the server


### PR DESCRIPTION
## What is the goal of this PR?

`prefetchSize` was still going by its old name `batchSize`, and there was a typo in `schemaLockAcquireTimeoutMillis` - both are now fixed.

## What are the changes implemented in this PR?

Rename `batchSize` option to `prefetchSize`
Rename `schemaLockTimeoutAcquireMillis` option to `schemaLockAcquireTimeoutMillis`

this PR forms part of #551 