### PR TITLE
Fix Typo

### DIFF
--- a/08-examples/00-overview.md
+++ b/08-examples/00-overview.md
@@ -17,7 +17,7 @@ Summary: TypeDB examples showcasing schema definition, data migration and retrie
 
 ## A hands-on walkthrough
 
-To get a better idea of how you can use TypeDB, we'll take a closer look at the [`phone_calls` example.](https://github.com/vaticle/typedb-examples/tree/master/phone_calls)
+To get a better idea of how you can use TypeDB, we'll take a closer look at the [`phone_calls` example.](https://github.com/vaticle/typedb-examples/tree/master/telecom/phone_calls)
 The database we'll be working on in this series contains a dataset of **people** who **call** each other. Those who have a **contract** with the **company** also have their **name**, **age**, and the **city** they reside in recorded within the database.
 
 In the following three sections, we together:


### PR DESCRIPTION
## What is the goal of this PR?

We fix a typo in the link that was overlooked in https://github.com/vaticle/docs/pull/610

## What are the changes implemented in this PR?

The typo is fixed, the link points to the correct destination. Furthermore, we have opened an issue to look at preventing this class of errors in the future: https://github.com/vaticle/docs/issues/612.

