### PR TITLE
Disable Bazel cache because its cert expired

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,4 @@
 
-try-import /opt/credentials/bazel-remote-cache.rc
-
 build --incompatible_strict_action_env --java_language_version=11 --javacopt='--release 11'
 run --incompatible_strict_action_env
 test --incompatible_strict_action_env --test_env=PATH

--- a/07-workbase/00-overview.md
+++ b/07-workbase/00-overview.md
@@ -8,7 +8,7 @@ toc: false
 
 <div class = "note">
 [Warning]
-TypeDB Workbase is currently in the process of being replaced with a more performant application: TypeDB Studio, which will be released very soon (September 2021)!
+TypeDB Workbase is currently in the process of being replaced with a more performant application: TypeDB Studio, which will be released very soon (March 2022)!
 </div>
 
 ## What is Workbase?

--- a/07-workbase/01-connection.md
+++ b/07-workbase/01-connection.md
@@ -8,7 +8,7 @@ toc: false
 
 <div class = "note">
 [Warning]
-TypeDB Workbase is currently in the process of being replaced with a more performant application: TypeDB Studio, which will be released very soon (September 2021)!
+TypeDB Workbase is currently in the process of being replaced with a more performant application: TypeDB Studio, which will be released very soon (March 2022)!
 </div>
 
 ## Connect to TypeDB

--- a/07-workbase/02-visualisation.md
+++ b/07-workbase/02-visualisation.md
@@ -8,7 +8,7 @@ toc: false
 
 <div class = "note">
 [Warning]
-TypeDB Workbase is currently in the process of being replaced with a more performant application: TypeDB Studio, which will be released very soon (September 2021)!
+TypeDB Workbase is currently in the process of being replaced with a more performant application: TypeDB Studio, which will be released very soon (March 2022)!
 </div>
 
 ## Visualise

--- a/07-workbase/03-investigation.md
+++ b/07-workbase/03-investigation.md
@@ -8,7 +8,7 @@ toc: false
 
 <div class = "note">
 [Warning]
-TypeDB Workbase is currently in the process of being replaced with a more performant application: TypeDB Studio, which will be released very soon (September 2021)!
+TypeDB Workbase is currently in the process of being replaced with a more performant application: TypeDB Studio, which will be released very soon (March 2022)!
 </div>
 
 ## Investigate

--- a/07-workbase/04-schema-designer.md
+++ b/07-workbase/04-schema-designer.md
@@ -8,7 +8,7 @@ toc: false
 
 <div class = "note">
 [Warning]
-TypeDB Workbase is currently in the process of being replaced with a more performant application: TypeDB Studio, which will be released very soon (September 2021)!
+TypeDB Workbase is currently in the process of being replaced with a more performant application: TypeDB Studio, which will be released very soon (March 2022)!
 </div>
 
 <div class = "note">

--- a/08-examples/05-phone-calls-queries.md
+++ b/08-examples/05-phone-calls-queries.md
@@ -28,7 +28,7 @@ Make sure you have [TypeDB Workbase](../07-workbase/00-overview.md) installed, [
 
 <div class = "note">
 [Warning]
-TypeDB Workbase is currently in the process of being replaced with a more performant application: TypeDB Studio, which will be released very soon (September 2021)!
+TypeDB Workbase is currently in the process of being replaced with a more performant application: TypeDB Studio, which will be released very soon (March 2022)!
 </div>
 
 Let’s begin.


### PR DESCRIPTION
## What is the goal of this PR?

Our RBE cert has expired. As a temporary fix to enable releasing Docs, we're disabling RBE until the issue is properly fixed.

## What are the changes implemented in this PR?

Disable Bazel cache because its cert expired
