### PR TITLE
Updated Linux installation instructions

### DIFF
--- a/01-running-typedb/01-install-and-run.md
+++ b/01-running-typedb/01-install-and-run.md
@@ -18,9 +18,9 @@ TypeDB runs on Mac, Linux and Windows. The only requirement is Java (version 11 
 
 As a superuser, add the repo:
 ```
-sudo apt install software-properties-common apt-transport-https
-sudo gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 8F3DA4B5E9AEF44C 
-sudo gpg --export 8F3DA4B5E9AEF44C | sudo tee /etc/apt/trusted.gpg.d/vaticle.gpg > /dev/null
+sudo apt install software-properties-common apt-transport-https gpg
+gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 8F3DA4B5E9AEF44C 
+gpg --export 8F3DA4B5E9AEF44C | sudo tee /etc/apt/trusted.gpg.d/vaticle.gpg > /dev/null
 echo "deb [ arch=all ] https://repo.vaticle.com/repository/apt/ trusty main" | sudo tee /etc/apt/sources.list.d/vaticle.list > /dev/null
 ```
 

--- a/01-running-typedb/01-install-and-run.md
+++ b/01-running-typedb/01-install-and-run.md
@@ -29,15 +29,6 @@ Update the package cache:
 sudo apt update
 ```
 
-**NOTE**: Ubuntu 16.04 requires some extra steps to be able to install TypeDB, namely upgrading `libstdc++`:
-
-```
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-sudo apt-get update
-sudo apt-get install gcc-4.9
-sudo apt-get install --only-upgrade libstdc++6
-```
-
 Install TypeDB Server and TypeDB Console:
 ```
 sudo apt install typedb-all

--- a/01-running-typedb/01-install-and-run.md
+++ b/01-running-typedb/01-install-and-run.md
@@ -19,8 +19,9 @@ TypeDB runs on Mac, Linux and Windows. The only requirement is Java (version 11 
 As a superuser, add the repo:
 ```
 sudo apt install software-properties-common apt-transport-https
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 8F3DA4B5E9AEF44C
-sudo add-apt-repository 'deb [ arch=all ] https://repo.vaticle.com/repository/apt/ trusty main'
+sudo gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 8F3DA4B5E9AEF44C 
+sudo gpg --export 8F3DA4B5E9AEF44C | sudo tee /etc/apt/trusted.gpg.d/vaticle.gpg > /dev/null
+echo "deb [ arch=all ] https://repo.vaticle.com/repository/apt/ trusty main" | sudo tee /etc/apt/sources.list.d/vaticle.list > /dev/null
 ```
 
 Update the package cache:


### PR DESCRIPTION
## What is the goal of this PR?

We've updated our Linux installation instructions given that apt-key and add-apt-repository are both deprecated and giving warnings upon use.

## What are the changes implemented in this PR?

We now use the recommended gpg tools directly, adding each key to its own `.gpg` file in /etc/apt/trusted.gpg.d/ and each repository to its own '.list' in /etc/apt/sources.list.d/

I've tested all the instructions work on a fresh install of Ubuntu 22.04.1 (LTS).
