### PR TITLE
Add section on efficient transitivity

### DIFF
--- a/09-schema/03-rules.md
+++ b/09-schema/03-rules.md
@@ -317,7 +317,7 @@ rule transitive-reachability-base:
 when{
     (from: $x, to: $y) isa edge;
 } then {
-    (from: $x, to: $z) isa reachable;
+    (from: $x, to: $y) isa reachable;
 };
 
 rule transitive-reachability-recursive:

--- a/09-schema/03-rules.md
+++ b/09-schema/03-rules.md
@@ -287,13 +287,15 @@ For complex queries, it can also be beneficial to add more CPU cores, as the rea
 
 A common use-case for rules is to infer the transitive closure of a relation. The most straight-forward way of doing this is as follows:
 ```typeql
-rule reachability-is-transitive:
+define
+
+rule transitive-reachability:
 when{
     (from: $x, to: $y) isa reachable;
     (from: $y, to: $z) isa reachable;
 } then {
     (from: $x, to: $z) isa reachable;
-}
+};
 ```
 We can interpret this rule as joining two paths together. In a chain `p-q-r-s-t`, to find all nodes reachable from p, we would generate the following relations:
 ```
@@ -309,20 +311,22 @@ Concretely, We would generate a `reachable` relation _**for every pair**_ of nod
 When it is possible to define different types for the persisted and (inferred) transitive version of the relation (which is often the case), we can instead use the two rules below which is more computationally efficient. 
 For the example above, we use `edge` as the base relation type and `reachable` as the inferred relation. 
 ```typeql
-rule reachability-is-transitive-base:
+define
+
+rule transitive-reachability-base:
 when{
     (from: $x, to: $y) isa edge;
 } then {
     (from: $x, to: $z) isa reachable;
-}
+};
 
-rule reachability-is-transitive-recursive:
+rule transitive-reachability-recursive:
 when{
     (from: $x, to: $y) isa reachable;
     (from: $y, to: $z) isa edge;
 } then {
     (from: $x, to: $z) isa reachable;
-}
+};
 ```
 We can intepret this as finding a path and extend it by one. To find all nodes reachable from p in the chain p-q-r-s-t, We would generate the following relations:
 ```

--- a/09-schema/03-rules.md
+++ b/09-schema/03-rules.md
@@ -301,7 +301,7 @@ We can interpret this rule as joining two paths together. In a chain `p-q-r-s-t`
 ```
 p--q, q--r, r--s, s--t  (already in the database)
 
-p--r, q--s, s--t,       (Inferred)
+p--r, q--s, r--t,       (Inferred)
 p--s, q--t              (Inferred)
 p--t                    (Inferred)
 ```
@@ -335,7 +335,7 @@ p-q, q-r, r-s, s-t      (edges already in the database)
 p--q,                   (Inferred with the first rule)
 p--r,                   (Inferred with the second rule)
 p--s,                   (Inferred with the second rule)
-s--t                    (Inferred with the second rule)
+p--t                    (Inferred with the second rule)
 ```
 Here, we only generate one relation for _**each node**_ reachable from p.
 

--- a/09-schema/03-rules.md
+++ b/09-schema/03-rules.md
@@ -278,7 +278,7 @@ This rule will make every relation transitive.
 
 A common use-case for rules is to infer all transitively reachable concepts from a particular (set of) starting concepts (e.g. finding all teams a particular user is a member of recursively, or all nodes reachable from a given node in a graph, etc.) This section describes how to write efficient transitivity rules when it is known in advance which one of the role-players will be specified. This is often the case and we can formulate our rules to answer such queries more efficiently.
 
-### Simple transitivity
+### Simple Transitivity
 The intuitive way of writing a transitive rule is as follows:
 ```typeql
 define
@@ -308,7 +308,7 @@ Concretely, one `path` relation is generated _for every pair_ of nodes reachable
 
 The following section describes an approach which generates only a **linear** number of relations when the `from` role-player is specified. Subsequent sections extend the approach to when the `to` role-player is specified and for symmetric relations where both players play the same role.
 
-### Optimal forward transitivity
+### Optimal Forward Transitivity
 We must first define separate types for the persisted and (inferred) transitive version of the relation.
 For the example above, we use `edge` as the base relation denoting stored facts and `forward-path` as the inferred relation. We then replace the rule with the following two rules: 
 ```typeql
@@ -346,7 +346,7 @@ p--t                    (Inferred with the second rule)
 ```
 Here, we only generate one relation for _**each node**_ reachable from p, bringing the complexity down from quadratic in to linear in the number of reachable nodes. The key difference is that the recursive-call in the rule is always called with the same `$x`.  
 
