### PR TITLE
Upgrade Client Python

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -121,7 +121,7 @@ build:
         sudo mv typedb.service /etc/systemd/system/
         
         sudo apt install -y python3-pip
-        python3 -m pip install typedb-client==2.11.1
+        python3 -m pip install typedb-client==2.11.2
 
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -15,7 +15,7 @@ build:
         bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
   correctness:
     build:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-20.04
       type: foreground
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
@@ -87,7 +87,7 @@ build:
         bazel run //test/example/java:phone-calls
         bazel run //test/example/java:social-network
     test-example-nodejs:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-20.04
       type: foreground
       command: |
         cat > typedb.service <<- EOM


### PR DESCRIPTION
## What is the goal of this PR?

We upgraded Client Python to the latest version, which should fix intermittent and common test failures in CI.

## What are the changes implemented in this PR?

Our CI jobs have been failing for some time due to a "metadata elements leaked" error, which we've fixed in Client Python in https://github.com/vaticle/typedb-client-python/pull/266, and now we've upgraded to the latest release of Client Python.