### PR TITLE
Update older arm mac installation guide via Homebrew note

### DIFF
--- a/typedb-src/modules/ROOT/partials/macos.adoc
+++ b/typedb-src/modules/ROOT/partials/macos.adoc
@@ -5,8 +5,8 @@
 brew install typedb
 ----
 
-For older versions (prior to `2.19.0`) and `arm64` architecture (e.g., a MacBook with the `M1` processor),
-we don't recommend using Homebrew; see the
+For `arm64` architecture (e.g., a MacBook with `M1` processor),
+we don't recommend installing TypeDB versions prior to `2.19.0` via Homebrew; see the
 https://forum.vaticle.com/t/running-typedb-on-an-m1-macbook/[Running TypeDB on an M1 MacBook,window=_blank] and
 use the <<_manual,manual>> installation instead.
 
@@ -15,7 +15,7 @@ use the <<_manual,manual>> installation instead.
 // tag::install-manual[]
 
 TypeDB runs natively on both `arm64` and `x86_64` architectures.
-For the best performance, make sure both TypeDB and Java SDK match your native architecture and don't run via
+For the best performance, make sure both TypeDB and Java SDK match your native architecture and are not using
 https://en.wikipedia.org/wiki/Rosetta_(software)[Rosetta].
 
 . Ensure Java 11+ is installed.


### PR DESCRIPTION
## What is the goal of this PR?

Improve readability of macOS installation guide.

## What are the changes implemented in this PR?

Fix the wording in the `arm64` architecture for older versions via Homebrew note for the macOS installation guide.