### PR TITLE
Document Concept API explicit methods

### DIFF
--- a/04-concept-api/references/attribute_type.yml
+++ b/04-concept-api/references/attribute_type.yml
@@ -69,8 +69,8 @@ methods:
 
   - method:
     common: &method-getInstances
-      title: Retrieve all direct and indirect instances of this AttributeType
-      description: Retrieves all Attributes that are instances of this Type.
+      title: Retrieve all instances of this AttributeType
+      description: Retrieves all direct and indirect Attributes that are instances of this Type.
     java:
       <<: *method-getInstances
       method: attributeType.asRemote(Transaction tx).getInstances();

--- a/04-concept-api/references/attribute_type.yml
+++ b/04-concept-api/references/attribute_type.yml
@@ -137,7 +137,7 @@ methods:
         - "[`Stream`](../client-api/nodejs#stream) of [`Thing`](../concept-api/thing?tab=javascript#thing-methods)"
     python:
       <<: *method-getOwnersExplicit
-      method: attributeType.as_remote(tx).get_owners_explicit(onlyKey)
+      method: attribute_type.as_remote(tx).get_owners_explicit(only_key)
       returns:
         - Iterator of [`Thing`](../concept-api/thing?tab=python#thing-methods)
 

--- a/04-concept-api/references/attribute_type.yml
+++ b/04-concept-api/references/attribute_type.yml
@@ -69,7 +69,7 @@ methods:
 
   - method:
     common: &method-getInstances
-      title: Retrieve all instances of this AttributeType
+      title: Retrieve all direct and indirect instances of this AttributeType
       description: Retrieves all Attributes that are instances of this Type.
     java:
       <<: *method-getInstances

--- a/04-concept-api/references/attribute_type.yml
+++ b/04-concept-api/references/attribute_type.yml
@@ -89,7 +89,7 @@ methods:
 
   - method:
     common: &method-getOwners
-      title: Retrieve owners of this Type of Attribute
+      title: Retrieve direct and inherited owners of this Type of Attribute
       description: Retrieve all Things that own an attribute of this type. Optionally, only fetches Things that own an attribute of this type as a key.
       accepts:
         param:
@@ -111,6 +111,33 @@ methods:
     python:
       <<: *method-getOwners
       method: attributeType.as_remote(tx).get_owners(onlyKey)
+      returns:
+        - Iterator of [`Thing`](../concept-api/thing?tab=python#thing-methods)
+
+  - method:
+    common: &method-getOwnersExplicit
+      title: Retrieve direct owners of this Type of Attribute
+      description: Retrieve all Things that directly own an attribute of this type. Optionally, only fetches Things that own an attribute of this type as a key.
+      accepts:
+        param:
+          name: onlyKey
+          description: If true, only retrieve things that have an attribute of this type as a key.
+          type: boolean
+          required: false
+          default: false
+    java:
+      <<: *method-getOwnersExplicit
+      method: attributeType.asRemote(Transaction tx).getOwnersExplicit(boolean onlyKey);
+      returns:
+        - Stream<[`Thing`](../concept-api/thing?tab=java#thing-methods)>
+    javascript:
+      <<: *method-getOwnersExplicit
+      method: attributeType.asRemote(tx).getOwnersExplicit(onlyKey)
+      returns:
+        - "[`Stream`](../client-api/nodejs#stream) of [`Thing`](../concept-api/thing?tab=javascript#thing-methods)"
+    python:
+      <<: *method-getOwnersExplicit
+      method: attributeType.as_remote(tx).get_owners_explicit(onlyKey)
       returns:
         - Iterator of [`Thing`](../concept-api/thing?tab=python#thing-methods)
 

--- a/04-concept-api/references/boolean_attribute_type.yml
+++ b/04-concept-api/references/boolean_attribute_type.yml
@@ -99,7 +99,7 @@ methods:
 
   - method:
     common: &method-getInstances
-      title: Retrieve all instances of this BooleanAttributeType
+      title: Retrieve all direct and indirect instances of this BooleanAttributeType
       description: Retrieves all BooleanAttributes that are instances of this Type.
     java:
       <<: *method-getInstances

--- a/04-concept-api/references/boolean_attribute_type.yml
+++ b/04-concept-api/references/boolean_attribute_type.yml
@@ -99,8 +99,8 @@ methods:
 
   - method:
     common: &method-getInstances
-      title: Retrieve all direct and indirect instances of this BooleanAttributeType
-      description: Retrieves all BooleanAttributes that are instances of this Type.
+      title: Retrieve all instances of this BooleanAttributeType
+      description: Retrieves all direct and indirect BooleanAttributes that are instances of this Type.
     java:
       <<: *method-getInstances
       method: booleanAttributeType.asRemote(Transaction tx).getInstances();

--- a/04-concept-api/references/datetime_attribute_type.yml
+++ b/04-concept-api/references/datetime_attribute_type.yml
@@ -128,7 +128,7 @@ methods:
   - method:
     common: &method-getInstances
       title: Retrieve all instances of this DateTimeAttributeType
-      description: Retrieves all DateTimeAttributes that are instances of this Type.
+      description: Retrieves all direct and indirect DateTimeAttributes that are instances of this Type.
     java:
       <<: *method-getInstances
       method: type.asRemote(Transaction tx).getInstances();

--- a/04-concept-api/references/double_attribute_type.yml
+++ b/04-concept-api/references/double_attribute_type.yml
@@ -128,7 +128,7 @@ methods:
   - method:
     common: &method-getInstances
       title: Retrieve all instances of this DoubleAttributeType
-      description: Retrieves all DoubleAttributes that are instances of this Type.
+      description: Retrieves all direct and indirect DoubleAttributes that are instances of this Type.
     java:
       <<: *method-getInstances
       method: type.asRemote(Transaction tx).getInstances();

--- a/04-concept-api/references/entity_type.yml
+++ b/04-concept-api/references/entity_type.yml
@@ -69,7 +69,7 @@ methods:
   - method:
     common: &method-getInstances
       title: Retrieve all instances of this EntityType
-      description: Retrieves all Entity objects that are instances of this Type.
+      description: Retrieves all direct and indirect Entity objects that are instances of this Type.
     java:
       <<: *method-getInstances
       method: type.asRemote(Transaction tx).getInstances();

--- a/04-concept-api/references/long_attribute_type.yml
+++ b/04-concept-api/references/long_attribute_type.yml
@@ -128,7 +128,7 @@ methods:
   - method:
     common: &method-getInstances
       title: Retrieve all instances of this LongAttributeType
-      description: Retrieves all LongAttributes that are instances of this Type.
+      description: Retrieves all direct and indirect LongAttributes that are instances of this Type.
     java:
       <<: *method-getInstances
       method: type.asRemote(Transaction tx).getInstances();

--- a/04-concept-api/references/relation_type.yml
+++ b/04-concept-api/references/relation_type.yml
@@ -22,7 +22,7 @@ methods:
   - method:
     common: &method-getrelates
       title: Retrieve roles
-      description: Retrieve roles that this RelationType relates to.
+      description: Retrieve roles that this RelationType relates to directly or via inheritance.
     java:
       <<: *method-getrelates
       method: relationType.asRemote(Transaction tx).getRelates();
@@ -36,6 +36,26 @@ methods:
     python:
       <<: *method-getrelates
       method: relation_type.as_remote(tx).get_relates()
+      returns:
+        - "Iterator of [`RoleType`](../concept-api/type?tab=python#roletype-methods)"
+
+  - method:
+    common: &method-getrelatesexplicit
+      title: Retrieve direct roles
+      description: Retrieve roles that this RelationType relates to directly.
+    java:
+      <<: *method-getrelatesexplicit
+      method: relationType.asRemote(Transaction tx).getRelatesExplicit();
+      returns:
+        - "[Stream](../client-api/nodejs#stream)<[`RoleType`](../concept-api/type?tab=java#roletype-methods)>"
+    javascript:
+      <<: *method-getrelatesexplicit
+      method: relationType.asRemote(tx).getRelatesExplicit();
+      returns:
+        - "[Stream](../client-api/nodejs#stream) of [`RoleType`](../concept-api/type?tab=javascript#roletype-methods)"
+    python:
+      <<: *method-getrelatesexplicit
+      method: relation_type.as_remote(tx).get_relates_explicit()
       returns:
         - "Iterator of [`RoleType`](../concept-api/type?tab=python#roletype-methods)"
 

--- a/04-concept-api/references/relation_type.yml
+++ b/04-concept-api/references/relation_type.yml
@@ -200,7 +200,7 @@ methods:
   - method:
     common: &method-getInstances
       title: Retrieve all instances of this RelationType
-      description: Retrieves all Relations that are instances of this Type.
+      description: Retrieves all direct and indirect Relations that are instances of this Type.
     java:
       <<: *method-getInstances
       method: type.asRemote(Transaction tx).getInstances();

--- a/04-concept-api/references/string_attribute_type.yml
+++ b/04-concept-api/references/string_attribute_type.yml
@@ -149,7 +149,7 @@ methods:
   - method:
     common: &method-getInstances
       title: Retrieve all instances of this StringAttributeType
-      description: Retrieves all StringAttributes that are instances of this Type.
+      description: Retrieves all direct and indirect StringAttributes that are instances of this Type.
     java:
       <<: *method-getInstances
       method: type.asRemote(Transaction tx).getInstances();

--- a/04-concept-api/references/thing_type.yml
+++ b/04-concept-api/references/thing_type.yml
@@ -108,26 +108,6 @@ methods:
         - Iterator of [`Thing`](../concept-api/thing?tab=python#thing-methods)
 
   - method:
-    common: &method-getInstancesExplicit
-      title: Retrieve direct instances
-      descriptions: Retrieve all direct instances of this ThingType.
-    java:
-      <<: *method-getInstancesExplicit
-      method: thingType.asRemote(Transaction tx).getInstancesExplicit();
-      returns:
-        - Stream<[`Thing`](../concept-api/thing?tab=java#thing-methods)>
-    javascript:
-      <<: *method-getInstancesExplicit
-      method: thingType.asRemote(tx).getInstancesExplicit();
-      returns:
-        - "[`Stream`](../client-api/nodejs#stream) of [`Thing`](../concept-api/thing?tab=javascript#thing-methods)"
-    python:
-      <<: *method-getInstancesExplicit
-      method: thing_type.as_remote(tx).get_instances_explicit()
-      returns:
-        - Iterator of [`Thing`](../concept-api/thing?tab=python#thing-methods)
-
-  - method:
     common: &method-setAbstract
       title: Set abstract
       description: Set a ThingType to be abstract, meaning it cannot have instances.

--- a/04-concept-api/references/thing_type.yml
+++ b/04-concept-api/references/thing_type.yml
@@ -90,7 +90,7 @@ methods:
   - method:
     common: &method-getInstances
       title: Retrieve instances
-      descriptions: Retrieve all instances of this ThingType.
+      descriptions: Retrieve all direct or indirect instances of this ThingType.
     java:
       <<: *method-getInstances
       method: thingType.asRemote(Transaction tx).getInstances();
@@ -104,6 +104,26 @@ methods:
     python:
       <<: *method-getInstances
       method: thing_type.as_remote(tx).get_instances()
+      returns:
+        - Iterator of [`Thing`](../concept-api/thing?tab=python#thing-methods)
+
+  - method:
+    common: &method-getInstancesExplicit
+      title: Retrieve direct instances
+      descriptions: Retrieve all direct instances of this ThingType.
+    java:
+      <<: *method-getInstancesExplicit
+      method: thingType.asRemote(Transaction tx).getInstancesExplicit();
+      returns:
+        - Stream<[`Thing`](../concept-api/thing?tab=java#thing-methods)>
+    javascript:
+      <<: *method-getInstancesExplicit
+      method: thingType.asRemote(tx).getInstancesExplicit();
+      returns:
+        - "[`Stream`](../client-api/nodejs#stream) of [`Thing`](../concept-api/thing?tab=javascript#thing-methods)"
+    python:
+      <<: *method-getInstancesExplicit
+      method: thing_type.as_remote(tx).get_instances_explicit()
       returns:
         - Iterator of [`Thing`](../concept-api/thing?tab=python#thing-methods)
 
@@ -336,9 +356,29 @@ methods:
         - Iterator of [`RoleType`](../concept-api/type?tab=python#roletype-methods)
 
   - method:
+    common: &method-getPlaysExplicit
+      title: Retrieve playable roles
+      description: Retrieves all direct roles that are allowed to be played by the instances of this type.
+    java:
+      <<: *method-getPlaysExplicit
+      method: thingType.asRemote(Transaction tx).getPlaysExplicit();
+      returns:
+        - Stream<[`RoleType`](../concept-api/type?tab=java#roletype-methods)>
+    javascript:
+      <<: *method-getPlaysExplicit
+      method: await thingType.asRemote(tx).getPlaysExplicit();
+      returns:
+        - "[`Stream`](../client-api/nodejs#stream) of [`RoleType`](../concept-api/type?tab=javascript#roletype-methods)"
+    python:
+      <<: *method-getPlaysExplicit
+      method: thing_type.as_remote(tx).get_plays_explicit()
+      returns:
+        - Iterator of [`RoleType`](../concept-api/type?tab=python#roletype-methods)
+
+  - method:
     common: &method-getOwns
       title: Retrieve attributes
-      description: Retrieves attribute types that the instances of this type are allowed to own.
+      description: Retrieves attribute types that the instances of this type are allowed to own directly or via inheritance.
       accepts:
         param:
           name: keysOnly
@@ -358,9 +398,31 @@ methods:
         - "[`Stream`](../client-api/nodejs#stream) of [`AttributeType`](../concept-api/type?tab=javascript#attributetype-methods)"
 
   - method:
+    common: &method-getOwnsExplicit
+      title: Retrieve attributes
+      description: Retrieves attribute types that the instances of this type are allowed to own directly.
+      accepts:
+        param:
+          name: keysOnly
+          type: boolean
+          description: If set to `true`, then only attribute types owned as keys will be retrieved.
+          required: false
+          default: false
+    java:
+      <<: *method-getOwnsExplicit
+      method: thingType.asRemote(Transaction tx).getOwnsExplicit(boolean keysOnly);
+      returns:
+        - Stream<[`AttributeType`](../concept-api/type?tab=java#attributetype-methods)>
+    javascript:
+      <<: *method-getOwnsExplicit
+      method: await thingType.asRemote(tx).getOwnsExplicit(keysOnly);
+      returns:
+        - "[`Stream`](../client-api/nodejs#stream) of [`AttributeType`](../concept-api/type?tab=javascript#attributetype-methods)"
+
+  - method:
     common: &method-getOwnsForValueType
       title: Retrieve attributes
-      description: Retrieves attribute types that the instances of this type are allowed to own.
+      description: Retrieves attribute types that the instances of this type are allowed to own directly or via inheritance.
       accepts:
         param1: &accepts-getOwnsForValueType-valueType
           name: valueType
@@ -396,10 +458,69 @@ methods:
         - "[`Stream`](../client-api/nodejs#stream) of [`AttributeType`](../concept-api/type?tab=javascript#attributetype-methods)"
 
   - method:
+    common: &method-getOwnsExplicitForValueType
+      title: Retrieve attributes
+      description: Retrieves attribute types that the instances of this type are allowed to own directly.
+      accepts:
+        param1: &accepts-getOwnsExplicitForValueType-valueType
+          name: valueType
+          type: "`AttributeType.ValueType`"
+          description: If specified, only attribute types of this ValueType will be retrieved.
+          required: false
+          default: null
+        param2: &accepts-getOwnsExplicitForValueType-keysOnly
+          name: keysOnly
+          type: boolean
+          description: If set to `true`, then only attribute types owned as keys will be retrieved.
+          required: false
+          default: false
+    java:
+      <<: *method-getOwnsExplicitForValueType
+      method: thingType.asRemote(Transaction tx).getOwnsExplicit(AttributeType.ValueType valueType, boolean keysOnly);
+      accepts:
+        param1:
+          <<: *accepts-getOwnsExplicitForValueType-valueType
+        param2:
+          <<: *accepts-getOwnsExplicitForValueType-keysOnly
+      returns:
+        - Stream<[`AttributeType`](../concept-api/type?tab=java#attributetype-methods)>
+    javascript:
+      <<: *method-getOwnsExplicitForValueType
+      method: await thingType.asRemote(tx).getOwnsExplicit(valueType, keysOnly);
+      accepts:
+        param1:
+          <<: *accepts-getOwnsExplicitForValueType-valueType
+        param2:
+          <<: *accepts-getOwnsExplicitForValueType-keysOnly
+      returns:
+        - "[`Stream`](../client-api/nodejs#stream) of [`AttributeType`](../concept-api/type?tab=javascript#attributetype-methods)"
+
+  - method:
     python:
       title: Retrieve attributes
-      description: Retrieves attribute types that the instances of this type are allowed to own.
+      description: Retrieves attribute types that the instances of this type are allowed to own directly or via inheritance.
       method: thing_type.as_remote(tx).get_owns(value_type=None, keys_only=False)
+      accepts:
+        param1:
+          name: value_type
+          type: "`ValueType`"
+          description: If specified, only attribute types of this ValueType will be retrieved.
+          required: false
+          default: None
+        param2:
+          name: keys_only
+          type: bool
+          description: If set to `True`, then only attribute types owned as keys will be retrieved.
+          required: false
+          default: False
+      returns:
+        - Iterator of [`AttributeType`](../concept-api/type?tab=python#attributetype-methods)
+
+  - method:
+    python:
+      title: Retrieve direct attributes
+      description: Retrieves attribute types that the instances of this type are allowed to own directly.
+      method: thing_type.as_remote(tx).get_owns_explicit(value_type=None, keys_only=False)
       accepts:
         param1:
           name: value_type

--- a/04-concept-api/references/type.yml
+++ b/04-concept-api/references/type.yml
@@ -161,3 +161,23 @@ methods:
       method: type.as_remote(tx).get_subtypes()
       returns:
         - Iterator of [`Type`](../concept-api/type?tab=python#type-methods)
+
+  - method:
+    common: &method-getSubtypesExplicit
+      title: Retrieve direct subtypes
+      description: Retrieves all direct subtypes of the type.
+    java:
+      <<: *method-getSubtypesExplicit
+      method: type.asRemote(Transaction tx).getSubtypesExplicit();
+      returns:
+        - Stream<[`Type`](../concept-api/type?tab=java#type-methods)>
+    javascript:
+      <<: *method-getSubtypesExplicit
+      method: type.asRemote(tx).getSubtypesExplicit()
+      returns:
+        - "[`Stream`](../client-api/nodejs#stream)<[`Type`](../concept-api/type?tab=javascript#type-methods)>"
+    python:
+      <<: *method-getSubtypesExplicit
+      method: type.as_remote(tx).get_subtypes_explicit()
+      returns:
+        - Iterator of [`Type`](../concept-api/type?tab=python#type-methods)

--- a/04-concept-api/references/type.yml
+++ b/04-concept-api/references/type.yml
@@ -161,23 +161,3 @@ methods:
       method: type.as_remote(tx).get_subtypes()
       returns:
         - Iterator of [`Type`](../concept-api/type?tab=python#type-methods)
-
-  - method:
-    common: &method-getSubtypesExplicit
-      title: Retrieve direct subtypes
-      description: Retrieves all direct subtypes of the type.
-    java:
-      <<: *method-getSubtypesExplicit
-      method: type.asRemote(Transaction tx).getSubtypesExplicit();
-      returns:
-        - Stream<[`Type`](../concept-api/type?tab=java#type-methods)>
-    javascript:
-      <<: *method-getSubtypesExplicit
-      method: type.asRemote(tx).getSubtypesExplicit()
-      returns:
-        - "[`Stream`](../client-api/nodejs#stream)<[`Type`](../concept-api/type?tab=javascript#type-methods)>"
-    python:
-      <<: *method-getSubtypesExplicit
-      method: type.as_remote(tx).get_subtypes_explicit()
-      returns:
-        - Iterator of [`Type`](../concept-api/type?tab=python#type-methods)


### PR DESCRIPTION
## What is the goal of this PR?

We document missing APIs, such as `getOwnsExplicit`, that are available on all our clients. We also clarify the wording for `getSubtypes` and `getInstances` to make clear they return direct and indirect concepts.

## What are the changes implemented in this PR?

Document:
  * `ThingType.getOwnsExplicit()` 
  * `ThingType.getPlaysExplicit()`
  * `RelationType.getRelatesExplicit()`
  * `AttributeType.getOwnersExplicit()`
