### PR TITLE
Improved documentation for running TypeDB Cluster

### DIFF
--- a/05-running-typedb-cluster/01-install-and-run.md
+++ b/05-running-typedb-cluster/01-install-and-run.md
@@ -191,6 +191,7 @@ $ ./typedb cluster \
     --server.peers.peer-3.internal-address.zeromq=10.0.0.3:1730 \
     --server.peers.peer-3.internal-address.grpc=10.0.0.3:1731
 ```
+and so on.
 
 In this case, port `1729` would need to be open to public and clients would use
 `external-host-1`, `external-host-2` and `external-host-3` hostname to communicate with TypeDB Cluster;

--- a/05-running-typedb-cluster/01-install-and-run.md
+++ b/05-running-typedb-cluster/01-install-and-run.md
@@ -8,7 +8,7 @@ toc: false
 
 ## Obtaining Commercial License
 
-TypeDB Cluster is a commercial offering that provides a production-grade experience - high-availability, scalability, and security. A licence can be obtained from our [sales team](mailto:commercial@vaticle.com).
+TypeDB Cluster is a commercial offering that provides a production-grade experience - high-availability, scalability, and security. A license can be obtained from our [sales team](mailto:commercial@vaticle.com).
 
 ## System Requirements
 TypeDB Cluster runs on macOS, Linux and Windows. The only requirement is Java (version 11 or higher) which can be downloaded from [OpenJDK](http://openjdk.java.net/install/) or [Oracle Java](https://www.oracle.com/java/technologies/javase-jdk15-downloads.html).

--- a/05-running-typedb-cluster/01-install-and-run.md
+++ b/05-running-typedb-cluster/01-install-and-run.md
@@ -110,7 +110,7 @@ of those servers acts as a leader and the others are followers. Increasing the n
 failure: to tolerate N nodes failing, Cluster needs to consist of 2*N+1 nodes.
 This section describes how you can set up a 3-node cluster (in this case, one node can fail and no data is lost).
 
-Each node binds to two ports: a client port which TypeDB client drivers connect to (`1729`), and two server ports (`1730` and `1731`) for server-to-server communication.
+Each node binds to three ports: a client port which TypeDB client drivers connect to (`1729`), and two server ports (`1730` and `1731`) for server-to-server communication.
 
 For this tutorial, it's assumed that all three nodes are on the same virtual network and have relevant ports open and
 uninhibited by any firewall. The nodes have IP addresses `10.0.0.1`, `10.0.0.2` and `10.0.0.3` respectively.

--- a/05-running-typedb-cluster/01-install-and-run.md
+++ b/05-running-typedb-cluster/01-install-and-run.md
@@ -121,7 +121,7 @@ If you're using a single machine to host all nodes, you can prefix the port with
 the ports `1729`, `1730`, `1731` would turn into `11729`, `11730`, `11731`; `21729`, `21730`, `21731` and so on.
 </div>
 
-This is how 3-node TypeDB Cluster would be started on a single machine.
+This is how 3-node TypeDB Cluster would be started on three separate machines.
 
 ```bash
 # On 10.0.0.1:

--- a/05-running-typedb-cluster/01-install-and-run.md
+++ b/05-running-typedb-cluster/01-install-and-run.md
@@ -112,7 +112,7 @@ This section describes how you can set up a 3-node cluster (in this case, one no
 
 Each node binds to three ports: a client port which TypeDB client drivers connect to (`1729`), and two server ports (`1730` and `1731`) for server-to-server communication.
 
-For this tutorial, it's assumed that all three nodes are on the same virtual network and have relevant ports open and
+For this tutorial, it's assumed that all three nodes are on the same virtual network and have the relevant ports open and are
 uninhibited by any firewall. The nodes have IP addresses `10.0.0.1`, `10.0.0.2` and `10.0.0.3` respectively.
 
 <div class="note">
@@ -193,14 +193,14 @@ $ ./typedb cluster \
 ```
 and so on.
 
-In this case, port `1729` would need to be open to public and clients would use
-`external-host-1`, `external-host-2` and `external-host-3` hostname to communicate with TypeDB Cluster;
+In this case, port `1729` would need to be open to public and clients would use the
+`external-host-1`, `external-host-2` and `external-host-3` hostnames to communicate with TypeDB Cluster;
 inter-server communication would be done over a private network using ports `1730` and `1731`.
 </div>
 
 ### Stopping
 
-Stopping TypeDB Cluster is done the same way as with single node: pressing Ctrl+C in the terminal that was used to start it.
+Stopping TypeDB Cluster is done the same way as on a single node: pressing Ctrl+C in the terminal that was used to start it.
 All nodes must be shut down independently in the same way.
 
 ## Summary

--- a/05-running-typedb-cluster/01-install-and-run.md
+++ b/05-running-typedb-cluster/01-install-and-run.md
@@ -1,17 +1,17 @@
 ---
 pageTitle: Install and Run TypeDB Cluster
 keywords: setup, getting started, typedb, download, install, server, linux, mac, windows, docker
-longTailKeywords: typedb on linux, typedb on mac, typedb on windows, start typedb cluster
+longTailKeywords: typedb cluster on linux, typedb cluster on mac, typedb cluster on windows, start typedb cluster, run typedb cluster
 summary: Install and run the TypeDB Cluster on Linux, Mac or Windows.
 toc: false
 ---
 
 ## Obtaining Commercial License
 
-TypeDB Cluster is a commercial offering that provides production-grade experience - high-availability, scalability, and security. The license can be obtained from our [Sales team](mailto:commercial@vaticle.com).
+TypeDB Cluster is a commercial offering that provides a production-grade experience - high-availability, scalability, and security. A licence can be obtained from our [sales team](mailto:commercial@vaticle.com).
 
 ## System Requirements
-TypeDB Cluster runs on Mac, Linux and Windows. The only requirement is Java (version 11 or higher) which can be downloaded from [OpenJDK](http://openjdk.java.net/install/) or [Oracle Java](https://www.oracle.com/java/technologies/javase-jdk15-downloads.html).
+TypeDB Cluster runs on macOS, Linux and Windows. The only requirement is Java (version 11 or higher) which can be downloaded from [OpenJDK](http://openjdk.java.net/install/) or [Oracle Java](https://www.oracle.com/java/technologies/javase-jdk15-downloads.html).
 
 ## Download and Install TypeDB Cluster
 
@@ -26,26 +26,25 @@ Download the [latest release](https://repo.vaticle.com/#browse/browse:private-ar
 
 If TypeDB Cluster doesn't have a distribution you need, please open an issue [on GitHub](https://github.com/vaticle/typedb/issues).
 
-
-Having installed or downloaded TypeDB Cluster, we can now start the [Cluster](#start-the-typedb-cluster) and interact with the [Console](../02-console/01-console.md).
+Having installed or downloaded TypeDB Cluster, we can now start the [Cluster](#starting-and-stopping-a-single-node-cluster) and interact with the [Console](../02-console/01-console.md).
 
 [tab:end]
 
 [tab:macOS]
 
 #### Manual Download
-Download the [latest release](https://repo.vaticle.com/#browse/browse:private-artifact), unzip it in a location on your machine that is easily accessible via terminal.
+Download the [latest release](https://repo.vaticle.com/#browse/browse:private-artifact), unzip it in a location on your machine that is easily accessible via a terminal.
 
-Having installed or downloaded TypeDB, we can now start the [Server](#start-the-typedb-cluster) and interact with the [Console](../02-console/01-console.md).
+Having installed or downloaded TypeDB, we can now start the [Server](#starting-and-stopping-a-single-node-cluster) and interact with the [Console](../02-console/01-console.md).
 
 [tab:end]
 
 [tab:Windows]
 
 #### Manual Download
-Download the [latest release](https://repo.vaticle.com/#browse/browse:private-artifact), unzip it in a location on your machine that is easily accessible via command prompt.
+Download the [latest release](https://repo.vaticle.com/#browse/browse:private-artifact), unzip it in a location on your machine that is easily accessible via a command prompt.
 
-Having downloaded TypeDB, we can now start the [Server](#start-the-typedb-cluster) and interact with the [Console](../02-console/01-console.md).
+Having downloaded TypeDB, we can now start the [Server](#starting-and-stopping-a-single-node-cluster) and interact with the [Console](../02-console/01-console.md).
 
 [tab:end]
 
@@ -87,35 +86,34 @@ docker exec -ti typedb bash -c '/opt/typedb-cluster-all-linux/typedb console'
 [tab:end]
 </div>
 
-## Starting and Stopping Single-node Cluster
+## Starting and Stopping a single node Cluster
 
 ### Starting
 
-If you have installed TypeDB using a package manager, to start the TypeDB Cluster, run `typedb cluster`.
+If you have installed TypeDB using a package manager, to start the TypeDB Cluster, open a terminal and run `typedb cluster`.
 
 Otherwise, if you have manually downloaded TypeDB, `cd` into the unzipped folder and run `./typedb cluster`.
 
 
 ### Stopping
 
-To stop the TypeDB Cluster, press Ctrl-C in same terminal as the one where you started it in.
+To stop the TypeDB Cluster, press Ctrl+C in the terminal session you are running TypeDB Cluster from.
 
 
-## Starting and Stopping Multi-node Cluster
+## Starting and Stopping a multi-node Cluster
 
 ### Starting
 
 While it's possible to run TypeDB Cluster in a single-node mode, a truly highly-available and fault-tolerant
-production-grade setup includes setting up multiple servers to connect and form a cluster. At every time, one
-of those servers acts as a leader and others are followers. Increasing number of nodes increases tolerance to
-failure: to tolerate N nodes failing, cluster needs to consist of 2*N+1 nodes.
-This section describes how it's done on an example 3-node setup (in this case, one node can fail and no data is lost).
+production-grade setup includes setting up multiple servers to connect and form a cluster. At any given point in time, one
+of those servers acts as a leader and the others are followers. Increasing the number of nodes increases the Cluster's tolerance to
+failure: to tolerate N nodes failing, Cluster needs to consist of 2*N+1 nodes.
+This section describes how you can set up a 3-node cluster (in this case, one node can fail and no data is lost).
 
 Each node binds to two ports: a client port which TypeDB client drivers connect to (`1729`), and two server ports (`1730` and `1731`) for server-to-server communication.
 
-For the tutorial, it's assumed that all three nodes are on the same virtual network and have relevant ports
-unblocked by the firewall. Node have IP addresses of `10.0.0.1`, `10.0.0.2` and `10.0.0.3` and hostnames of
-`node1`, `node2` and `node3`.
+For this tutorial, it's assumed that all three nodes are on the same virtual network and have relevant ports open and
+uninhibited by any firewall. The nodes have IP addresses `10.0.0.1`, `10.0.0.2` and `10.0.0.3` respectively.
 
 <div class="note">
 [Note]
@@ -123,41 +121,88 @@ If you're using a single machine to host all nodes, you can prefix the port with
 the ports `1729`, `1730`, `1731` would turn into `11729`, `11730`, `11731`; `21729`, `21730`, `21731` and so on.
 </div>
 
-This is how TypeDB Cluster would be started:
+This is how 3-node TypeDB Cluster would be started on a single machine.
 
 ```bash
-user@node1:~/typedb-cluster/$ ./typedb cluster --address=10.0.0.1:1729:1730:1731 --peer 10.0.0.1:1729:1730:1731 --peer 10.0.0.2:1729:1730:1731 --peer 10.0.0.3:1729:1730:1731
+# On 10.0.0.1:
+$ ./typedb cluster \
+    --server.address=10.0.0.1:1729 \
+    --server.internal-address.zeromq=10.0.0.1:1730 \
+    --server.internal-address.grpc=10.0.0.1:1731 \
+    --server.peers.peer-1.address=10.0.0.1:1729 \
+    --server.peers.peer-1.internal-address.zeromq=10.0.0.1:1730 \
+    --server.peers.peer-1.internal-address.grpc=10.0.0.1:1731 \
+    --server.peers.peer-2.address=10.0.0.2:1729 \
+    --server.peers.peer-2.internal-address.zeromq=10.0.0.2:1730 \
+    --server.peers.peer-2.internal-address.grpc=10.0.0.2:1731 \
+    --server.peers.peer-3.address=10.0.0.3:1729 \
+    --server.peers.peer-3.internal-address.zeromq=10.0.0.3:1730 \
+    --server.peers.peer-3.internal-address.grpc=10.0.0.3:1731
 
-user@node2:~/typedb-cluster/$ ./typedb cluster --address=10.0.0.2:1729:1730:1731 --peer 10.0.0.1:1729:1730:1731 --peer 10.0.0.2:1729:1730:1731 --peer 10.0.0.3:1729:1730:1731
+# On 10.0.0.2:
+$ ./typedb cluster \
+    --server.address=10.0.0.2:1729 \
+    --server.internal-address.zeromq=10.0.0.2:1730 \
+    --server.internal-address.grpc=10.0.0.2:1731 \
+    --server.peers.peer-1.address=10.0.0.1:11729 \
+    --server.peers.peer-1.internal-address.zeromq=10.0.0.1:1730 \
+    --server.peers.peer-1.internal-address.grpc=10.0.0.1:1731 \
+    --server.peers.peer-2.address=10.0.0.2:1729 \
+    --server.peers.peer-2.internal-address.zeromq=10.0.0.2:1730 \
+    --server.peers.peer-2.internal-address.grpc=10.0.0.2:1731 \
+    --server.peers.peer-3.address=10.0.0.3:1729 \
+    --server.peers.peer-3.internal-address.zeromq=10.0.0.3:1730 \
+    --server.peers.peer-3.internal-address.grpc=10.0.0.3:1731
 
-user@node3:~/typedb-cluster/$ ./typedb cluster --address=10.0.0.3:1729:1730:1731 --peer 10.0.0.1:1729:1730:1731 --peer 10.0.0.2:1729:1730:1731 --peer 10.0.0.3:1729:1730:1731
+# On 10.0.0.3:
+$ ./typedb cluster \
+    --server.address=10.0.0.3:1729 \
+    --server.internal-address.zeromq=10.0.0.3:1730 \
+    --server.internal-address.grpc=10.0.0.3:1731 \
+    --server.peers.peer-1.address=10.0.0.1:1729 \
+    --server.peers.peer-1.internal-address.zeromq=10.0.0.1:1730 \
+    --server.peers.peer-1.internal-address.grpc=10.0.0.1:1731 \
+    --server.peers.peer-2.address=10.0.0.2:1729 \
+    --server.peers.peer-2.internal-address.zeromq=10.0.0.2:1730 \
+    --server.peers.peer-2.internal-address.grpc=10.0.0.2:1731 \
+    --server.peers.peer-3.address=10.0.0.3:1729 \
+    --server.peers.peer-3.internal-address.zeromq=10.0.0.3:1730 \
+    --server.peers.peer-3.internal-address.grpc=10.0.0.3:1731
 ```  
 
 <div class="note">
 [Note]
-This guide assumes application accessing TypeDB Cluster resides on the same private network. If this is *not* the case,
-TypeDB Cluster also supports using different IP addresses for client and server communication. In order to do that client
-and server addresses need to be passed separated by a comma to `--address` and `--peer` options:
+This guide assumes the application accessing TypeDB Cluster resides on the same private network. If this is *not* the case,
+TypeDB Cluster also supports using different IP addresses for client and server communication. In order to do so, the
+relevant external hostname should be passed as arguments using the `--server.address` and `--server.peers` flags as below.
 
-```
-./typedb cluster \
-    --address external-host-1:1729,10.0.0.1:1730,10.0.0.1:1731 \
-    --peer external-host-1:1729,10.0.0.1:1730,10.0.0.1:1731 \
-    --peer external-host-2:1729,10.0.0.2:1730,10.0.0.2:1731 \
-    --peer external-host-3:1729,10.0.0.3:1730,10.0.0.3:1731
+```bash
+$ ./typedb cluster \
+    --server.address=external-host-1:1729 \
+    --server.internal-address.zeromq=10.0.0.1:1730 \
+    --server.internal-address.grpc=10.0.0.1:1731 \
+    --server.peers.peer-1.address=external-host-1:1729 \
+    --server.peers.peer-1.internal-address.zeromq=10.0.0.1:1730 \
+    --server.peers.peer-1.internal-address.grpc=10.0.0.1:1731 \
+    --server.peers.peer-2.address=external-host-2:1729 \
+    --server.peers.peer-2.internal-address.zeromq=10.0.0.2:1730 \
+    --server.peers.peer-2.internal-address.grpc=10.0.0.2:1731 \
+    --server.peers.peer-3.address=external-host-3:1729 \
+    --server.peers.peer-3.internal-address.zeromq=10.0.0.3:1730 \
+    --server.peers.peer-3.internal-address.grpc=10.0.0.3:1731
 ```
 
 In this case, port `1729` would need to be open to public and clients would use
 `external-host-1`, `external-host-2` and `external-host-3` hostname to communicate with TypeDB Cluster;
-inter-server communication would be done over private network using port `1730`.
+inter-server communication would be done over a private network using ports `1730` and `1731`.
 </div>
 
 ### Stopping
 
-Stopping the TypeDB Cluster is done the same way as with single node: pressing Ctrl+C in the terminal that was used to start it.
-All nodes would be to be shut down independently.
+Stopping TypeDB Cluster is done the same way as with single node: pressing Ctrl+C in the terminal that was used to start it.
+All nodes must be shut down independently in the same way.
 
 ## Summary
-So far we have learned how to download, install and run the TypeDB Cluster.
+So far we have learned how to download, install and run TypeDB Cluster in an ad-hoc way. 
 
-Next, we learn how to configure the TypeDB Cluster and interact with a TypeDB Cluster knowledge graph via the TypeDB Console.
+Next, we'll learn how to deploy TypeDB Cluster using Kubernetes and Helm.


### PR DESCRIPTION
## What is the goal of this PR?

We've updated the documentation for installing and running TypeDB Cluster, bringing the documentation in line with the current flags and syntax.

## What are the changes implemented in this PR?

We've improved 
```
05-running-typedb-cluster/01-install-and-run.md
```
Most of the edits concern syntax upgrades, typos and rephrasings to increase clarity.

## Additional Information
We should also confirm that the Kubernetes deployment information is correct.