-### Optimal Backward transitivity
+### Optimal Backward Transitivity
 To see what happens when we try to compute backwards transitivity using the above formulation, consider the query to find all nodes from which `t` is reachable in the same chain `p-q-r-s-t`. The second rule is now executed backwards - first finding all `$y` there is an edge to `t`. Then it recursively queries all nodes reachable from `$y`. Thus, a relation is generated for every pair of nodes which are reachable from `t` - no better than the naive approach.
 
 To answer backward transitive queries such as `$t isa node, has id "t"; (from: $x, to: $t) isa path;` where the **to** role is fixed, we need a backwards version of the transitive relation and rules. Intuitively, This approach computes forward-transitivity on the reversed graph.
@@ -375,7 +375,7 @@ when {
 };
 ```
 
-### Optimal undirected transitivity
+### Optimal Undirected Transitivity
 We can use the same approach for undirected graphs. If the undirected edges are defined by the relations `(node: $x, node: $y) isa edge;`, then the rules would read:
 
 ```typeql

--- a/09-schema/03-rules.md
+++ b/09-schema/03-rules.md
@@ -313,10 +313,11 @@ We must first define separate types for the persisted and (inferred) transitive 
 For the example above, we use `edge` as the base relation denoting stored facts and `forward-path` as the inferred relation. We then replace the rule with the following two rules: 
 ```typeql
 define
-
 node_id sub attribute, value string;
-node sub entity, owns node_id, plays path:from, plays path:to; 
-backward-path sub relation, relates from, relates to;
+node sub entity, owns node_id, 
+    plays edge:from, plays edge:to,
+    plays forward-path:from, plays forward-path:to; 
+forward-path sub relation, relates from, relates to;
 
 rule forward-transitivity-base:
 when {
@@ -351,9 +352,11 @@ To see what happens when we try to compute backwards transitivity using the abov
 To answer backward transitive queries such as `$t isa node, has id "t"; (from: $x, to: $t) isa path;` where the **to** role is fixed, we need a backwards version of the transitive relation and rules. Intuitively, This approach computes forward-transitivity on the reversed graph.
 ```typeql
 define
-
 node_id sub attribute, value string;
-node sub entity, owns node_id, plays path:from, plays path:to; 
+node sub entity, owns node_id, 
+    plays edge:from, plays edge:to,
+    plays backward-path:from, plays backward-path:to; 
+edge sub relation, relates from, relates to;
 backward-path sub relation, relates from, relates to;
 
 rule backward-transitivity-base:
@@ -377,9 +380,12 @@ We can use the same approach for undirected graphs. If the undirected edges are 
 
 ```typeql
 define
-node sub entity, plays edge:node;
+node_id sub attribute, value string;
 edge sub relation, relates node;
-forward-path:
+undirected-path sub relation, relates from, relates to;
+node sub entity, owns node_id,
+    plays edge:node, 
+    plays undirected-path:from, plays undirected-path:to;
 
 rule undirected-transitivity-base:
 when {

--- a/09-schema/03-rules.md
+++ b/09-schema/03-rules.md
@@ -337,7 +337,7 @@ Here, we only generate one relation for _**each node**_ reachable from p, bringi
 To see what happens when we try to compute backwards transitivity using the above formulation, consider the query to find all nodes from which `t` is reachable in the same chain `p-q-r-s-t`. The second rule is now executed backwards - first checking all nodes `$y` from which there is an edge to `t`. Then it recursively queries all nodes reachable from `$y`. Thus, a relation is generated for every pair of nodes which are reachable from `t`.
 
 To answer backward transitive queries, we simply need a backwards version of the transitive relation and rules. Intuitively, This approach computes forward-transitivity on the reversed graph.
-```
+```typeql
 rule backward-transitivity-base:
 when{
     (to: $x, from: $y) isa edge;
@@ -379,7 +379,7 @@ when{
 
 <div class = "note">
 [Important]
-* These rules are efficient only when evaluated with `$x` specified. Thus, when writing a query, it is recommended to query the directed-version of the relation which enables this.
+* These rules are efficient only when evaluated with `$x` specified. Thus, when writing a query, it is recommended to use `forward-reachable` or `backward-reachable` depending on whether the `from` or `to` is specified.
 </div>
 
 ## Optimisation Notes

--- a/09-schema/03-rules.md
+++ b/09-schema/03-rules.md
@@ -300,7 +300,7 @@ Concretely, We would generate an `edge` relation _for every pair_ of nodes reach
 
  The following section describes a recipe to answer forward transitivity queries materialising only a **linear** number of relations. Later, the recipe is extended to backward queries and undirected relations.
 
-### Efficient forward transitivity
+### Forward transitivity
 We first define separate types for the persisted and (inferred) transitive version of the relation.
 For the example above, we use `edge` as the base relation type and `forward-reachable` as the inferred relation. We then update the rule as follows: 
 ```typeql
