### PR TITLE
Document `is` and add link to grammar

### DIFF
--- a/11-query/00-overview.md
+++ b/11-query/00-overview.md
@@ -36,6 +36,8 @@ As shown in the image above, TypeQL queries are categorized into two main types:
   - **[Insert](../11-query/03-insert-query.md)**: inserts a data instance according to the given statement(s), optionally, preceded by a `match` clause.
   - **[Group](../11-query/06-aggregate-query.md#grouping-answers)**: always as a part of a `get` query, returns the results grouped by the given variable, optionally mapped to the count of each group.
   - **[Aggregate Values](../11-query/06-aggregate-query.md#aggregate-values-over-a-dataset)**: always as a part of a `get` query, returns the statistical value of numeric attributes based on the given aggregate function.
+  
+The TypeQL repository contains the [full grammar](https://github.com/vaticle/typeql/blob/master/grammar/TypeQL.g4) for TypeQL.
 
 ## TypeQL Answers
 

--- a/11-query/01-match-clause.md
+++ b/11-query/01-match-clause.md
@@ -367,6 +367,31 @@ TypeQLMatch.Filtered query = TypeQL.match(
 [tab:end]
 </div>
 
+### Concept Equality
+
+TypeQL allows exact concept equality using the `is` keyword. This is commonly combined with negation to check two 
+concepts are not equal:
+
+<div class="tabs dark">
+[tab:TypeQL]
+<!-- test-ignore -->
+```typeql
+match $x isa person; $y isa person; not { $x is $y; }; 
+```
+[tab:end]
+
+[tab:Java]
+<!-- test-ignore -->
+```java
+TypeQLMatch query = TypeQL.match(
+  var("x").isa("person"), 
+  var("y").isa("person"),
+  TypeQL.not(var("x").is(var("y")))
+);
+```
+[tab:end]
+</div>
+
 ### Comparators
 When matching an instance of an attribute type based on its value or simply comparing two variables, the following comparators may be used: `=`, `!=`, `>`, `>=`, `<` and `<=`.
 


### PR DESCRIPTION
## What is the goal of this PR?

We add missing documentation for the `is` keyword, and add a link to the full grammar of TypeQL.

## What are the changes implemented in this PR?

* LInk to TypeQL grammar
* Add section for `is` in the match documentation