### PR TITLE
Move from grabl to Factory

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -120,7 +120,7 @@ build:
         EOM
         sudo mv typedb.service /etc/systemd/system/
         
-        apt install -y python3-pip
+        sudo apt install -y python3-pip
         python3 -m pip install typedb-client=2.11.1
 
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -121,7 +121,7 @@ build:
         sudo mv typedb.service /etc/systemd/system/
         
         sudo apt install -y python3-pip
-        python3 -m pip install typedb-client=2.11.1
+        python3 -m pip install typedb-client==2.11.1
 
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -110,13 +110,7 @@ build:
     test-example-python:
       image: vaticle-ubuntu-21.04
       type: foreground
-      command: |
-        pyenv install 3.7.12
-        pyenv global 3.7.12
-        sudo unlink /usr/bin/python3
-        sudo ln -s $(which python3) /usr/bin/python3
-        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.12/lib/python3.7/site-packages/lsb_release.py
-
+      command: | 
         cat > typedb.service <<- EOM
         [Unit]
         Description=TypeDB
@@ -125,6 +119,9 @@ build:
         ExecStart=$PWD/dist/typedb-all-linux/typedb server
         EOM
         sudo mv typedb.service /etc/systemd/system/
+        
+        apt install -y python3-pip
+        python3 -m pip install typedb-client=2.11.1
 
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
@@ -132,9 +129,6 @@ build:
         bazel run //:typedb-extractor -- dist/typedb-all-linux
         sudo systemctl daemon-reload
         sudo systemctl start typedb
-
-        pip3 install -U pip
-        pip install typedb-client==2.8.0
 
         bazel run //test/example/python:phone-calls
         bazel run //test/example/python:social-network

--- a/08-examples/04-phone-calls-migration-python.md
+++ b/08-examples/04-phone-calls-migration-python.md
@@ -385,11 +385,11 @@ def parse_data_to_dictionaries(input):
                 ## now: the tag is complete
                 buffer += line
                 keep_adding_lines = False
-                ## convert the buffer (string) to a strurctured tag
+                ## convert the buffer (string) to a structured tag
                 tnode = et.fromstring(buffer)
                 ## parse the tag to a dictionary
                 item = {}
-                for element in tnode.getchildren():
+                for element in list(tnode):
                     item[element.tag] = element.text
                 ## append the item to the list
                 items.append(item)
@@ -677,9 +677,9 @@ def parse_data_to_dictionaries(input):
                 buffer += line
                 append = False
                 tnode = et.fromstring(buffer)
-                ## parse the tag to a dictionary and append to tiems
+                ## parse the tag to a dictionary and append to items
                 item = {}
-                for element in tnode.getchildren():
+                for element in list(tnode):
                     item[element.tag] = element.text
                 items.append(item)
                 ## delete the buffer to free the memory

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -27,5 +27,5 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "0f84e6577b6ef60dac838b604e6d66222c512957",
+        commit = "efeaad5fc9f5dc3a2b217c5ba1abec2d3d7493dd",
     )


### PR DESCRIPTION
## What is the goal of this PR?

We've migrated CI from grabl to Factory. 

## What are the changes implemented in this PR?

Moving CI has changed our target image, which has uncovered some out of date instructions we provide. We've updated these to make them correct now.

- Some typos corrected.
- We've bumped the version of typedb and typedb-client-python used.
- We've updated the xml migration instructions, removing deprecated functions.