### PR TITLE
Add a link to the Rust Driver API reference

### DIFF
--- a/clients-src/modules/ROOT/pages/rust/rust-overview.adoc
+++ b/clients-src/modules/ROOT/pages/rust/rust-overview.adoc
@@ -8,7 +8,9 @@ The TypeDB Rust Driver was developed by Vaticle to enable TypeDB support for Rus
 
 For installation guide, see the xref:rust/rust-install.adoc[installation] page.
 
-The Tutorial and Driver API reference pages are under development. Coming soon.
+Use the xref:rust/rust-api-ref.adoc[API reference] page for documentation of the methods and objects used in
+the Driver.
+
 
 //Explore the Rust Driver xref:rust/rust-tutorial.adoc[tutorial] with example of connecting to TypeDB.
 


### PR DESCRIPTION
## What is the goal of this PR?

Update the Rust Driver overview page with the link to the Driver API reference.

## What are the changes implemented in this PR?

Add the link to the page.
Remove the coming soon text.