### PR TITLE
Adds description of "name" parameter for TypeDB Cluster kubernetes deployment

### DIFF
--- a/05-running-typedb-cluster/02-kubernetes.md
+++ b/05-running-typedb-cluster/02-kubernetes.md
@@ -179,6 +179,7 @@ Configurable settings for Helm package include:
 | `javaopts`          | `null`           | JVM options that controls various runtime aspects of TypeDB Cluster (eg., `-Xmx`, `-Xms`)          |
 | `logstash.enabled`  | `false`          | Whether TypeDB Cluster pushes logs into Logstash                                                   |
 | `logstash.uri`      | `localhost:5044` | Hostname and port of a Logstash daemon accepting log records                                       |
+| `name`              | `null`           | An override for the Helm release name when used for naming the deployed objects                    |
 
 
 ### Troubleshooting

--- a/05-running-typedb-cluster/02-kubernetes.md
+++ b/05-running-typedb-cluster/02-kubernetes.md
@@ -170,7 +170,7 @@ Configurable settings for Helm package include:
 
 | Key                 | Default value    | Description
 | :-----------------: | :---------------:| :------------------------------------------------------------------------------------------------: |
-| `name`              | `null`           | An override for the Helm release name when used for naming the deployed objects                    |
+| `name`              | `null`           | Used for naming deployed objects replacing the Helm release name used if this is not provided      |
 | `replicas`          | `3`              | Number of TypeDB Cluster nodes to run                                                              |
 | `cpu`               | `7`              | How many CPUs should be allocated for each TypeDB Cluster node                                     |
 | `storage.size`      | `100Gi`          | How much disk space should be allocated for each TypeDB Cluster node                               |

--- a/05-running-typedb-cluster/02-kubernetes.md
+++ b/05-running-typedb-cluster/02-kubernetes.md
@@ -170,6 +170,7 @@ Configurable settings for Helm package include:
 
 | Key                 | Default value    | Description
 | :-----------------: | :---------------:| :------------------------------------------------------------------------------------------------: |
+| `name`              | `null`           | An override for the Helm release name when used for naming the deployed objects                    |
 | `replicas`          | `3`              | Number of TypeDB Cluster nodes to run                                                              |
 | `cpu`               | `7`              | How many CPUs should be allocated for each TypeDB Cluster node                                     |
 | `storage.size`      | `100Gi`          | How much disk space should be allocated for each TypeDB Cluster node                               |
@@ -179,7 +180,6 @@ Configurable settings for Helm package include:
 | `javaopts`          | `null`           | JVM options that controls various runtime aspects of TypeDB Cluster (eg., `-Xmx`, `-Xms`)          |
 | `logstash.enabled`  | `false`          | Whether TypeDB Cluster pushes logs into Logstash                                                   |
 | `logstash.uri`      | `localhost:5044` | Hostname and port of a Logstash daemon accepting log records                                       |
-| `name`              | `null`           | An override for the Helm release name when used for naming the deployed objects                    |
 
 
 ### Troubleshooting

--- a/05-running-typedb-cluster/02-kubernetes.md
+++ b/05-running-typedb-cluster/02-kubernetes.md
@@ -170,7 +170,7 @@ Configurable settings for Helm package include:
 
 | Key                 | Default value    | Description
 | :-----------------: | :---------------:| :------------------------------------------------------------------------------------------------: |
-| `name`              | `null`           | Used for naming deployed objects replacing the Helm release name used if this is not provided      |
+| `name`              | `null`           | Used for naming deployed objects. When not provided, the Helm release name will be used instead    |
 | `replicas`          | `3`              | Number of TypeDB Cluster nodes to run                                                              |
 | `cpu`               | `7`              | How many CPUs should be allocated for each TypeDB Cluster node                                     |
 | `storage.size`      | `100Gi`          | How much disk space should be allocated for each TypeDB Cluster node                               |


### PR DESCRIPTION
## What is the goal of this PR?

We add an entry to the table of configurable values in the TypeDB Cluster to describe the `name` field added with https://github.com/vaticle/typedb-cluster/pull/441, as well as a description thereof.

## What are the changes implemented in this PR?

We introduce a new entry in the markdown table containing the required information.
