### PR TITLE
Add linux ARM note to Docker start

### DIFF
--- a/typedb-src/antora.yml
+++ b/typedb-src/antora.yml
@@ -3,7 +3,7 @@ title: TypeDB
 version: 2.x
 asciidoc:
   attributes:
-    latest-version: 2.19.0@
+    latest-version: 2.19.1@
 nav:
 - modules/ROOT/nav.adoc
 start_page: typedb::overview.adoc

--- a/typedb-src/modules/ROOT/partials/docker.adoc
+++ b/typedb-src/modules/ROOT/partials/docker.adoc
@@ -28,16 +28,17 @@ docker pull vaticle/typedb:latest
 The TypeDB container exposes TypeDB's default port, `1729`, and uses its default data directory,
 `/opt/typedb-all-linux/server/data`.
 
-The following command starts a named TypeDB container, maps its exposed port to the host machine, and creates a named
-volume mapped to the data directory -- making it persistent across container restarts.
+The following command starts a named TypeDB container, maps its connection port to the host machine, and creates a
+docker volume named `try-typedb` mapped to the data directory -- making it persistent across container restarts.
 
 [,bash]
 ----
 docker run --name try-typedb -d -v try-typedb-data:/opt/typedb-all-linux/server/data/ -p 1729:1729 --platform linux/amd64 vaticle/typedb:latest
 ----
 
-The `--platform linux/amd64` parameter is required to run the TypeDB container on macOS with an `ARM64`/`AArch64`
-architecture.
+The `--platform linux/amd64` parameter is required to run the TypeDB container on macOS with the `ARM64`/`AArch64`
+architecture. The support for the `ARM64` architecture on Linux will be available in one of the future versions of
+TypeDB.
 
 The following variables should be noted and can be modified:
 

--- a/typedb-src/modules/ROOT/partials/docker.adoc
+++ b/typedb-src/modules/ROOT/partials/docker.adoc
@@ -37,7 +37,7 @@ docker run --name try-typedb -d -v try-typedb-data:/opt/typedb-all-linux/server/
 ----
 
 The `--platform linux/amd64` parameter is required to run the TypeDB container on macOS with the `ARM64`/`AArch64`
-architecture. The support for the `ARM64` architecture on Linux will be available in one of the future versions of
+architecture. Support for `linux/arm64` will be released in a future version of
 TypeDB.
 
 The following variables should be noted and can be modified:

--- a/typedb-src/modules/ROOT/partials/linux.adoc
+++ b/typedb-src/modules/ROOT/partials/linux.adoc
@@ -69,6 +69,9 @@ specific version for every package.
 
 // tag::install-manual[]
 
+`ARM64` architecture support on Linux OS will be added in future versions of TypeDB.
+For now, TypeDB for Linux supports `x86/x64` only.
+
 . Ensure Java 11+ is installed.
 TypeDB supports https://jdk.java.net[OpenJDK,window=_blank] and
 https://www.oracle.com/java/technologies/downloads/[Oracle JDK,window=_blank].

--- a/typedb-src/modules/ROOT/partials/linux.adoc
+++ b/typedb-src/modules/ROOT/partials/linux.adoc
@@ -69,7 +69,6 @@ specific version for every package.
 
 // tag::install-manual[]
 
-`ARM64` architecture support on Linux OS will be added in future versions of TypeDB.
 For now, TypeDB for Linux supports `x86/x64` only.
 
 . Ensure Java 11+ is installed.

--- a/typedb-src/modules/ROOT/partials/linux.adoc
+++ b/typedb-src/modules/ROOT/partials/linux.adoc
@@ -69,8 +69,6 @@ specific version for every package.
 
 // tag::install-manual[]
 
-For now, TypeDB for Linux supports `x86/x64` only.
-
 . Ensure Java 11+ is installed.
 TypeDB supports https://jdk.java.net[OpenJDK,window=_blank] and
 https://www.oracle.com/java/technologies/downloads/[Oracle JDK,window=_blank].


### PR DESCRIPTION
## What is the goal of this PR?

Add a warning of not supporting Linux ARM in the form of announcing future support.

## What are the changes implemented in this PR?

Add a note announcing future support of `ARM` architecture on Linux for Linux manual installation and docker start.
Minor fixes in wording of existing content.
Updated the latest-version variable value.