@@ -333,7 +333,7 @@ p--t                    (Inferred with the second rule)
 ```
 Here, we only generate one relation for _**each node**_ reachable from p, bringing the complexity down from quadratic in to linear in the number of reachable nodes.
 
-### Efficient backward queries
+### Backward transitivity
 To see what happens when we try to compute backwards transitivity using the above formulation, consider the query to find all nodes from which `t` is reachable in the same chain `p-q-r-s-t`. The second rule is now executed backwards - first checking all nodes `$y` from which there is an edge to `t`. Then it recursively queries all nodes reachable from `$y`. Thus, a relation is generated for every pair of nodes which are reachable from `t`.
 
 To answer backward transitive queries, we simply need a backwards version of the transitive relation and rules. Intuitively, This approach computes forward-transitivity on the reversed graph.
@@ -354,7 +354,7 @@ when{
 };
 ```
 
-### Undirected queries
+### Undirected transitivity
 We can use the same formulation for undirected graphs. If the undirected edges are defined by the relations `(node: $x, node: $y) isa edge;` then the rules would read:
 
 ```typeql

--- a/09-schema/03-rules.md
+++ b/09-schema/03-rules.md
@@ -347,7 +347,7 @@ when{
 
 rule backward-transitivity-recursive:
 when{
-    (to $x, from: $y) isa backward-reachable;
+    (to: $x, from: $y) isa backward-reachable;
     (to: $y, from: $z) isa edge;
 } then {
     (to: $x, from: $z) isa backward-reachable;

--- a/09-schema/03-rules.md
+++ b/09-schema/03-rules.md
@@ -305,7 +305,6 @@ We first define separate types for the persisted and (inferred) transitive versi
 For the example above, we use `edge` as the base relation type and `forward-reachable` as the inferred relation. We then update the rule as follows: 
 ```typeql
 define
