### PR TITLE
fix: syntax error in `fundamentals.adoc`

### DIFF
--- a/typeql-src/modules/ROOT/pages/fundamentals.adoc
+++ b/typeql-src/modules/ROOT/pages/fundamentals.adoc
@@ -322,7 +322,7 @@ name sub attribute, value string;
 
 person sub entity,
   owns name,
-  plays spouse:marriage;
+  plays marriage:spouse;
 
 marriage sub relation,
   relates spouse;


### PR DESCRIPTION
## What is the goal of this PR?

Fixing the syntax error in `fundamentals.adoc`.

## What are the changes implemented in this PR?

- Switched around the relation and role so the relation is first
