### PR TITLE
[GH-594] Fixed formatting of Note block in Migration and Backup

### DIFF
--- a/06-management/04-migration-and-backup.md
+++ b/06-management/04-migration-and-backup.md
@@ -80,8 +80,8 @@ typedb server import --database=[database] --port=[server rpc port] --file=[file
 ```
 
 <div class="note">
-In versions previous to 2.6.0, the "--database=" and "--file=" named arguments are not used, and you should simply use positional arguments like this:
-"old/typedb server export {database} data.typedb" or "old/typedb server import --database={database} --file=data.typedb"
+[Note]
+In versions previous to 2.6.0, the `--database=` and `--file=` named arguments are not used, and you should simply use positional arguments like this: `old/typedb server export {database} data.typedb` or `old/typedb server import --database={database} --file=data.typedb`.
 </div>
 
  

--- a/06-management/04-migration-and-backup.md
+++ b/06-management/04-migration-and-backup.md
@@ -81,7 +81,7 @@ typedb server import --database=[database] --port=[server rpc port] --file=[file
 
 <div class="note">
 [Note]
-In versions previous to 2.6.0, the `--database=` and `--file=` named arguments are not used, and you should simply use positional arguments like this: `old/typedb server export {database} data.typedb` or `old/typedb server import --database={database} --file=data.typedb`.
+In versions previous to 2.6.0, the `--database=` and `--file=` named arguments are not used, and you should simply use positional arguments like this: `old/typedb server export {database} data.typedb` or `old/typedb server import {database} data.typedb`.
 </div>
 
  


### PR DESCRIPTION
## What is the goal of this PR?

To fix the rendering of the Note block.

## What are the changes implemented in this PR?

Added [Note] syntax to markdown to fix the block rendering.
Also added some minor text tweaks.

Closes https://github.com/vaticle/docs/issues/594