### PR TITLE
Update examples links

### DIFF
--- a/08-examples/00-overview.md
+++ b/08-examples/00-overview.md
@@ -7,13 +7,13 @@ Summary: TypeDB examples showcasing schema definition, data migration and retrie
 
 ## Examples
 
-[**Telecoms - Phone Calls (Java, JS, Python):**](https://github.com/vaticle/typedb-examples/tree/master/phone_calls) a database of customers of a fictional telecom company and calls they make.
+[**Telecoms - Phone Calls (Java, JS, Python):**](https://github.com/vaticle/typedb-examples/tree/master/telecom/phone_calls) a database of customers of a fictional telecom company and calls they make.
 
-[**Gaming - XCOM 2 (Java):**](https://github.com/vaticle/typedb-examples/tree/master/xcom) a database of interdependent research tasks in the game XCOM 2, featuring automatic inference of available research based on completed tasks and available items.
+[**Gaming - XCOM 2 (Java):**](https://github.com/vaticle/typedb-examples/tree/master/gaming/xcom) a database of interdependent research tasks in the game XCOM 2, featuring automatic inference of available research based on completed tasks and available items.
 
-[**Biology - Catalogue of Life (Java):**](https://github.com/vaticle/typedb-examples/tree/master/catalogue_of_life) a database containing the information about the taxonomy of life on Earth, showcasing automated loading of data using [TypeDB-Loader.](https://github.com/typedb-osi/typedb-loader)
+[**Biology - Catalogue of Life (Java):**](https://github.com/vaticle/typedb-examples/tree/master/biology/catalogue_of_life) a database containing the information about the taxonomy of life on Earth, showcasing automated loading of data using [TypeDB-Loader.](https://github.com/typedb-osi/typedb-loader)
 
-[**Software Dev - GitHub (Kotlin):**](https://github.com/vaticle/typedb-examples/tree/master/github) Load data from a live repository on GitHub or from a Vaticle GitHub snapshot, and get results via a custom GUI interface that uses the Java client to fetch the requested data.
+[**Software Dev - GitHub (Kotlin):**](https://github.com/vaticle/typedb-examples/tree/master/software/github) Load data from a live repository on GitHub or from a Vaticle GitHub snapshot, and get results via a custom GUI interface that uses the Java client to fetch the requested data.
 
 ## A hands-on walkthrough
 


### PR DESCRIPTION
## What is the goal of this PR?

We update all links to the examples now that typedb-examples was restructured.

## What are the changes implemented in this PR?

Merge after https://github.com/vaticle/typedb-examples/pull/137 is merged. Closes https://github.com/vaticle/typedb-examples/issues/122.
