### PR TITLE
Fix common friends example query

### DIFF
--- a/12-comparisons/02-graph-databases-and-typedb.md
+++ b/12-comparisons/02-graph-databases-and-typedb.md
@@ -228,8 +228,8 @@ In TypeDB, the same query looks like this (we could actually optimise this query
 ```typeql
 match $bob isa person, has name "Bob"; 
 $susan isa person, has name "Susan"; $common-friend isa person;
-($bob, $susan) isa friendship; ($susan, $common-friend) isa friendship;
-($common-friend, $bob) isa friendship; get $common-friend; 
+($susan, $common-friend) isa friendship; ($common-friend, $bob) isa friendship;
+get $common-friend;
 ```
 
 In TypeDB, we ask for the relations of type `friendship` between Bob and Susan, Susan and an undefined person, and Bob and an undefined person. Note that the `ISA_FRIEND_OF` relation doesn't directly translate into a `friendship` relation in TypeDB. The former is a directional edge that only represents how one person is a friend of another person, but not the other way around. Conversely, the TypeDB relation `friendship` represents that both persons play the role of `friend`. Let's look at another example:


### PR DESCRIPTION
Susan and Bob need not be friends.

## What is the goal of this PR?

Fixes example query

## What are the changes implemented in this PR?

Removes the constraint that Bob and Susan are friends from the Type query. In the example for finding common friends between Bob and Susan it's not mentioned that Bob and Susan are friends. However this is added as an additional constraint in the Type query. For example the cypher query doesn't have the constraint that Bob and Susan are friends.
