### PR TITLE
Fix the windows and mac start instructions

### DIFF
--- a/typedb-src/modules/ROOT/partials/macos.adoc
+++ b/typedb-src/modules/ROOT/partials/macos.adoc
@@ -54,8 +54,6 @@ Run the following command in a terminal:
 typedb server
 ----
 
-Now we can start the TypeDB server by using the `typedb server` command in the local terminal.
-
 TypeDB will run in the foreground. If the terminal running TypeDB is closed, TypeDB server will be shut down.
 We recommend opening a new terminal to run TypeDB Console.
 

--- a/typedb-src/modules/ROOT/partials/win.adoc
+++ b/typedb-src/modules/ROOT/partials/win.adoc
@@ -40,12 +40,17 @@ typedb server
 TypeDB will run in the foreground. If the terminal running TypeDB is closed, TypeDB will be shut down. We recommend
 opening a new terminal to run TypeDB Console.
 
-Use a `typedb.bat server` command directly from the directory with TypeDB files to start a TypeDB server without
-environment variables setup.
+Alternatively, use a `typedb.bat server` command directly from the directory with TypeDB files to start a TypeDB server
+without environment variables setup.
 
 If the following error occurs, please try to install the "C++ redistributable" by following the instructions
-https://developers.google.com/optimization/install/python/windows#microsoft-visual-c-redistributable[here,window=_blank].
+https://developers.google.com/optimization/install/java/binary_windows#microsoft_visual_c_redistributable[here,window=_blank].
 
+[,shell]
+----
+Exception in thread "main" java.lang.UnsatisfiedLinkError:
+C:\Users\Vaticle\AppData\Local\Temp\ortools-java\win32-x86-64\jniortools.dll: Can't find dependent libraries
+----
 // end::start[]
 
 // tag::stop[]


### PR DESCRIPTION
## What is the goal of this PR?

Fix the start instructions on the installation page.

## What are the changes implemented in this PR?

Windows: Include the error text and fix the broken link.
macOS: Remove a redundant phrase.