### PR TITLE
Describe how to set up Console to support UTF-8 characters

### DIFF
--- a/02-console/01-console.md
+++ b/02-console/01-console.md
@@ -43,6 +43,8 @@ If it doesn't, these characters will most likely be rendered as "?" symbols in C
 - **Windows**: use [Windows Terminal](https://apps.microsoft.com/store/detail/windows-terminal/9N0DX20HK701?hl=en-gb&gl=GB) or run [chcp](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/chcp) in your terminal (e.g: `chcp 936` for Chinese text)
 - **MacOS, Linux**: use `locale -a` to list all installed locales, and use (for example, to use `en_US.UTF-8`) `export LANG=en_US.UTF-8 && export LC_ALL=en_US.UTF-8`
 
+Most systems also allow you to set the system-wide locale, however this impacts the appearance of other applications.
+
 ## Command line arguments
 
 You can provide several command-line arguments when running Console in the terminal.

--- a/02-console/01-console.md
+++ b/02-console/01-console.md
@@ -9,10 +9,10 @@ toc: false
 ## What is the TypeDB Console?
 The TypeDB Console, along with the [TypeDB Clients](../03-client-api/00-overview.md) and [Studio](../07-studio/00-overview.md), is an interface which we can use to read from and write to a TypeDB knowledge graph. Console interacts directly with a given database that contains the TypeDB knowledge graph.
 
-## Running TypeDB Console in the terminal
+## Run TypeDB Console in the terminal
 
 
-### Connecting to TypeDB 
+### Connect to TypeDB 
 
 Go to the directory where you have your `typedb-all` or `typedb-console` distribution unarchived, and run `./typedb console`
 ```
@@ -22,7 +22,7 @@ cd <your_typedb_console_dir>/
 ```
 
 
-### Connecting to TypeDB Cluster
+### Connect to TypeDB Cluster
 
 Go to the directory whe you have your `typedb-cluster-all` or `typedb-console` distribution unarchived, and run `./typedb console`
 ```
@@ -31,6 +31,17 @@ cd <your_typedb_console_dir>/
 Enter password:
 >
 ```
+
+### Locale settings
+
+TypeDB allows string attributes to be stored that contain characters outside the [ASCII](https://ascii.cl/) range
+(for example: non-English letters, symbols, and emojis). To manipulate them using Console, the system locale must use
+the Unicode code set.
+
+If it doesn't, these characters will most likely be rendered as "?" symbols in Console. If this issue occurs:
+
+- **Windows**: use [Windows Terminal](https://apps.microsoft.com/store/detail/windows-terminal/9N0DX20HK701?hl=en-gb&gl=GB) or run [chcp](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/chcp) in your terminal (e.g: `chcp 936` for Chinese text)
+- **MacOS, Linux**: use `locale -a` to list all installed locales, and use (for example, to use `en_US.UTF-8`) `export LANG=en_US.UTF-8 && export LC_ALL=en_US.UTF-8`
 
 ## Command line arguments
 

--- a/02-console/01-console.md
+++ b/02-console/01-console.md
@@ -35,8 +35,8 @@ Enter password:
 ### Locale settings
 
 TypeDB can store string attributes that have characters outside the [ASCII](https://ascii.cl/) range (for example:
-non-English letters, symbols, and emojis). To manipulate them using Console, the system locale must use a compatible
-code set, such as Unicode.
+non-English letters, symbols, and emojis). To manipulate them using Console, the console terminal must use a locale
+with a compatible code set, such as Unicode.
 
 If it doesn't, these characters will most likely be rendered as "?" symbols in Console. If this issue occurs:
 

--- a/02-console/01-console.md
+++ b/02-console/01-console.md
@@ -35,8 +35,8 @@ Enter password:
 ### Locale settings
 
 TypeDB can store string attributes that have characters outside the [ASCII](https://ascii.cl/) range (for example:
-non-English letters, symbols, and emojis). To manipulate them using Console, the system locale must use the Unicode
-code set.
+non-English letters, symbols, and emojis). To manipulate them using Console, the system locale must use a compatible
+code set, such as Unicode.
 
 If it doesn't, these characters will most likely be rendered as "?" symbols in Console. If this issue occurs:
 

--- a/02-console/01-console.md
+++ b/02-console/01-console.md
@@ -34,9 +34,9 @@ Enter password:
 
 ### Locale settings
 
-TypeDB allows string attributes to be stored that contain characters outside the [ASCII](https://ascii.cl/) range
-(for example: non-English letters, symbols, and emojis). To manipulate them using Console, the system locale must use
-the Unicode code set.
+TypeDB can store string attributes that have characters outside the [ASCII](https://ascii.cl/) range (for example:
+non-English letters, symbols, and emojis). To manipulate them using Console, the system locale must use the Unicode
+code set.
 
 If it doesn't, these characters will most likely be rendered as "?" symbols in Console. If this issue occurs:
 


### PR DESCRIPTION
## What is the goal of this PR?

We added a section to the Console docs on how to ensure that non-ASCII characters can be correctly inserted into TypeDB and printed correctly (for example, when entering foreign characters)

## What are the changes implemented in this PR?

Describe how to set up Console to support UTF-8 characters