### PR TITLE
documentation: fix for call relation example

### DIFF
--- a/08-examples/01-phone-calls-schema.md
+++ b/08-examples/01-phone-calls-schema.md
@@ -96,8 +96,8 @@ define
     relates customer;
 
   call sub relation,
-    relates provider,
-    relates customer,
+    relates caller,
+    relates callee,
     owns started-at,
     owns duration;
 


### PR DESCRIPTION
## What is the goal of this PR?

Fix a mistake in the documentation. The typeql code for `call` mistakenly reuses the roles defined in `contract`.

## What are the changes implemented in this PR?

Replaced the roles with `caller` and `callee`.