### PR TITLE
Linux installation command fix

### DIFF
--- a/typedb-src/modules/ROOT/partials/linux.adoc
+++ b/typedb-src/modules/ROOT/partials/linux.adoc
@@ -7,7 +7,7 @@
 sudo apt install software-properties-common apt-transport-https gpg
 gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 8F3DA4B5E9AEF44C
 gpg --export 8F3DA4B5E9AEF44C | sudo tee /etc/apt/trusted.gpg.d/vaticle.gpg > /dev/null
-echo "deb [ arch=all ] https://repo.vaticle.com/repository/apt/ trusty main" | sudo tee /etc/apt/sources.list.d/vaticle.list > /dev/null
+echo "deb https://repo.vaticle.com/repository/apt/ trusty main" | sudo tee /etc/apt/sources.list.d/vaticle.list > /dev/null
 ----
 . Update the package cache:
 +


### PR DESCRIPTION
## What is the goal of this PR?

Fixing the installation commands by Dmitrii's advice.

## What are the changes implemented in this PR?

Removed the `arch` in the Add repository command:
`deb https://repo.vaticle.com/repository/apt/ trusty main`