### PR TITLE
Driver API Annotations fix

### DIFF
--- a/clients-src/modules/ROOT/partials/java/concepts/attribute_type.adoc
+++ b/clients-src/modules/ROOT/partials/java/concepts/attribute_type.adoc
@@ -98,7 +98,7 @@ Optionally, filtered by annotations provided.
 | Only retrieve things that have an attribute of this type with annotations (KEY or UNIQUE).
 | set of `Annotation`
 | False
-| Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
+| Collections.emptySet();
 
 |===
 
@@ -128,7 +128,7 @@ Optionally, filtered by annotations provided.
 | Only retrieve things that have an attribute of this type with annotations (KEY or UNIQUE).
 | set of `Annotation`
 | False
-| Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
+| Collections.emptySet();
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/java/concepts/attribute_type.adoc
+++ b/clients-src/modules/ROOT/partials/java/concepts/attribute_type.adoc
@@ -85,7 +85,7 @@ attributeType.asRemote(Transaction tx).getOwners(Set<TypeQLToken.Annotation> ann
 
 === Description
 
-Retrieve all Things that own an attribute of this type.
+Retrieve all Things that own an attribute of this type. +
 Optionally, only fetches Things that own an attribute of this type with annotation set provided.
 
 === Input parameters
@@ -94,12 +94,12 @@ Optionally, only fetches Things that own an attribute of this type with annotati
 |===
 |Name |Description |Type |Required |Default Value
 
-| Annotation
+| annotations
 | Only retrieve things that have an attribute of this type with the exact annotation set.
-a|
-* `TypeQLToken.Annotation.KEY`
-* `TypeQLToken.Annotation.UNIQUE`
-| False | N/A
+| set of `Annotation`
+| False
+| Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
+
 |===
 
 === Returns
@@ -112,19 +112,23 @@ a|
 
 [source,java]
 ----
-attributeType.asRemote(Transaction tx).getOwnersExplicit(boolean onlyKey);
+attributeType.asRemote(Transaction tx).getOwnersExplicit(Set<TypeQLToken.Annotation> annotations);
 ----
 
 === Description
 
-Retrieve all Things that directly own an attribute of this type. Optionally, only fetches Things that own an attribute of this type as a key.
+Retrieve all Things that directly own an attribute of this type. +
+Optionally, only fetches Things that own an attribute of this type as a key.
 
 === Input parameters
 
 [options="header"]
 |===
-|Name |Description |Type |Required |Default Value
-| onlyKey | If true, only retrieve things that have an attribute of this type as a key. | boolean | False | False
+| annotations
+| Only retrieve things that have an attribute of this type with the exact annotation set.
+| set of `Annotation`
+| False
+| Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/java/concepts/attribute_type.adoc
+++ b/clients-src/modules/ROOT/partials/java/concepts/attribute_type.adoc
@@ -86,7 +86,7 @@ attributeType.asRemote(Transaction tx).getOwners(Set<TypeQLToken.Annotation> ann
 === Description
 
 Retrieve all Things that own an attribute of this type. +
-Optionally, only fetches Things that own an attribute of this type with annotation set provided.
+Optionally, filtered by annotations provided.
 
 === Input parameters
 
@@ -95,7 +95,7 @@ Optionally, only fetches Things that own an attribute of this type with annotati
 |Name |Description |Type |Required |Default Value
 
 | annotations
-| Only retrieve things that have an attribute of this type with the exact annotation set.
+| Only retrieve things that have an attribute of this type with annotations (KEY or UNIQUE).
 | set of `Annotation`
 | False
 | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
@@ -118,14 +118,14 @@ attributeType.asRemote(Transaction tx).getOwnersExplicit(Set<TypeQLToken.Annotat
 === Description
 
 Retrieve all Things that directly own an attribute of this type. +
-Optionally, only fetches Things that own an attribute of this type as a key.
+Optionally, filtered by annotations provided.
 
 === Input parameters
 
 [options="header"]
 |===
 | annotations
-| Only retrieve things that have an attribute of this type with the exact annotation set.
+| Only retrieve things that have an attribute of this type with annotations (KEY or UNIQUE).
 | set of `Annotation`
 | False
 | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();

--- a/clients-src/modules/ROOT/partials/java/concepts/thing.adoc
+++ b/clients-src/modules/ROOT/partials/java/concepts/thing.adoc
@@ -130,19 +130,20 @@ Unassigns an Attribute from this Thing.
 
 [source,java]
 ----
-thing.asRemote(Transaction tx).getHas(boolean onlyKey));
+thing.asRemote(Transaction tx).getHas(Set<TypeQLToken.Annotation> annotations);
 ----
 
 === Description
 
-Retrieves the Attributes that this Thing owns, optionally filtered by one or more AttributeTypes.
+Retrieves the Attributes that this Thing owns. +
+Optionally filtered by the exact set of annotations.
 
 === Input parameters
 
 [options="header"]
 |===
 |Name |Description |Type |Required |Default Value
-| onlyKey | If set to `true`, only attributes owned as a key will be retrieved. | boolean | False | False
+| annotations | Only retrieve attributes with the exact annotation set. | set of `Annotation` | False | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/java/concepts/thing.adoc
+++ b/clients-src/modules/ROOT/partials/java/concepts/thing.adoc
@@ -143,7 +143,7 @@ Optionally, filtered by annotations provided.
 [options="header"]
 |===
 |Name |Description |Type |Required |Default Value
-| annotations | Only retrieve attributes with annotations (KEY or UNIQUE). | set of `Annotation` | False | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
+| annotations | Only retrieve attributes with annotations (KEY or UNIQUE). | set of `Annotation` | False | Collections.emptySet();
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/java/concepts/thing.adoc
+++ b/clients-src/modules/ROOT/partials/java/concepts/thing.adoc
@@ -136,14 +136,14 @@ thing.asRemote(Transaction tx).getHas(Set<TypeQLToken.Annotation> annotations);
 === Description
 
 Retrieves the Attributes that this Thing owns. +
-Optionally filtered by the exact set of annotations.
+Optionally, filtered by annotations provided.
 
 === Input parameters
 
 [options="header"]
 |===
 |Name |Description |Type |Required |Default Value
-| annotations | Only retrieve attributes with the exact annotation set. | set of `Annotation` | False | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
+| annotations | Only retrieve attributes with annotations (KEY or UNIQUE). | set of `Annotation` | False | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/java/concepts/thing_type.adoc
+++ b/clients-src/modules/ROOT/partials/java/concepts/thing_type.adoc
@@ -154,7 +154,7 @@ Allows the instances of this type to play the given role.
 
 [source,java]
 ----
-thingType.asRemote(Transaction tx).setOwns(AttributeType attributeType, boolean isKey);
+thingType.asRemote(Transaction tx).setOwns(AttributeType attributeType, Set<TypeQLToken.Annotation> annotations);
 ----
 
 === Description
@@ -167,20 +167,20 @@ Allows the instances of this type to own the given `AttributeType`.
 |===
 |Name |Description |Type |Required |Default Value
 | attributeType | The AttributeType to be owned by the instances of this type. | [`AttributeType`]  | True | N/A
-| isKey | Whether this AttributeType is to be owned as a unique key. | boolean | False | False
+| annotations | Adds the set of annotations to the ownership. | set of `Annotation` | False | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
 |===
 
 === Returns
 
 * void
 
-== Add attribute ownership
+== Add attribute ownership (overriden)
 
 === Syntax
 
 [source,java]
 ----
-thingType.asRemote(Transaction tx).setOwns(AttributeType attributeType, AttributeType overriddenType, boolean isKey);
+thingType.asRemote(Transaction tx).setOwns(AttributeType attributeType, AttributeType overriddenType, Set<TypeQLToken.Annotation> annotations);
 ----
 
 === Description
@@ -194,7 +194,7 @@ Allows the instances of this type to own the given `AttributeType`.
 |Name |Description |Type |Required |Default Value
 | attributeType | The AttributeType to be owned by the instances of this type. | [`AttributeType`]  | True | N/A
 | overriddenType | The AttributeType that this attribute ownership overrides, if applicable. | [`AttributeType`]  | False | None
-| isKey | Whether this AttributeType is to be owned as a unique key. | boolean | False | False
+| annotations | Adds the set of annotations to the ownership. | set of `Annotation` | False | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
 |===
 
 === Returns
@@ -241,7 +241,7 @@ Retrieves all direct roles that are allowed to be played by the instances of thi
 
 [source,java]
 ----
-thingType.asRemote(Transaction tx).getOwns(boolean keysOnly);
+thingType.asRemote(Transaction tx).getOwns(Set<TypeQLToken.Annotation> annotations);
 ----
 
 === Description
@@ -253,7 +253,11 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 [options="header"]
 |===
 |Name |Description |Type |Required |Default Value
-| keysOnly | If set to `true`, then only attribute types owned as keys will be retrieved. | boolean | False | False
+| annotations
+| Only retrieve attribute types owned with the exact annotation set.
+| set of `Annotation`
+| False
+| Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
 |===
 
 === Returns
@@ -266,7 +270,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 
 [source,java]
 ----
-thingType.asRemote(Transaction tx).getOwnsExplicit(boolean keysOnly);
+thingType.asRemote(Transaction tx).getOwnsExplicit(Set<TypeQLToken.Annotation> annotations);
 ----
 
 === Description
@@ -278,7 +282,11 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 [options="header"]
 |===
 |Name |Description |Type |Required |Default Value
-| keysOnly | If set to `true`, then only attribute types owned as keys will be retrieved. | boolean | False | False
+| annotations
+| Only retrieve attribute types owned with the exact annotation set.
+| set of `Annotation`
+| False
+| Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
 |===
 
 === Returns
@@ -291,7 +299,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 
 [source,java]
 ----
-thingType.asRemote(Transaction tx).getOwns(AttributeType.ValueType valueType, boolean keysOnly);
+thingType.asRemote(Transaction tx).getOwns(AttributeType.ValueType valueType, Set<TypeQLToken.Annotation> annotations);
 ----
 
 === Description
@@ -304,7 +312,11 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 |===
 |Name |Description |Type |Required |Default Value
 | valueType | If specified, only attribute types of this ValueType will be retrieved. | `AttributeType.ValueType` | False | None
-| keysOnly | If set to `true`, then only attribute types owned as keys will be retrieved. | boolean | False | False
+| annotations
+| Only retrieve attribute types owned with the exact annotation set.
+| set of `Annotation`
+| False
+| Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
 |===
 
 === Returns
@@ -317,7 +329,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 
 [source,java]
 ----
-thingType.asRemote(Transaction tx).getOwnsExplicit(AttributeType.ValueType valueType, boolean keysOnly);
+thingType.asRemote(Transaction tx).getOwnsExplicit(AttributeType.ValueType valueType, Set<TypeQLToken.Annotation> annotations);
 ----
 
 === Description
@@ -330,7 +342,11 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 |===
 |Name |Description |Type |Required |Default Value
 | valueType | If specified, only attribute types of this ValueType will be retrieved. | `AttributeType.ValueType` | False | None
-| keysOnly | If set to `true`, then only attribute types owned as keys will be retrieved. | boolean | False | False
+| annotations
+| Only retrieve attribute types owned with the exact annotation set.
+| set of `Annotation`
+| False
+| Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/java/concepts/thing_type.adoc
+++ b/clients-src/modules/ROOT/partials/java/concepts/thing_type.adoc
@@ -167,7 +167,7 @@ Allows the instances of this type to own the given `AttributeType`.
 |===
 |Name |Description |Type |Required |Default Value
 | attributeType | The AttributeType to be owned by the instances of this type. | [`AttributeType`]  | True | N/A
-| annotations | Adds annotations (KEY or UNIQUE) to the ownership. | set of `Annotation` | False | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
+| annotations | Adds annotations (KEY or UNIQUE) to the ownership. | set of `Annotation` | False | Collections.emptySet();
 |===
 
 === Returns
@@ -194,7 +194,7 @@ Allows the instances of this type to own the given `AttributeType`.
 |Name |Description |Type |Required |Default Value
 | attributeType | The AttributeType to be owned by the instances of this type. | [`AttributeType`]  | True | N/A
 | overriddenType | The AttributeType that this attribute ownership overrides, if applicable. | [`AttributeType`]  | False | None
-| annotations | Adds annotations (KEY or UNIQUE) to the ownership. | set of `Annotation` | False | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
+| annotations | Adds annotations (KEY or UNIQUE) to the ownership. | set of `Annotation` | False | Collections.emptySet();
 |===
 
 === Returns
@@ -257,7 +257,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 | Only retrieve attribute types owned with annotations (KEY or UNIQUE).
 | set of `Annotation`
 | False
-| Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
+| Collections.emptySet();
 |===
 
 === Returns
@@ -286,7 +286,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 | Only retrieve attribute types owned with annotations (KEY or UNIQUE).
 | set of `Annotation`
 | False
-| Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
+| Collections.emptySet();
 |===
 
 === Returns
@@ -316,7 +316,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 | Only retrieve attribute types owned with annotations (KEY or UNIQUE).
 | set of `Annotation`
 | False
-| Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
+| Collections.emptySet();
 |===
 
 === Returns
@@ -346,7 +346,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 | Only retrieve attribute types owned with annotations (KEY or UNIQUE).
 | set of `Annotation`
 | False
-| Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
+| Collections.emptySet();
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/java/concepts/thing_type.adoc
+++ b/clients-src/modules/ROOT/partials/java/concepts/thing_type.adoc
@@ -167,7 +167,7 @@ Allows the instances of this type to own the given `AttributeType`.
 |===
 |Name |Description |Type |Required |Default Value
 | attributeType | The AttributeType to be owned by the instances of this type. | [`AttributeType`]  | True | N/A
-| annotations | Adds the set of annotations to the ownership. | set of `Annotation` | False | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
+| annotations | Adds annotations (KEY or UNIQUE) to the ownership. | set of `Annotation` | False | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
 |===
 
 === Returns
@@ -194,7 +194,7 @@ Allows the instances of this type to own the given `AttributeType`.
 |Name |Description |Type |Required |Default Value
 | attributeType | The AttributeType to be owned by the instances of this type. | [`AttributeType`]  | True | N/A
 | overriddenType | The AttributeType that this attribute ownership overrides, if applicable. | [`AttributeType`]  | False | None
-| annotations | Adds the set of annotations to the ownership. | set of `Annotation` | False | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
+| annotations | Adds annotations (KEY or UNIQUE) to the ownership. | set of `Annotation` | False | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
 |===
 
 === Returns
@@ -254,7 +254,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 |===
 |Name |Description |Type |Required |Default Value
 | annotations
-| Only retrieve attribute types owned with the exact annotation set.
+| Only retrieve attribute types owned with annotations (KEY or UNIQUE).
 | set of `Annotation`
 | False
 | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
@@ -283,7 +283,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 |===
 |Name |Description |Type |Required |Default Value
 | annotations
-| Only retrieve attribute types owned with the exact annotation set.
+| Only retrieve attribute types owned with annotations (KEY or UNIQUE).
 | set of `Annotation`
 | False
 | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
@@ -313,7 +313,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 |Name |Description |Type |Required |Default Value
 | valueType | If specified, only attribute types of this ValueType will be retrieved. | `AttributeType.ValueType` | False | None
 | annotations
-| Only retrieve attribute types owned with the exact annotation set.
+| Only retrieve attribute types owned with annotations (KEY or UNIQUE).
 | set of `Annotation`
 | False
 | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();
@@ -343,7 +343,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 |Name |Description |Type |Required |Default Value
 | valueType | If specified, only attribute types of this ValueType will be retrieved. | `AttributeType.ValueType` | False | None
 | annotations
-| Only retrieve attribute types owned with the exact annotation set.
+| Only retrieve attribute types owned with annotations (KEY or UNIQUE).
 | set of `Annotation`
 | False
 | Set<TypeQLToken.Annotation> annotations = Collections.emptySet();

--- a/clients-src/modules/ROOT/partials/javascript/concepts/attribute_type.adoc
+++ b/clients-src/modules/ROOT/partials/javascript/concepts/attribute_type.adoc
@@ -80,26 +80,20 @@ Retrieves all direct and indirect Attributes that are instances of this Type.
 
 [source,javascript]
 ----
-attributeType.asRemote(tx).getOwners(annotations: Annotation[]);
+attributeType.asRemote(tx).getOwners(annotations);
 ----
 
 === Description
 
-Retrieve all Things that own an attribute of this type.
-Optionally, only fetches Things that own an attribute of this type with annotation set provided.
+Retrieve all things that own an attribute of this type. +
+Optionally, filtered by annotations provided.
 
 === Input parameters
 
 [options="header"]
 |===
 |Name |Description |Type |Required |Default Value
-
-| Annotation
-| Only retrieve things that have an attribute of this type with the exact annotation set.
-a|
-* `ThingType.Annotation.KEY`
-* `ThingType.Annotations.UNIQUE`
-| False | N/A
+| annotations | Only retrieve things that have an attribute of this type with the annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
 |===
 
 === Returns
@@ -112,19 +106,20 @@ a|
 
 [source,javascript]
 ----
-attributeType.asRemote(tx).getOwnersExplicit(onlyKey)
+attributeType.asRemote(tx).getOwnersExplicit(annotations)
 ----
 
 === Description
 
-Retrieve all Things that directly own an attribute of this type. Optionally, only fetches Things that own an attribute of this type as a key.
+Retrieve all Things that directly own an attribute of this type. +
+Optionally, filtered by annotations provided.
 
 === Input parameters
 
 [options="header"]
 |===
 |Name |Description |Type |Required |Default Value
-| onlyKey | If true, only retrieve things that have an attribute of this type as a key. | boolean | False | False
+| annotations | Only retrieve things that directly have an attribute of this type with the annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/javascript/concepts/attribute_type.adoc
+++ b/clients-src/modules/ROOT/partials/javascript/concepts/attribute_type.adoc
@@ -93,7 +93,7 @@ Optionally, filtered by annotations provided.
 [options="header"]
 |===
 |Name |Description |Type |Required |Default Value
-| annotations | Only retrieve things that have an attribute of this type with the annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
+| annotations | Only retrieve things that have an attribute of this type with annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
 |===
 
 === Returns
@@ -119,7 +119,7 @@ Optionally, filtered by annotations provided.
 [options="header"]
 |===
 |Name |Description |Type |Required |Default Value
-| annotations | Only retrieve things that directly have an attribute of this type with the annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
+| annotations | Only retrieve things that directly have an attribute of this type with annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/javascript/concepts/thing.adoc
+++ b/clients-src/modules/ROOT/partials/javascript/concepts/thing.adoc
@@ -130,19 +130,20 @@ Unassigns an Attribute from this Thing.
 
 [source,javascript]
 ----
-await thing.asRemote(tx).getHas(onlyKey);
+await thing.asRemote(tx).getHas(annotations);
 ----
 
 === Description
 
-Retrieves the Attributes that this Thing owns, optionally filtered by one or more AttributeTypes.
+Retrieves the Attributes that this thing owns. +
+Optionally, filtered by annotations provided.
 
 === Input parameters
 
 [options="header"]
 |===
 |Name |Description |Type |Required |Default Value
-| onlyKey | If set to `true`, only attributes owned as a key will be retrieved. | boolean | False | False
+| annotations | Only retrieve attributes owned with the annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/javascript/concepts/thing.adoc
+++ b/clients-src/modules/ROOT/partials/javascript/concepts/thing.adoc
@@ -143,7 +143,7 @@ Optionally, filtered by annotations provided.
 [options="header"]
 |===
 |Name |Description |Type |Required |Default Value
-| annotations | Only retrieve attributes owned with the annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
+| annotations | Only retrieve attributes owned with annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/javascript/concepts/thing_type.adoc
+++ b/clients-src/modules/ROOT/partials/javascript/concepts/thing_type.adoc
@@ -154,12 +154,13 @@ Allows the instances of this type to play the given role.
 
 [source,javascript]
 ----
-await thingType.asRemote(tx).setOwns(attributeType, isKey);
+await thingType.asRemote(tx).setOwns(attributeType, annotations);
 ----
 
 === Description
 
-Allows the instances of this type to own the given `AttributeType`.
+Allows the instances of this type to own the given `AttributeType`. +
+Optionally, adds annotations to the ownership.
 
 === Input parameters
 
@@ -167,7 +168,7 @@ Allows the instances of this type to own the given `AttributeType`.
 |===
 |Name |Description |Type |Required |Default Value
 | attributeType | The AttributeType to be owned by the instances of this type. | [`AttributeType`]  | True | N/A
-| isKey | Whether this AttributeType is to be owned as a unique key. | boolean | False | False
+| annotations | Adds annotations (KEY or UNIQUE) to the ownership. | `ThingType.Annotation[]` | False | []
 |===
 
 === Returns
@@ -180,7 +181,7 @@ Allows the instances of this type to own the given `AttributeType`.
 
 [source,javascript]
 ----
-await thingType.asRemote(tx).setOwns(attributeType, overriddenType, isKey);
+await thingType.asRemote(tx).setOwns(attributeType, overriddenType, annotations);
 ----
 
 === Description
@@ -194,7 +195,7 @@ Allows the instances of this type to own the given `AttributeType`.
 |Name |Description |Type |Required |Default Value
 | attributeType | The AttributeType to be owned by the instances of this type. | [`AttributeType`]  | True | N/A
 | overriddenType | The AttributeType that this attribute ownership overrides, if applicable. | [`AttributeType`]  | False | None
-| isKey | Whether this AttributeType is to be owned as a unique key. | boolean | False | False
+| annotations | Adds annotations (KEY or UNIQUE) to the ownership. | `ThingType.Annotation[]` | False | []
 |===
 
 === Returns
@@ -241,19 +242,20 @@ Retrieves all direct roles that are allowed to be played by the instances of thi
 
 [source,javascript]
 ----
-await thingType.asRemote(tx).getOwns(keysOnly);
+await thingType.asRemote(tx).getOwns(annotations);
 ----
 
 === Description
 
-Retrieves attribute types that the instances of this type are allowed to own directly or via inheritance.
+Retrieves attribute types that the instances of this type are allowed to own directly or via inheritance. +
+Optionally, filters by annotations provided.
 
 === Input parameters
 
 [options="header"]
 |===
 |Name |Description |Type |Required |Default Value
-| keysOnly | If set to `true`, then only attribute types owned as keys will be retrieved. | boolean | False | False
+| annotations | Only retrieve attribute types owned with the annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
 |===
 
 === Returns
@@ -266,19 +268,20 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 
 [source,javascript]
 ----
-await thingType.asRemote(tx).getOwnsExplicit(keysOnly);
+await thingType.asRemote(tx).getOwnsExplicit(annotations);
 ----
 
 === Description
 
-Retrieves attribute types that the instances of this type are allowed to own directly.
+Retrieves attribute types that the instances of this type are allowed to own directly. +
+Optionally, filters by annotations provided.
 
 === Input parameters
 
 [options="header"]
 |===
 |Name |Description |Type |Required |Default Value
-| keysOnly | If set to `true`, then only attribute types owned as keys will be retrieved. | boolean | False | False
+| annotations | Only retrieve attribute types owned with the annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
 |===
 
 === Returns
@@ -291,12 +294,13 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 
 [source,javascript]
 ----
-await thingType.asRemote(tx).getOwns(valueType, keysOnly);
+await thingType.asRemote(tx).getOwns(valueType, annotations);
 ----
 
 === Description
 
-Retrieves attribute types that the instances of this type are allowed to own directly or via inheritance.
+Retrieves attribute types that the instances of this type are allowed to own directly or via inheritance. +
+Optionally, filters by annotations provided.
 
 === Input parameters
 
@@ -304,7 +308,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 |===
 |Name |Description |Type |Required |Default Value
 | valueType | If specified, only attribute types of this ValueType will be retrieved. | `AttributeType.ValueType` | False | None
-| keysOnly | If set to `true`, then only attribute types owned as keys will be retrieved. | boolean | False | False
+| annotations | Only retrieve attribute types owned with the annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
 |===
 
 === Returns
@@ -317,12 +321,13 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 
 [source,javascript]
 ----
-await thingType.asRemote(tx).getOwnsExplicit(valueType, keysOnly);
+await thingType.asRemote(tx).getOwnsExplicit(valueType, annotations);
 ----
 
 === Description
 
-Retrieves attribute types that the instances of this type are allowed to own directly.
+Retrieves attribute types that the instances of this type are allowed to own directly. +
+Optionally, filters by annotations provided.
 
 === Input parameters
 
@@ -330,7 +335,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 |===
 |Name |Description |Type |Required |Default Value
 | valueType | If specified, only attribute types of this ValueType will be retrieved. | `AttributeType.ValueType` | False | None
-| keysOnly | If set to `true`, then only attribute types owned as keys will be retrieved. | boolean | False | False
+| annotations | Only retrieve attribute types owned with the annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/javascript/concepts/thing_type.adoc
+++ b/clients-src/modules/ROOT/partials/javascript/concepts/thing_type.adoc
@@ -255,7 +255,7 @@ Optionally, filters by annotations provided.
 [options="header"]
 |===
 |Name |Description |Type |Required |Default Value
-| annotations | Only retrieve attribute types owned with the annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
+| annotations | Only retrieve attribute types owned with annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
 |===
 
 === Returns
@@ -281,7 +281,7 @@ Optionally, filters by annotations provided.
 [options="header"]
 |===
 |Name |Description |Type |Required |Default Value
-| annotations | Only retrieve attribute types owned with the annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
+| annotations | Only retrieve attribute types owned with annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
 |===
 
 === Returns
@@ -308,7 +308,7 @@ Optionally, filters by annotations provided.
 |===
 |Name |Description |Type |Required |Default Value
 | valueType | If specified, only attribute types of this ValueType will be retrieved. | `AttributeType.ValueType` | False | None
-| annotations | Only retrieve attribute types owned with the annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
+| annotations | Only retrieve attribute types owned with annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
 |===
 
 === Returns
@@ -335,7 +335,7 @@ Optionally, filters by annotations provided.
 |===
 |Name |Description |Type |Required |Default Value
 | valueType | If specified, only attribute types of this ValueType will be retrieved. | `AttributeType.ValueType` | False | None
-| annotations | Only retrieve attribute types owned with the annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
+| annotations | Only retrieve attribute types owned with annotations (KEY or UNIQUE). | `ThingType.Annotation[]` | False | []
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/python/concepts/attribute_type.adoc
+++ b/clients-src/modules/ROOT/partials/python/concepts/attribute_type.adoc
@@ -80,7 +80,7 @@ Retrieves all direct and indirect Attributes that are instances of this Type.
 
 [source,python]
 ----
-attributeType.as_remote(tx).get_owners(annotations: Set["Annotation"])
+attribute_type.as_remote(tx).get_owners(annotations_set)
 ----
 
 === Description
@@ -94,11 +94,17 @@ Optionally, only fetches Things that own an attribute of this type with annotati
 |===
 |Name |Description |Type |Required |Default Value
 
-| Annotation
+| annotations_set
 | Only retrieve things that have an attribute of this type with the exact annotation set.
-a|
-* `ThingType.Annotation.KEY`
-* `ThingType.Annotations.UNIQUE`
+a| `annotations=set_of_annotations`
+
+Where `set_of_annotations` is a set of Enums from the `typedb.client.Annotations`:
+
+* `Annotations.KEY`
+* `Annotations.UNIQUE`
+
+To be able to do that, don't forget to import `Annotations`:
+`from typedb.client import Annotations`.
 | False | N/A
 |===
 
@@ -112,19 +118,32 @@ a|
 
 [source,python]
 ----
-attribute_type.as_remote(tx).get_owners_explicit(only_key)
+attribute_type.as_remote(tx).get_owners_explicit(annotations_set)
 ----
 
 === Description
 
-Retrieve all Things that directly own an attribute of this type. Optionally, only fetches Things that own an attribute of this type as a key.
+Retrieve all Things that directly own an attribute of this type.
+Optionally, only fetches Things that own an attribute with annotations.
 
 === Input parameters
 
 [options="header"]
 |===
 |Name |Description |Type |Required |Default Value
-| onlyKey | If true, only retrieve things that have an attribute of this type as a key. | boolean | False | False
+
+| annotations_set
+| Only retrieve things that have an attribute of this type with the exact annotation set.
+a| `annotations=set_of_annotations`
+
+Where `set_of_annotations` is a set of Enums from the `typedb.client.Annotations`:
+
+* `Annotations.KEY`
+* `Annotations.UNIQUE`
+
+To be able to do that, don't forget to import `Annotations`:
+`from typedb.client import Annotations`.
+| False | N/A
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/python/concepts/attribute_type.adoc
+++ b/clients-src/modules/ROOT/partials/python/concepts/attribute_type.adoc
@@ -80,7 +80,7 @@ Retrieves all direct and indirect Attributes that are instances of this Type.
 
 [source,python]
 ----
-attribute_type.as_remote(tx).get_owners(annotations_set)
+attribute_type.as_remote(tx).get_owners(annotations=frozenset())
 ----
 
 === Description
@@ -94,18 +94,11 @@ Optionally, only fetches Things that own an attribute of this type with annotati
 |===
 |Name |Description |Type |Required |Default Value
 
-| annotations_set
+| annotations
 | Only retrieve things that have an attribute of this type with the exact annotation set.
-a| `annotations=set_of_annotations`
-
-Where `set_of_annotations` is a set of Enums from the `typedb.client.Annotations`:
-
-* `Annotations.KEY`
-* `Annotations.UNIQUE`
-
-To be able to do that, don't forget to import `Annotations`:
-`from typedb.client import Annotations`.
-| False | N/A
+| set of `Annotations`
+| False
+| frozenset()
 |===
 
 === Returns
@@ -118,7 +111,7 @@ To be able to do that, don't forget to import `Annotations`:
 
 [source,python]
 ----
-attribute_type.as_remote(tx).get_owners_explicit(annotations_set)
+attribute_type.as_remote(tx).get_owners_explicit(annotations=frozenset())
 ----
 
 === Description
@@ -132,18 +125,11 @@ Optionally, only fetches Things that own an attribute with annotations.
 |===
 |Name |Description |Type |Required |Default Value
 
-| annotations_set
+| annotations
 | Only retrieve things that have an attribute of this type with the exact annotation set.
-a| `annotations=set_of_annotations`
-
-Where `set_of_annotations` is a set of Enums from the `typedb.client.Annotations`:
-
-* `Annotations.KEY`
-* `Annotations.UNIQUE`
-
-To be able to do that, don't forget to import `Annotations`:
-`from typedb.client import Annotations`.
-| False | N/A
+| set of `Annotations`
+| False
+| frozenset()
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/python/concepts/attribute_type.adoc
+++ b/clients-src/modules/ROOT/partials/python/concepts/attribute_type.adoc
@@ -85,8 +85,8 @@ attribute_type.as_remote(tx).get_owners(annotations=frozenset())
 
 === Description
 
-Retrieve all Things that own an attribute of this type.
-Optionally, only fetches Things that own an attribute of this type with annotation set provided.
+Retrieve all Things that own an attribute of this type. +
+Optionally, filtered by annotations.
 
 === Input parameters
 
@@ -95,7 +95,7 @@ Optionally, only fetches Things that own an attribute of this type with annotati
 |Name |Description |Type |Required |Default Value
 
 | annotations
-| Only retrieve things that have an attribute of this type with the exact annotation set.
+| Only retrieve things that have an attribute of this type with annotations (KEY or UNIQUE).
 | set of `Annotations`
 | False
 | frozenset()
@@ -117,7 +117,7 @@ attribute_type.as_remote(tx).get_owners_explicit(annotations=frozenset())
 === Description
 
 Retrieve all Things that directly own an attribute of this type.
-Optionally, only fetches Things that own an attribute with annotations.
+Optionally, filtered by annotations.
 
 === Input parameters
 
@@ -126,7 +126,7 @@ Optionally, only fetches Things that own an attribute with annotations.
 |Name |Description |Type |Required |Default Value
 
 | annotations
-| Only retrieve things that have an attribute of this type with the exact annotation set.
+| Only retrieve things that directly have an attribute of this type with annotations (KEY or UNIQUE).
 | set of `Annotations`
 | False
 | frozenset()

--- a/clients-src/modules/ROOT/partials/python/concepts/thing.adoc
+++ b/clients-src/modules/ROOT/partials/python/concepts/thing.adoc
@@ -130,12 +130,14 @@ Unassigns an Attribute from this Thing.
 
 [source,python]
 ----
-thing.as_remote(tx).get_has(attribute_type=None, attribute_types=[], only_key=False)
+thing.as_remote(tx).get_has(attribute_type=None, attribute_types=[], annotations_set)
 ----
 
 === Description
 
-Retrieves the Attributes that this Thing owns, optionally filtered by one or more AttributeTypes.
+Retrieves the Attributes that this Thing owns.
+Optionally filtered by one or more AttributeTypes.
+Optionally filtered by a specific set of annotations.
 
 === Input parameters
 
@@ -144,7 +146,18 @@ Retrieves the Attributes that this Thing owns, optionally filtered by one or mor
 |Name |Description |Type |Required |Default Value
 | attribute_type | The AttributeType to filter the attributes by. | `AttributeType` | False | None
 | attribute_types | The AttributeTypes to filter the attributes by. | list of `AttributeType` | False | []
-| only_key | If set to `True`, only attributes owned as a key will be retrieved. | boolean | False | False
+| annotations_set
+| Only retrieve attributes with the exact annotation set.
+a| `annotations=set_of_annotations`
+
+Where `set_of_annotations` is a set of Enums from the `typedb.client.Annotations`:
+
+* `Annotations.KEY`
+* `Annotations.UNIQUE`
+
+To be able to do that, don't forget to import `Annotations`:
+`from typedb.client import Annotations`.
+| False | N/A
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/python/concepts/thing.adoc
+++ b/clients-src/modules/ROOT/partials/python/concepts/thing.adoc
@@ -136,8 +136,8 @@ thing.as_remote(tx).get_has(attribute_type=None, attribute_types=[], annotations
 === Description
 
 Retrieves the Attributes that this Thing owns. +
-Optionally filtered by one or more AttributeTypes. +
-Optionally filtered by a specific set of annotations.
+Optionally, filtered by one or more AttributeTypes. +
+Optionally, filtered by annotations.
 
 === Input parameters
 
@@ -146,7 +146,7 @@ Optionally filtered by a specific set of annotations.
 |Name |Description |Type |Required |Default Value
 | attribute_type | The AttributeType to filter the attributes by. | `AttributeType` | False | `None`
 | attribute_types | The AttributeTypes to filter the attributes by. | list of `AttributeType` | False | `None`
-| annotations | Only retrieve attributes with the exact annotation set. | set of `Annotations` | False | frozenset()
+| annotations | Only retrieve attributes with annotations (KEY or UNIQUE). | set of `Annotations` | False | frozenset()
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/python/concepts/thing.adoc
+++ b/clients-src/modules/ROOT/partials/python/concepts/thing.adoc
@@ -130,13 +130,13 @@ Unassigns an Attribute from this Thing.
 
 [source,python]
 ----
-thing.as_remote(tx).get_has(attribute_type=None, attribute_types=[], annotations_set)
+thing.as_remote(tx).get_has(attribute_type=None, attribute_types=[], annotations=frozenset())
 ----
 
 === Description
 
-Retrieves the Attributes that this Thing owns.
-Optionally filtered by one or more AttributeTypes.
+Retrieves the Attributes that this Thing owns. +
+Optionally filtered by one or more AttributeTypes. +
 Optionally filtered by a specific set of annotations.
 
 === Input parameters
@@ -144,20 +144,9 @@ Optionally filtered by a specific set of annotations.
 [options="header"]
 |===
 |Name |Description |Type |Required |Default Value
-| attribute_type | The AttributeType to filter the attributes by. | `AttributeType` | False | None
-| attribute_types | The AttributeTypes to filter the attributes by. | list of `AttributeType` | False | []
-| annotations_set
-| Only retrieve attributes with the exact annotation set.
-a| `annotations=set_of_annotations`
-
-Where `set_of_annotations` is a set of Enums from the `typedb.client.Annotations`:
-
-* `Annotations.KEY`
-* `Annotations.UNIQUE`
-
-To be able to do that, don't forget to import `Annotations`:
-`from typedb.client import Annotations`.
-| False | N/A
+| attribute_type | The AttributeType to filter the attributes by. | `AttributeType` | False | `None`
+| attribute_types | The AttributeTypes to filter the attributes by. | list of `AttributeType` | False | `None`
+| annotations | Only retrieve attributes with the exact annotation set. | set of `Annotations` | False | frozenset()
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/python/concepts/thing_type.adoc
+++ b/clients-src/modules/ROOT/partials/python/concepts/thing_type.adoc
@@ -154,7 +154,7 @@ Allows the instances of this type to play the given role.
 
 [source,python]
 ----
-thing_type.as_remote(tx).set_owns(attribute_type, overridden_type=None, is_key=False);
+thing_type.as_remote(tx).set_owns(attribute_type, overridden_type=None, annotations_set);
 ----
 
 === Description
@@ -168,7 +168,18 @@ Allows the instances of this type to own the given `AttributeType`.
 |Name |Description |Type |Required |Default Value
 | attributeType | The AttributeType to be owned by the instances of this type. | [`AttributeType`]  | True | N/A
 | overriddenType | The AttributeType that this attribute ownership overrides, if applicable. | [`AttributeType`]  | False | None
-| isKey | Whether this AttributeType is to be owned as a unique key. | bool | False | False
+| annotations_set
+| Adds the set of annotations to the ownership.
+a| `annotations=set_of_annotations`
+
+Where `set_of_annotations` is a set of Enums from the `typedb.client.Annotations`:
+
+* `Annotations.KEY`
+* `Annotations.UNIQUE`
+
+To be able to do that, don't forget to import `Annotations`:
+`from typedb.client import Annotations`.
+| False | N/A
 |===
 
 === Returns
@@ -215,7 +226,7 @@ Retrieves all direct roles that are allowed to be played by the instances of thi
 
 [source,python]
 ----
-thing_type.as_remote(tx).get_owns(value_type=None, keys_only=False)
+thing_type.as_remote(tx).get_owns(value_type=None, annotations_set)
 ----
 
 === Description
@@ -228,7 +239,18 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 |===
 |Name |Description |Type |Required |Default Value
 | value_type | If specified, only attribute types of this ValueType will be retrieved. | `ValueType` | False | None
-| keys_only | If set to `True`, then only attribute types owned as keys will be retrieved. | bool | False | False
+| annotations_set
+| Only retrieve attribute types owned with the exact annotation set.
+a| `annotations=set_of_annotations`
+
+Where `set_of_annotations` is a set of Enums from the `typedb.client.Annotations`:
+
+* `Annotations.KEY`
+* `Annotations.UNIQUE`
+
+To be able to do that, don't forget to import `Annotations`:
+`from typedb.client import Annotations`.
+| False | N/A
 |===
 
 === Returns
@@ -241,7 +263,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 
 [source,python]
 ----
-thing_type.as_remote(tx).get_owns_explicit(value_type=None, keys_only=False)
+thing_type.as_remote(tx).get_owns_explicit(value_type=None, annotations_set)
 ----
 
 === Description
@@ -254,7 +276,18 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 |===
 |Name |Description |Type |Required |Default Value
 | value_type | If specified, only attribute types of this ValueType will be retrieved. | `ValueType` | False | None
-| keys_only | If set to `True`, then only attribute types owned as keys will be retrieved. | bool | False | False
+| annotations_set
+| Only retrieve attribute types owned with the exact annotation set.
+a| `annotations=set_of_annotations`
+
+Where `set_of_annotations` is a set of Enums from the `typedb.client.Annotations`:
+
+* `Annotations.KEY`
+* `Annotations.UNIQUE`
+
+To be able to do that, don't forget to import `Annotations`:
+`from typedb.client import Annotations`.
+| False | N/A
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/python/concepts/thing_type.adoc
+++ b/clients-src/modules/ROOT/partials/python/concepts/thing_type.adoc
@@ -154,7 +154,7 @@ Allows the instances of this type to play the given role.
 
 [source,python]
 ----
-thing_type.as_remote(tx).set_owns(attribute_type, overridden_type=None, annotations_set);
+thing_type.as_remote(tx).set_owns(attribute_type, overridden_type=None, annotations=frozenset());
 ----
 
 === Description
@@ -168,18 +168,7 @@ Allows the instances of this type to own the given `AttributeType`.
 |Name |Description |Type |Required |Default Value
 | attributeType | The AttributeType to be owned by the instances of this type. | [`AttributeType`]  | True | N/A
 | overriddenType | The AttributeType that this attribute ownership overrides, if applicable. | [`AttributeType`]  | False | None
-| annotations_set
-| Adds the set of annotations to the ownership.
-a| `annotations=set_of_annotations`
-
-Where `set_of_annotations` is a set of Enums from the `typedb.client.Annotations`:
-
-* `Annotations.KEY`
-* `Annotations.UNIQUE`
-
-To be able to do that, don't forget to import `Annotations`:
-`from typedb.client import Annotations`.
-| False | N/A
+| annotations | Adds the set of annotations to the ownership. | set of `Annotations` | False | frozenset()
 |===
 
 === Returns
@@ -226,7 +215,7 @@ Retrieves all direct roles that are allowed to be played by the instances of thi
 
 [source,python]
 ----
-thing_type.as_remote(tx).get_owns(value_type=None, annotations_set)
+thing_type.as_remote(tx).get_owns(value_type=None, annotations=frozenset())
 ----
 
 === Description
@@ -239,18 +228,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 |===
 |Name |Description |Type |Required |Default Value
 | value_type | If specified, only attribute types of this ValueType will be retrieved. | `ValueType` | False | None
-| annotations_set
-| Only retrieve attribute types owned with the exact annotation set.
-a| `annotations=set_of_annotations`
-
-Where `set_of_annotations` is a set of Enums from the `typedb.client.Annotations`:
-
-* `Annotations.KEY`
-* `Annotations.UNIQUE`
-
-To be able to do that, don't forget to import `Annotations`:
-`from typedb.client import Annotations`.
-| False | N/A
+| annotations | Only retrieve attribute types owned with the exact annotation set. | set of `Annotations` | False | frozenset()
 |===
 
 === Returns
@@ -261,9 +239,9 @@ To be able to do that, don't forget to import `Annotations`:
 
 === Syntax
 
-[source,python]
+[options="header"]
 ----
-thing_type.as_remote(tx).get_owns_explicit(value_type=None, annotations_set)
+thing_type.as_remote(tx).get_owns_explicit(value_type=None, annotations=frozenset())
 ----
 
 === Description
@@ -276,18 +254,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 |===
 |Name |Description |Type |Required |Default Value
 | value_type | If specified, only attribute types of this ValueType will be retrieved. | `ValueType` | False | None
-| annotations_set
-| Only retrieve attribute types owned with the exact annotation set.
-a| `annotations=set_of_annotations`
-
-Where `set_of_annotations` is a set of Enums from the `typedb.client.Annotations`:
-
-* `Annotations.KEY`
-* `Annotations.UNIQUE`
-
-To be able to do that, don't forget to import `Annotations`:
-`from typedb.client import Annotations`.
-| False | N/A
+annotations | Only retrieve attribute types owned with the exact annotation set. | set of `Annotations` | False | frozenset()
 |===
 
 === Returns

--- a/clients-src/modules/ROOT/partials/python/concepts/thing_type.adoc
+++ b/clients-src/modules/ROOT/partials/python/concepts/thing_type.adoc
@@ -239,7 +239,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 
 === Syntax
 
-[options="header"]
+[source,python]
 ----
 thing_type.as_remote(tx).get_owns_explicit(value_type=None, annotations=frozenset())
 ----

--- a/clients-src/modules/ROOT/partials/python/concepts/thing_type.adoc
+++ b/clients-src/modules/ROOT/partials/python/concepts/thing_type.adoc
@@ -168,7 +168,7 @@ Allows the instances of this type to own the given `AttributeType`.
 |Name |Description |Type |Required |Default Value
 | attributeType | The AttributeType to be owned by the instances of this type. | [`AttributeType`]  | True | N/A
 | overriddenType | The AttributeType that this attribute ownership overrides, if applicable. | [`AttributeType`]  | False | None
-| annotations | Adds the set of annotations to the ownership. | set of `Annotations` | False | frozenset()
+| annotations | Adds annotations (KEY or UNIQUE) to the ownership. | set of `Annotations` | False | frozenset()
 |===
 
 === Returns
@@ -228,7 +228,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 |===
 |Name |Description |Type |Required |Default Value
 | value_type | If specified, only attribute types of this ValueType will be retrieved. | `ValueType` | False | None
-| annotations | Only retrieve attribute types owned with the exact annotation set. | set of `Annotations` | False | frozenset()
+| annotations | Only retrieve attribute types owned with annotations (KEY or UNIQUE). | set of `Annotations` | False | frozenset()
 |===
 
 === Returns
@@ -254,7 +254,7 @@ Retrieves attribute types that the instances of this type are allowed to own dir
 |===
 |Name |Description |Type |Required |Default Value
 | value_type | If specified, only attribute types of this ValueType will be retrieved. | `ValueType` | False | None
-annotations | Only retrieve attribute types owned with the exact annotation set. | set of `Annotations` | False | frozenset()
+annotations | Only retrieve attribute types owned with annotations (KEY or UNIQUE). | set of `Annotations` | False | frozenset()
 |===
 
 === Returns


### PR DESCRIPTION
## What is the goal of this PR?

Fix outdated info on Key annotation. It was replaced by a universal set/frozenset of Annotations in TypeDB 2.18.

## What are the changes implemented in this PR?

We are using `annotations` now instead of `only_Key`, `is_Key`, and `keys_only`.