-
 rule forward-transitivity-base:
 when{
     (from: $x, to: $y) isa edge;
@@ -338,6 +337,7 @@ To see what happens when we try to compute backwards transitivity using the abov
 
 To answer backward transitive queries, we simply need a backwards version of the transitive relation and rules. Intuitively, This approach computes forward-transitivity on the reversed graph.
 ```typeql
+define
 rule backward-transitivity-base:
 when{
     (to: $x, from: $y) isa edge;
@@ -359,7 +359,6 @@ We can use the same formulation for undirected graphs. If the undirected edges a
 
 ```typeql
 define
-
 rule forward-transitivity-base:
 when{
     (node: $x, node: $y) isa edge;

--- a/09-schema/03-rules.md
+++ b/09-schema/03-rules.md
@@ -278,6 +278,7 @@ This rule will make every relation transitive.
 
 A common use-case for rules is to infer all transitively reachable concepts from a particular (set of) starting concepts (e.g. finding all teams a particular user is a member of recursively, or all nodes reachable from a given node in a graph, etc.) This section describes how to write efficient transitivity rules when it is known in advance which one of the role-players will be specified. This is often the case and we can formulate our rules to answer such queries more efficiently.
 
+### Naive transitivity
 The intuitive way of writing a transitive rule is as follows:
 ```typeql
 define
@@ -295,7 +296,7 @@ when {
 };
 ```
 
-We can interpret this rule as joining two paths together. In a chain `p-q-r-s-t`, querying all nodes reachable from p (`$p isa node, has id "p"; (from: $p, to:$x) isa path;`) would generate the following relations:
+We can interpret this rule as joining two paths together. In a chain `p-q-r-s-t`, querying all nodes reachable from p using the query `$p isa node, has id "p"; (from: $p, to:$x) isa path;` would generate the following relations:
 ```
 p--q, q--r, r--s, s--t  (already in the database)
 
@@ -333,7 +334,7 @@ when {
 };
 ```
 
-We can intepret this approach as finding a path and extending it by one hop. The same query for all nodes reachable from p in the chain p-q-r-s-t would generate the following relations:
+We can intepret this approach as finding a path and extending it by one hop. The same query `$p isa node, has id "p"; (from: $p, to:$x) isa path;` for all nodes reachable from p in the chain p-q-r-s-t would generate the following relations:
 ```
 p-q, q-r, r-s, s-t      (edges already in the database)
 
@@ -347,7 +348,7 @@ Here, we only generate one relation for _**each node**_ reachable from p, bringi
 ### Backward transitivity
 To see what happens when we try to compute backwards transitivity using the above formulation, consider the query to find all nodes from which `t` is reachable in the same chain `p-q-r-s-t`. The second rule is now executed backwards - first finding all `$y` there is an edge to `t`. Then it recursively queries all nodes reachable from `$y`. Thus, a relation is generated for every pair of nodes which are reachable from `t` - no better than the naive approach.
 
-To answer backward transitive queries, we need a backwards version of the transitive relation and rules. Intuitively, This approach computes forward-transitivity on the reversed graph.
+To answer backward transitive queries such as `$t isa node, has id "t"; (from: $x, to: $t) isa path;`, we need a backwards version of the transitive relation and rules. Intuitively, This approach computes forward-transitivity on the reversed graph.
 ```typeql
 define
 
@@ -372,7 +373,7 @@ when {
 ```
 
 ### Undirected transitivity
-We can use the same approach for undirected graphs. If the undirected edges are defined by the relations `(node: $x, node: $y) isa edge;` then the rules would read:
+We can use the same approach for undirected graphs.  If the undirected edges are defined by the relations `(node: $x, node: $y) isa edge;`, then the rules would read:
 
 ```typeql
 define
@@ -396,7 +397,7 @@ when {
 };
 ```
 
- Notice that we still need different roles for `$x` and `$z` in `undirected-path` and we only gain efficiency when `$x` is specified.  
+ Notice that we still need different roles for `$x` and `$z` in `undirected-path`. Further, we are efficienct only in queries where the `from` role is specified, such as `$t isa node, has id "t"; (from: $t, to: $x) isa path;`. 
 
 ## Optimisation Notes
 

--- a/10-pattern/01-negation.md
+++ b/10-pattern/01-negation.md
@@ -672,16 +672,13 @@ Let us define a network of nodes with possible edges between nodes:
 ```typeql
 define
 
-traversable sub entity,
+node sub entity,
     plays edge:from,
     plays edge:to,
     plays reachable:from,
     plays reachable:to,
     plays indirect-edge:from,
     plays indirect-edge:to;
-
-
-node sub traversable;
 
 edge sub relation, relates from, relates to;
 ```
@@ -690,8 +687,7 @@ edge sub relation, relates from, relates to;
 [tab:Java]
 ```java
 TypeQLDefine query = TypeQL.define(
-    type("traversable").sub("entity").plays("edge", "from").plays("edge", "to"),
-    type("node").sub("traversable"), 
+    type("node").sub("entity").plays("edge", "from").plays("edge", "to"),
     type("edge").sub("relation").relates("from").relates("to")
 );
 ```
@@ -799,7 +795,7 @@ We can mark the unreachable nodes by defining the following rule:
 define
 
 unreachable sub relation, relates from, relates to;
-traversable sub entity,
+node sub entity,
     plays unreachable:from,
     plays unreachable:to;
 rule unreachability-rule:
@@ -817,7 +813,7 @@ rule unreachability-rule:
 ```java
 TypeQLDefine query = TypeQL.define(
     type("unreachable").sub("relation").relates("from").relates("to"),
-    type("traversable").sub("entity").plays("unreachable", "from").plays("unreachable", "to"),
+    type("node").sub("entity").plays("unreachable", "from").plays("unreachable", "to"),
     rule("unreachability-rule")
         .when(
             and(

--- a/files/negation/schema.tql
+++ b/files/negation/schema.tql
@@ -1,13 +1,12 @@
 define
 
-traversable sub entity,
+node sub entity,
     plays edge:from,
     plays edge:to,
     plays reachable:from,
     plays reachable:to,
     plays indirect-edge:from,
     plays indirect-edge:to;
-node sub traversable;
 
 indirect-edge sub relation, relates from, relates to;
 edge sub relation, relates from, relates to;


### PR DESCRIPTION
## What is the goal of this PR?
Document the more efficient formulation of rules to compute the transitive closure of a relation. This involves separating the base and inferred types, and having two rules:
1. The base case which creates the inferred relation for each relation of the inferred type.
2. The recursive case which infers a new relation by extending an inferred relation by one-hop.

## What are the changes implemented in this PR?
Adds a section explaining the above.