### PR TITLE
[GH-553] Fixed mistake in get_iid() reference: type -> thing

### DIFF
--- a/04-concept-api/references/thing.yml
+++ b/04-concept-api/references/thing.yml
@@ -2,7 +2,7 @@ methods:
   - method:
     common: &method-iid
       title: Retrieves internal ID (Local)
-      description: Retrieves the unique id of the type.
+      description: Retrieves the unique id of the Thing.
       returns:
         - string
     java:


### PR DESCRIPTION
## What is the goal of this PR?

Close https://github.com/vaticle/docs/issues/553
Fix a mistake in a term used in the reference.

## What are the changes implemented in this PR?

Changed word type to a word Thing.