### PR TITLE
TypeQL-Advanced patterns IAM note fix and other minor fixes

### DIFF
--- a/typeql-src/modules/ROOT/pages/data/advanced.adoc
+++ b/typeql-src/modules/ROOT/pages/data/advanced.adoc
@@ -22,8 +22,7 @@ toc::[]
 The statements below can be used as standalone patterns or
 xref:typeql::data/basic-patterns.adoc#_combining_statements[combined] with other statements
 to find types defined in a database's schema.
-
-Use the xref:data/get.adoc[Get] query to try them.
+Use the xref:schema/define-types.adoc[Define] query to try them.
 
 [cols="^.^1,^.^2,^.^2"]
 |===
@@ -41,15 +40,15 @@ Use the xref:data/get.adoc[Get] query to try them.
 | `$<var_label> sub! <type>;`
 | `$t sub! subject;`
 
-| Role type in a relation
+| Role in a relation type
 | `<relation> relates $<var_label>;`
 | `permission relates $r;`
 
-| Players type in a relation
+| Role player's type in a relation
 | `$<var_label> plays <relation>:<role>;`
 | `$r plays permission:subject;`
 
-| Owner of an attribute type
+| Owner type of an attribute type
 | `$<var_label> owns <attr-type>;`
 | `$o owns full-name;`
 
@@ -63,38 +62,28 @@ Use the xref:data/get.adoc[Get] query to try them.
 The statements below can be used as a standalone patterns or in a
 xref:typeql::data/basic-patterns.adoc#_combining_statements[combination] with other statements
 to find data in a database.
-
 Use the xref:data/get.adoc[Get] query to try them.
-
-[NOTE]
-====
-The patterns below are designed for the IAM schema and dataset, but they can return any number of results:
-
-* zero,
-* one,
-* multiple.
-====
 
 [cols="^.^1,^.^2,^.^2"]
 |===
 | *What we are looking for in data* | *Pattern syntax* | *Examples*
 
-| Instance of type or subtype
+| Instance of a type or a subtype
 | `+$<var_label> isa <type> [, <has-attribute statement>...];+`
 | `$p isa person, has $a;`
 
-| Instance of type
+| Instance of a type
 | `+$<var_label> isa! <type> [, <has-attribute statement>...];+`
 | `$p isa! person, has $a;`
 
-| Attribute
+| Instance of an attribute type
 | `+$<var_label> [isa[!] <attr-type>] (contains "<text>" \| like "<regex>" \| <value>) [, <has-attribute statement>...];+`
 a|
 * `$a "Kevin Morrison";`
 * `$b isa full-name;`
 * `$c contains "Kevin";`
 
-| relation
+| Instance of a relation
 | `+[$<var_label>] ([<role>:] $<var_label> [, [<role>:] $<var_label>]...) isa <relation-type> [, <has-attribute statement>...];+`
 | `$pe (subject: $p, access: $ac) isa permission, has validity true;`
 
@@ -117,6 +106,17 @@ xref:typeql::data/basic-patterns.adoc#_combining_statements[combining statements
 -- see the xref:typeql::data/basic-patterns.adoc[] page.
 
 == Matching patterns examples
+
+[NOTE]
+====
+The patterns below are designed for the IAM
+xref:typedb::attachment$iam-schema.tql[schema] and
+xref:typedb::attachment$iam-data.tql[dataset], but they can return any number of results:
+
+* zero,
+* one,
+* multiple.
+====
 
 === Schema
 


### PR DESCRIPTION
## What is the goal of this PR?

Move the IAM note on the Advanced Patterns page to a more relevant location.

## What are the changes implemented in this PR?

Move the IAM note block further down to examples, that actually use the IAM schema/data. Added links to the schema/data.
Some minor fixes on the same page.
