### PR TITLE
Revert compatibility table for Cluster 2.14.1 

### DIFF
--- a/03-client-api/01-java.md
+++ b/03-client-api/01-java.md
@@ -218,7 +218,7 @@ By default, Client Java uses Logback to print errors and debugging info to stand
 
 |   Client Java   |      TypeDB      | TypeDB Cluster  |
 |:---------------:|:----------------:|:---------------:|
-|     2.14.1      |      2.14.1      |     2.14.1      |
+|     2.14.1      |      2.14.1      |  Coming soon!   |
 |     2.12.0      | 2.12.0 to 2.13.0 |     2.13.0      |
 | 2.9.0 to 2.11.1 | 2.9.0 to 2.11.1  | 2.9.0 to 2.11.2 |
 |      2.8.0      |      2.8.0       |       N/A       |

--- a/07-studio/00-overview.md
+++ b/07-studio/00-overview.md
@@ -28,7 +28,7 @@ brew install --cask vaticle/tap/typedb-studio
 
 | Studio | TypeDB | TypeDB Cluster  |
 |:------:|:------:|:---------------:|
-| 2.14.1 | 2.14.1 |     2.14.1      |
+| 2.14.1 | 2.14.1 |  Coming soon!   |
 | 2.11.0 | 2.11.1 | 2.11.1 - 2.11.2 |
 
 


### PR DESCRIPTION
## What is the goal of this PR?

We've removed references to an unreleased version of TypeDB Cluster, replacing it with a note that it is on its way.

## What are the changes implemented in this PR?

Replaced references to Cluster 2.14.1 with "Coming soon!".