### PR TITLE
Rewrite migration and backup page

### DIFF
--- a/06-management/04-migration-and-backup.md
+++ b/06-management/04-migration-and-backup.md
@@ -7,7 +7,7 @@ up and migrating data between versions of TypeDB. toc: false
 
 ## Migration or Backup by Copying
 
-One method to migrate data across TypeDB distributions is by copying the data directory from the server. To do this,
+One method to migrate data across TypeDB distributions is by copying the data directory between servers. To do this,
 simply shut down the servers, and copy the database you wish to migrate from the `server/data/` directory into the
 `server/data/` directory in the destination distribution.
 
@@ -21,22 +21,21 @@ TypeDB will warn you when moving data across incompatible database encoding vers
 ## Migration or Backup using Export/Import
 
 TypeDB offers a way to export all data into a binary format, and then re-import it elsewhere. Using the export feature
-is a good way to bridge TypeDB versions that break backward compatibility.
+is the best way to migrate to a version of TypeDB that is not backward compatible.
 
-Note that this process will require local disk at least twice that of the database, as they make use of files to contain
-your data. If your have to migrate data that will not fit onto disk, please reach out to us on
-our [Discord](https://discord.com/invite/vaticle)
-community or [Forums](https://discuss.vaticle.com) where we can advise you further.
+Note that this process will require local disk at least twice that of the database.
+If your have to migrate data that will not fit onto disk, please reach out to us on our 
+[Discord](https://discord.com/invite/vaticle) community or [Forums](https://discuss.vaticle.com) where we can advise you further.
 
 Migration or backup using the export/import features is a two-step process: schema migration followed by data migration.
 
 ### Schema Migration
 
-The first step of migration is to migrate your schema. The `database schema my-database-name` command in Console allows
+The first step of migration is to migrate your schema. The command `database schema my-database-name` in Console allows
 you to get the current schema of a database as a single `define` query. This schema query can then be loaded via the
 Console to the new server.
 
-Export the old schema using console (the older server must be running for this):
+Export the old schema using console (the old server must be running for this):
 
 ```
 old/typedb console
@@ -47,7 +46,7 @@ Copy the schema into a file named `schema.tql`.
 
 You can skip the step of exporting schema if you already have a copy of your schema to import.
 
-If migrating from TypeDB version <2.0 to version >=2.0 you need to update your schema to conform to 2.0 syntax.
+You may need to update your schema syntax when moving between TypeDB versions.
 
 We then load the schema into the new TypeDB distribution:
 
@@ -59,9 +58,9 @@ new/typedb console
 [database]::schema::write> commit
 ```
 
-### Data Export/Import
+### Data Migration
 
-To create a binary export of a TypeDB database data, make sure that the TypeDB server you wish to export from is
+To create a binary export of a data from a TypeDB database, make sure that the TypeDB server you wish to export from is
 running. After the server is running, use the following command that ships with `typedb`:
 
 ```
@@ -71,24 +70,18 @@ typedb server export --database=[database] --file=[filename].typedb
 Note that this will NOT export the schema, only data. This file contains a complete copy of the data of the source
 database.
 
-If you have already migrated the schema into a new server distribution, you can import the data export produced using:
+If you have already migrated the schema into a new server distribution, you can import the exported binary data:
 
 ```
 typedb server import --database=[database] --file=[filename].typedb
 ```
-
-If a failure occurs during import, please check your database has the correct schema loaded first.
-
-These paths are relative or absolute.
 
 <div class="note">
 In versions previous to 2.6.0, the `--database=` and `--file=` named arguments are not used, and you should simply use positional arugments like this:
 `old/typedb server export <database> data.typedb` or `old/typedb server import --database=<database> --file=data.typedb`
 </div>
 
-## Dealing With Migration Issues
-
-### Migration Errors
+### Dealing With Export/Import Errors 
 
 If you encounter migration errors, follow this checklist:
 
@@ -96,7 +89,5 @@ If you encounter migration errors, follow this checklist:
   exporting from or importing to.)
 * Ensure that the schema has been imported correctly to the new database.
 * Ensure that the correct data import path was specified.
-* Ensure that the data was correctly exported by checking the filesize.
-* Ensure that any changed labels are remapped in the import options.
 
 If you have any further errors, please join one of our communities and ask for assistance.

--- a/06-management/04-migration-and-backup.md
+++ b/06-management/04-migration-and-backup.md
@@ -1,55 +1,43 @@
 ---
-pageTitle: Migration and Backup
-keywords: typedb, migration, backup
-longTailKeywords: typedb migration
-Summary: Backing up and migrating data between versions of TypeDB.
-toc: false
+pageTitle: Migration and Backup keywords: typedb, migration, backup longTailKeywords: typedb migration Summary: Backing
+up and migrating data between versions of TypeDB. toc: false
 ---
 
 # Migration and Backup
 
-TypeDB will warn you when moving data across incompatible binary-data layer versions.
+## Migration or Backup by Copying
 
-Here is the compatibility chart of loaded data of TypeDB:
+One method to migrate data across TypeDB distributions is by copying the data directory from the server. To do this,
+simply shut down the servers, and copy the database you wish to migrate from the `server/data/` directory into the
+`server/data/` directory in the destination distribution.
 
-| Data Encoding Version | Compatible TypeDB Versions |
-| --------------------- | -------------------------- |
-| 1                     | 2.0.0 - 2.5.0              |
-| 2                     | 2.6.0 -                    |
-  
+TypeDB will warn you when moving data across incompatible database encoding versions.
 
-<div class="note">
-[Important]
-If you are migrating from 1.6.x or below to 2.0.x, you must first copy your `server/db` directory from your existing Grakn installation into an Grakn 1.7.3 installation. This will be fast and can be done to move from a version of TypeDB without migration tools to one which has them. From 1.7.3 you are able to migrate to TypeDB 2.0. 
-</div>
+| Database encoding Version  | Compatible TypeDB Versions |
+| -------------------------- | -------------------------- |
+| 0                          | 2.0.0 - 2.5.0              |
+| 1                          | 2.6.0 -                    |
 
-The migration features describe beyond this point are designed for use with databases that can reasonably fit on a local disk at least twice, as they make use of files to contain your data. If you have use cases for migrating data that will not fit onto disk, please reach out to us on our [Discord](https://discord.com/invite/vaticle) community or [Forums](https://discuss.vaticle.com) where we can advise you further.
+## Migration or Backup using Export/Import
 
-## Data Backup
+TypeDB offers a way to export all data into a binary format, and then re-import it elsewhere. Using the export feature
+is a good way to bridge TypeDB versions that break backward compatibility.
 
-You can back up your data (NOT schema!) in a version-independent file using:
+Note that this process will require local disk at least twice that of the database, as they make use of files to contain
+your data. If your have to migrate data that will not fit onto disk, please reach out to us on
+our [Discord](https://discord.com/invite/vaticle)
+community or [Forums](https://discuss.vaticle.com) where we can advise you further.
 
-```
-typedb server export --database=[database] --file=[filename].typedb
-```
-
-You can import a backup into a new database with a compatible schema using:
-
-```
-typedb server import --database=[database] --file=[filename].typedb
-```
-
-These paths are relative or absolute. 
-
-Importing a backup will not delete existing data in the database, so you should clean the database using console and reload the schema prior to the operation.
-
-## Migration
+Migration or backup using the export/import features is a two-step process: schema migration followed by data migration.
 
 ### Schema Migration
 
-The first step of migration is to migrate your schema. The `database schema my-database-name` command in Console allows you to get the current schema of a database as a single `define` query. This schema query can then be loaded via the Console to the new server.
+The first step of migration is to migrate your schema. The `database schema my-database-name` command in Console allows
+you to get the current schema of a database as a single `define` query. This schema query can then be loaded via the
+Console to the new server.
 
-Export the old schema using console:
+Export the old schema using console (the older server must be running for this):
+
 ```
 old/typedb console
 > database schema [database]
@@ -59,29 +47,39 @@ Copy the schema into a file named `schema.tql`.
 
 You can skip the step of exporting schema if you already have a copy of your schema to import.
 
-If migrating from TypeDB version <2.0 to version >=2.0 you need to update your schema to conform to 2.0 syntax. 
+If migrating from TypeDB version <2.0 to version >=2.0 you need to update your schema to conform to 2.0 syntax.
 
-Once conforming to the new syntax, import the new schema:
+We then load the schema into the new TypeDB distribution:
+
 ```
 new/typedb console
 > database create <database> 
 > transaction <database> schema write
-[database]::schema::write> source schema.tql
+[database]::schema::write> source <path to schema.tql>
 [database]::schema::write> commit
 ```
 
-### Data Migration
+### Data Export/Import
 
-Data migration is performed using an export followed by an import.
+To create a binary export of a TypeDB database data, make sure that the TypeDB server you wish to export from is
+running. After the server is running, use the following command that ships with `typedb`:
 
 ```
-old/typedb server export --database=<database> --file=data.typedb
-new/typedb server import --database=<database> --file=data.typedb
+typedb server export --database=[database] --file=[filename].typedb
 ```
 
-This requires your database in the new typedb to have a valid schema that is compatible with your data. If a failure occurs during import, please check your database has the schema you expect.
+Note that this will NOT export the schema, only data. This file contains a complete copy of the data of the source
+database.
 
-Once the data has been successfully imported, you can safely delete the data file with `rm data.typedb`.
+If you have already migrated the schema into a new server distribution, you can import the data export produced using:
+
+```
+typedb server import --database=[database] --file=[filename].typedb
+```
+
+If a failure occurs during import, please check your database has the correct schema loaded first.
+
+These paths are relative or absolute.
 
 <div class="note">
 In versions previous to 2.6.0, the `--database=` and `--file=` named arguments are not used, and you should simply use positional arugments like this:
@@ -94,7 +92,8 @@ In versions previous to 2.6.0, the `--database=` and `--file=` named arguments a
 
 If you encounter migration errors, follow this checklist:
 
-* Ensure that you are running the correct `typedb` command (the binary in the TypeDB directory of the server you are exporting from or importing to.)
+* Ensure that you are running the correct `typedb` command (the binary in the TypeDB directory of the server you are
+  exporting from or importing to.)
 * Ensure that the schema has been imported correctly to the new database.
 * Ensure that the correct data import path was specified.
 * Ensure that the data was correctly exported by checking the filesize.


### PR DESCRIPTION
## What is the goal of this PR?
Since we updated the page on configuring and running TypeDB to reflect changes in 2.6.0, we do the same for the running of the import/export commands, which now used named instead of positional arguments.

## What are the changes implemented in this PR?
* Update migration docs to use named instead of positional arguments
* Remove the docs on features we no longer have: remapping type labels on import
* Highlight that previous to 2.6.0 the arguments were position instead of named