### PR TITLE
Use the latest Driver and TypeQL APIs

### DIFF
--- a/clients-src/modules/ROOT/pages/console.adoc
+++ b/clients-src/modules/ROOT/pages/console.adoc
@@ -60,12 +60,12 @@ Copyright (C) 2022 Vaticle
 
 === TypeDB Cloud / TypeDB Enterprise
 
-There is a slight difference when accessing TypeDB cluster (TypeDB Cloud or TypeDB Enterprise) as it requires
-additional parameters (`cluster`, `username`, `password`, etc.):
+There is a slight difference when accessing TypeDB Enterprise (in TypeDB Cloud or on-premise TypeDB Enterprise) as it requires
+additional parameters (`enterprise`, `username`, `password`, etc.):
 
 [,bash]
 ----
-./typedb console --cluster=127.0.0.1:1729 --username=<username> --password --tls-enabled=<true|false>
+./typedb console --enterprise=127.0.0.1:1729 --username=<username> --password --tls-enabled=<true|false>
 ----
 
 As a result we get a password prompt.
@@ -149,7 +149,7 @@ We can provide several command-line arguments when running Console in the termin
 Default value: `localhost:1729`. +
 (*Not for the TypeDB Enterprise & TypeDB Cloud*)
 
-| `--cluster=<address>`
+| `--enterprise=<address>`
 |
 | Address to which Console will connect to. +
 (*TypeDB Enterprise & TypeDB Cloud only*)
@@ -462,7 +462,7 @@ transaction test data write
     insert $x isa person;
     commit
 transaction test data read
-    match $x isa person;
+    match $x isa person; get;
     close
 database delete test
 ----
@@ -490,7 +490,7 @@ answers: 1, duration: 87 ms
 ++ commit
 Transaction changes committed
 + transaction test data read
-++ match $x isa person;
+++ match $x isa person; get;
 { $x iid 0x966e80018000000000000000 isa person; }
 answers: 1, duration: 25 ms
 ++ close

--- a/clients-src/modules/ROOT/pages/java-driver.adoc
+++ b/clients-src/modules/ROOT/pages/java-driver.adoc
@@ -20,7 +20,7 @@ Add the code below to the `pom.xml` file in the Maven project.
 
 [IMPORTANT]
 ====
-Be sure to replace the `\{version}` placeholder tag with the version of Client Java we want to install.
+Be sure to replace the `\{version}` placeholder tag with the version of Driver Java we want to install.
 ====
 
 [,xml]

--- a/clients-src/modules/ROOT/pages/java-driver/query-builder.adoc
+++ b/clients-src/modules/ROOT/pages/java-driver/query-builder.adoc
@@ -53,7 +53,7 @@ See the examples below.
 
 [,java]
 ----
-TypeQLMatch.Filtered getQuery = TypeQL.match(
+TypeQLGet getQuery = TypeQL.match(
         cVar("u").isa("user").has("full-name", "Kevin Morrison"),
         cVar("p").rel(cVar("u")).rel(cVar("pa")).isa("permission"),
         cVar("o").isa("object").has("path", cVar("fp")),
@@ -73,7 +73,7 @@ In version prior to `2.18.0` the `var()` was used instead of `cVar()` as there w
 
 [,java]
 ----
-readTransaction.query().match(getQuery)
+readTransaction.query().get(getQuery)
 ----
 
 The result should be the same as if we set `getQuery` variable as a TypeQL string.
@@ -91,7 +91,7 @@ The following example showcases the usage of sorting, offsetting and limiting a 
 
 [,java]
 ----
-TypeQLMatch.Limited getQuery = TypeQL.match(
+TypeQLGet getQuery = TypeQL.match(
         cVar("u").isa("user").has("full-name", "Kevin Morrison"),
         cVar("p").rel(cVar("u")).rel(cVar("pa")).isa("permission"),
         cVar("o").isa("object").has("path", cVar("fp")),
@@ -105,7 +105,7 @@ TypeQLMatch.Limited getQuery = TypeQL.match(
 
 [,java]
 ----
-TypeQLMatch query = match(
+TypeQLGet query = match(
         cVar("x").isa("triangle").has("base", cVar("b")).has("height", cVar("h")),
         vVar("area").assign(Expression.constant(0.5).mul(cVar("b").mul(cVar("h"))))))
 );
@@ -121,6 +121,6 @@ The following example showcases the usage of insert query.
 insertQuery = TypeQL.match(
         cVar("f").isa("file").has("path", filepath),
         cVar("vav").isa("action").has("name", "view_file")
-                )
-        .insert(cVar("pa").rel(cVar("vav")).rel(cVar("f")).isa("access"));
+)
+.insert(cVar("pa").rel(cVar("vav")).rel(cVar("f")).isa("access"));
 ----

--- a/clients-src/modules/ROOT/pages/java-driver/tutorial.adoc
+++ b/clients-src/modules/ROOT/pages/java-driver/tutorial.adoc
@@ -13,13 +13,13 @@ The TypeDB server also needs to be installed and running.
 
 Import the following modules:
 
-* `com.vaticle.typedb.client.TypeDB`
-* `com.vaticle.typedb.client.api.TypeDBClient`
-* `com.vaticle.typedb.client.api.TypeDBSession`
+* `com.vaticle.typedb.driver.TypeDB`
+* `com.vaticle.typedb.driver.api.TypeDBDriver`
+* `com.vaticle.typedb.driver.api.TypeDBSession`
 
 == Connecting
 
-Instantiate a TypeDB Core client and open a xref:typedb::development/connect.adoc#_sessions[session] to a
+Instantiate a TypeDB Core driver and open a xref:typedb::development/connect.adoc#_sessions[session] to a
 xref:typedb::development/connect.adoc#_databases[database].
 
 [NOTE]
@@ -38,20 +38,20 @@ The database should have the following data inserted: xref:attachment$data.tql[d
 ----
 package com.vaticle.doc.examples;
 
-import com.vaticle.typedb.client.TypeDB;
-import com.vaticle.typedb.client.api.TypeDBClient;
-import com.vaticle.typedb.client.api.TypeDBSession;
+import com.vaticle.typedb.driver.TypeDB;
+import com.vaticle.typedb.driver.api.TypeDBDriver;
+import com.vaticle.typedb.driver.api.TypeDBSession;
 
 public class TypeDBQuickstartA {
     public static void main(String[] args) {
-        TypeDBClient client = TypeDB.coreClient("localhost:1729");
-        // client is open
-        TypeDBSession session = client.session("social_network", TypeDBSession.Type.DATA);
+        TypeDBDriver driver = TypeDB.coreDriver("localhost:1729");
+        // driver is open
+        TypeDBSession session = driver.session("social_network", TypeDBSession.Type.DATA);
         // session is open
         session.close();
         // session is closed
-        client.close();
-        // client is closed
+        driver.close();
+        // driver is closed
     }
 }
 ----
@@ -66,16 +66,16 @@ Create transactions to use for reading and writing data.
 ----
 package com.vaticle.doc.examples;
 
-import com.vaticle.typedb.client.api.TypeDBClient;
-import com.vaticle.typedb.client.api.TypeDBSession;
-import com.vaticle.typedb.client.api.TypeDBTransaction;
-import com.vaticle.typedb.client.TypeDB;
+import com.vaticle.typedb.driver.api.TypeDBDriver;
+import com.vaticle.typedb.driver.api.TypeDBSession;
+import com.vaticle.typedb.driver.api.TypeDBTransaction;
+import com.vaticle.typedb.driver.TypeDB;
 
 public class TypeDBQuickstartB {
     public static void main(String[] args) {
-        TypeDBClient client = TypeDB.coreClient("localhost:1729");
+        TypeDBDriver driver = TypeDB.coreDriver("localhost:1729");
 
-        try (TypeDBSession session = client.session("social_network", TypeDBSession.Type.DATA)) {
+        try (TypeDBSession session = driver.session("social_network", TypeDBSession.Type.DATA)) {
             // creating a write transaction
             TypeDBTransaction writeTransaction = session.transaction(TypeDBTransaction.Type.WRITE);
             // write transaction is open
@@ -89,7 +89,7 @@ public class TypeDBQuickstartB {
             readTransaction.close();
         }
 
-        client.close();
+        driver.close();
     }
 }
 ----
@@ -104,15 +104,15 @@ Running basic retrieval and insertion queries.
 ----
 package com.vaticle.doc.examples;
 
-import com.vaticle.typedb.client.TypeDB;
-import com.vaticle.typedb.client.api.TypeDBClient;
-import com.vaticle.typedb.client.api.TypeDBSession;
-import com.vaticle.typedb.client.api.TypeDBTransaction;
+import com.vaticle.typedb.driver.TypeDB;
+import com.vaticle.typedb.driver.api.TypeDBDriver;
+import com.vaticle.typedb.driver.api.TypeDBSession;
+import com.vaticle.typedb.driver.api.TypeDBTransaction;
 import com.vaticle.typeql.lang.TypeQL;
 import static com.vaticle.typeql.lang.TypeQL.*;
-import com.vaticle.typeql.lang.query.TypeQLMatch;
+import com.vaticle.typeql.lang.query.TypeQLGet;
 import com.vaticle.typeql.lang.query.TypeQLInsert;
-import com.vaticle.typedb.client.api.answer.ConceptMap;
+import com.vaticle.typedb.driver.api.answer.ConceptMap;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -120,9 +120,9 @@ import java.util.stream.Collectors;
 
 public class TypeDBQuickstartC {
     public static void main(String[] args) {
-        TypeDBClient client = TypeDB.coreClient("localhost:1729");
+        TypeDBDriver driver = TypeDB.coreDriver("localhost:1729");
 
-        try (TypeDBSession session = client.session("social_network", TypeDBSession.Type.DATA)) {
+        try (TypeDBSession session = driver.session("social_network", TypeDBSession.Type.DATA)) {
 
             try (TypeDBTransaction writeTransaction = session.transaction(TypeDBTransaction.Type.WRITE)) {
                 // Insert a person using a WRITE transaction
@@ -135,13 +135,13 @@ public class TypeDBQuickstartC {
 
             try (TypeDBTransaction readTransaction = session.transaction(TypeDBTransaction.Type.READ)) {
                 // Read the person using a READ only transaction
-                TypeQLMatch.Limited getQuery = TypeQL.match(cVar("p").isa("person")).get(cVar("p")).limit(10);
-                Stream<ConceptMap> answers = readTransaction.query().match(getQuery);
+                TypeQLGet.Limited getQuery = TypeQL.match(cVar("p").isa("person")).get(cVar("p")).limit(10);
+                Stream<ConceptMap> answers = readTransaction.query().get(getQuery);
                 answers.forEach(answer -> System.out.println(answer.get("p").asThing().getIID()));
             }
         }
 
-        client.close();
+        driver.close();
     }
 }
 ----

--- a/clients-src/modules/ROOT/pages/new-driver.adoc
+++ b/clients-src/modules/ROOT/pages/new-driver.adoc
@@ -21,7 +21,7 @@ to be confused by what is what.
 *TypeDB Client* -- any software that can connect to TypeDB and provide us with some kind of interface we
 can use: API, CLI, or GUI.
 
-*TypeDB Driver* -- a library that implements TypeDB Client RPC protocol to connect to TypeDB and provides an API to
+*TypeDB Driver* -- a library that implements TypeDB Driver RPC protocol to connect to TypeDB and provides an API to
 use it. Usually, Drivers are used as a part of other applications to connect to TypeDB.
 
 For convenience, the term TypeDB Clients includes all TypeDB Drivers.
@@ -36,11 +36,11 @@ maintaining them, so we also recommend community contributions to follow the sam
 
 The following diagram shows all the packages (directories) in Java Driver and their dependency graph:
 
-image::package-structure.png[Client Package Structure]
+image::package-structure.png[Driver Package Structure]
 
-The entry point is the root package, in this case named `client-java`.
-`api` is where we declare all the available client methods -- basically all the interfaces.
-`connection` holds core client and cluster client with all the basic building blocks: client, session, transaction.
+The entry point is the root package, in this case named `driver-java`.
+`api` is where we declare all the available driver methods -- basically all the interfaces.
+`connection` holds core driver and enterprise driver with all the basic building blocks: driver, session, transaction.
 Then we have `query` for querying, `logic` for reasoning, and `concept` for the API to be able to process concepts in
 responses.
 
@@ -53,7 +53,7 @@ responses.
 +
 [,bash]
 ----
-bazel query --noimplicit_deps 'allpaths(//:client-java,//common:common)' --output graph > graph.in
+bazel query --noimplicit_deps 'allpaths(//:driver-java,//common:common)' --output graph > graph.in
 ----
 4. Visualize the gathered information:
 +
@@ -63,13 +63,13 @@ dot -Tpng < graph.in > graph.png
 ----
 ====
 
-There are many places we could start building a client. In the
+There are many places we could start building a driver. In the
 xref:typedb::tutorials/new-driver-tutorial.adoc[] tutorial, we start by
 attempting to make a single gRPC call to TypeDB, and create a database.
 
 === Connection and databases
 
-To instantiate a client we need to be able to establish a network connection to a TypeDB Core server or a
+To instantiate a driver we need to be able to establish a network connection to a TypeDB Core server or a
 TypeDB Enterprise cluster.
 
 This connection opens us basic features of xref:typedb::development/connect.adoc#_databases[database] management, user
@@ -78,7 +78,7 @@ management (TypeDB Enterprise & TypeDB Cloud only) and enables us to open a sess
 [#_grpc]
 ==== gRPC
 
-https://grpc.io/[gRPC,window=_blank] is the network call framework that TypeDB uses. A TypeDB Driver needs a gRPC client
+https://grpc.io/[gRPC,window=_blank] is the network call framework that TypeDB uses. A TypeDB Driver needs a gRPC driver
 library to communicate with the server. Most languages have gRPC libraries.
 
 Architecturally, gRPC is an alternative to HTTP (say, REST API or websockets). In TypeDB's client-server architecture,
@@ -123,16 +123,16 @@ a distribution channel for the chosen language's compiled protobuf files. If thi
 To query schema and data, we need to open a Session and Transaction of the appropriate types. For example, we can't
 modify schema in a data session.
 
-A Session is essentially a long-lasting tunnel from a client to a database. However, we implement that with just simple
+A Session is essentially a long-lasting tunnel from a driver to a database. However, we implement that with just simple
 RPC calls -- Open and Close.
 
-Sessions consume server resources, and may hold locks. If a client disconnects (say, by crashing) the server needs a
-way to know. So, we use a pulse mechanism. Every 5 seconds, a TypeDB client sends a Session Pulse to inform the
-server that the client is still alive. If no pulse is received in 30 seconds, the server times out the session,
+Sessions consume server resources, and may hold locks. If a driver disconnects (say, by crashing) the server needs a
+way to know. So, we use a pulse mechanism. Every 5 seconds, a TypeDB driver sends a Session Pulse to inform the
+server that the driver is still alive. If no pulse is received in 30 seconds, the server times out the session,
 freeing up its resources for use elsewhere.
 
 Once a Session is open, we can open a Transaction inside it to read and write to the database. This is implemented
-with a bidirectional streaming RPC. Rather like a websocket, it's a long-lasting tunnel that allows the client and
+with a bidirectional streaming RPC. Rather like a websocket, it's a long-lasting tunnel that allows the driver and
 server to talk to each other.
 
 TypeDB Drivers support multiple layers of concurrency. A Client can have many Sessions, and a Session can have many
@@ -142,7 +142,7 @@ image::concurrency-model.png[Concurrency Model]
 
 === Inside a transaction stream
 
-Inside a transaction stream, the client sends requests, and the server is expected to respond to the client's
+Inside a transaction stream, the driver sends requests, and the server is expected to respond to the driver's
 requests in a timely manner.
 
 Each request must have the same message type. This is `Transaction.Client`, defined in
@@ -192,14 +192,14 @@ types of `ConceptManager.Req`.
 For requests such as TypeQL Match queries, the responses can be very long, so TypeDB breaks them up into parts.
 We issue `Match.Req`, and get back multiple ``Match.ResPart``s, which each contain some answers to the query.
 
-Getting all the answers may be costly in terms of server resources, and it can be wasteful if the client exits early.
+Getting all the answers may be costly in terms of server resources, and it can be wasteful if the driver exits early.
 So we only auto-stream up to a certain limit, called the *prefetch size*, then we send a special message called
 "`Continue`".
-If the client needs more answers, it should respond with a `Stream.Req`.
+If the driver needs more answers, it should respond with a `Stream.Req`.
 That tells the server to continue streaming, and, when there are no answers left, it sends a `Stream.ResPart`
 with `state = DONE`.
 
-In a client, the Match response is typically represented as a Stream or Iterator. Seeing "`DONE`" from the server
+In a driver, the Match response is typically represented as a Stream or Iterator. Seeing "`DONE`" from the server
 signals the end of iteration. The iterator implementation varies a bit by language. In Java, Streams are in-built;
 in Python we use an Iterator, and in NodeJS we use an Async Iterator. Use whatever is most natural in the preferred
 language.
@@ -215,7 +215,7 @@ The queue fills up as answers are received from the server, and it gets emptied 
 ==== Request batching
 
 Loading bulk data may potentially require millions of INSERT queries, and gRPC can only send so many in a given
-timeframe. To mitigate this, we use request batching - see the `RequestTransmitter` class in any official client.
+timeframe. To mitigate this, we use request batching - see the `RequestTransmitter` class in any official driver.
 It collects all requests in a 1ms time window, bundles them into a single gRPC message, and dispatches it.
 
 === Exploring query answers
@@ -240,20 +240,19 @@ Implementing all concept methods for TypeDB API is not complicated, but it is qu
 lot of methods. Concept methods either return single or streamed responses. `ThingType.getInstances` is an example
 of a Streamed Concept method.
 
-== TypeDB cluster client
+== TypeDB Enterprise driver
 
-TypeDB Cloud and TypeDB Enterprise use clusters of TypeDB Enterprise servers that run as a distributed network of
-database servers which communicate internally to form a consensus when querying. If one server has an outage, we can
-recover from the issue by falling back to another server. To enable this, TypeDB Driver constructs 1 Core client per a
-TypeDB server (cluster node):
+TypeDB Cloud and TypeDB Enterprise use groups of TypeDB Enterprise servers which communicate internally to form a
+consensus when querying. If one server has an outage, we can recover from the issue by falling back to another server.
+To enable this, TypeDB Driver constructs 1 Core driver per a TypeDB server (Enterprise server):
 
-image::cluster.png[Cluster client Architecture]
+image::cluster.png[Cluster driver Architecture]
 
 Suppose we open a Transaction to, say, Node 1, but we don't get a response.
 
-In TypeDB, that would be a non-recoverable error. In TypeDB Enterprise & TypeDB Cloud, the Cluster client simply
-reroutes the request to a different Core client, which sends the request to its linked server. In this way, the
-client recovers from the failure and continues running as normal.
+In TypeDB, that would be a non-recoverable error. In TypeDB Enterprise & TypeDB Cloud, the Cluster driver simply
+reroutes the request to a different Core driver, which sends the request to its linked server. In this way, the
+driver recovers from the failure and continues running as normal.
 
 [#_behavioral_testing]
 == Behavioral testing

--- a/clients-src/modules/ROOT/pages/nodejs-driver.adoc
+++ b/clients-src/modules/ROOT/pages/nodejs-driver.adoc
@@ -52,14 +52,15 @@ include::java-driver.adoc[tag=questions]
 [#_version_compatibility]
 == Version Compatibility
 
-[cols="^.^2,^.^2,^.^2,^.^2,^.^1"]
+[cols="^.^2,^.^1,^.^2,^.^2,^.^1"]
 |===
-| Node.js Driver | Protocol encoding version | TypeDB | TypeDB Cloud & TypeDB Enterprise | Node
+| Node.js Driver | Protocol encoding version | TypeDB Core | TypeDB Cloud & TypeDB Enterprise | Node
 
 | 2.25.2
 | 3
 | 2.25.0
 | 2.25.0
+| >= 14.15
 
 | 2.24.15
 | 2

--- a/clients-src/modules/ROOT/pages/nodejs-driver.adoc
+++ b/clients-src/modules/ROOT/pages/nodejs-driver.adoc
@@ -27,7 +27,7 @@ npm install typedb-driver
 ====
 [,bash]
 ----
-npm install typedb-client
+npm install typedb-driver
 ----
 ====
 

--- a/clients-src/modules/ROOT/pages/nodejs-driver.adoc
+++ b/clients-src/modules/ROOT/pages/nodejs-driver.adoc
@@ -27,7 +27,7 @@ npm install typedb-driver
 ====
 [,bash]
 ----
-npm install typedb-driver
+npm install typedb-client
 ----
 ====
 

--- a/clients-src/modules/ROOT/pages/nodejs-driver/tutorial.adoc
+++ b/clients-src/modules/ROOT/pages/nodejs-driver/tutorial.adoc
@@ -103,7 +103,7 @@ async function runBasicQueries(database) {
 
 	// Insert a person using a WRITE transaction
 	const writeTransaction = await session.transaction(TransactionType.WRITE);
-	const insertStream = await writeTransaction.query.insert('insert $x isa person, has email "x3@email.com";');
+	const insertStream = await writeTransaction.query.insert('insert $x isa person, has email "x@email.com";');
 	const conceptMaps = await insertStream.collect();
 	console.log("Inserted a person with ID: " + conceptMaps[0].get("x").iid);
 	// to persist changes, a write transaction must always be committed (closed)

--- a/clients-src/modules/ROOT/pages/nodejs-driver/tutorial.adoc
+++ b/clients-src/modules/ROOT/pages/nodejs-driver/tutorial.adoc
@@ -11,18 +11,18 @@ The TypeDB server also needs to be installed and running.
 
 == Importing
 
-Use the `require` keyword with the `typedb-client`.
+Use the `require` keyword with the `typedb-driver`.
 
-// test-example socialNetworkNodejsClientA.js
+// test-example socialNetworkNodejsDriverA.js
 
 [,javascript]
 ----
-const { TypeDB } = require("typedb-client");
+const { TypeDB } = require("typedb-driver");
 ----
 
 == Connecting
 
-Instantiate a TypeDB Core client and open a xref:typedb::development/connect.adoc#_sessions[session] to a
+Instantiate a TypeDB Core driver and open a xref:typedb::development/connect.adoc#_sessions[session] to a
 xref:typedb::development/connect.adoc#_databases[database].
 
 [NOTE]
@@ -35,39 +35,39 @@ The database should have the following schema loaded: xref:attachment$schema.tql
 The database should have the following data inserted: xref:attachment$data.tql[data.tql].
 ====
 
-Instantiate a client and open a session.
+Instantiate a driver and open a session.
 
-// test-example socialNetworkNodejsClientB.js
+// test-example socialNetworkNodejsDriverB.js
 
 [,javascript]
 ----
-const { TypeDB, SessionType } = require("typedb-client");
+const { TypeDB, SessionType } = require("typedb-driver");
 
 async function openSession (database) {
-	const client = TypeDB.coreClient("localhost:1729");
-	const session = await client.session(database, SessionType.DATA);
+	const driver = TypeDB.coreDriver("localhost:1729");
+	const session = await driver.session(database, SessionType.DATA);
 	// session is open
 	await session.close();
 	//session is closed
-	client.close();
+	driver.close();
 };
 
-openSession("social_network");
+await openSession("social_network");
 ----
 
 == Creating transactions
 
 Create transactions to use for reading and writing data.
 
-// test-example socialNetworkNodejsClientC.js
+// test-example socialNetworkNodejsDriverC.js
 
 [,javascript]
 ----
-const { TypeDB, SessionType, TransactionType } = require("typedb-client");
+const { TypeDB, SessionType, TransactionType } = require("typedb-driver");
 
 async function createTransactions (database) {
-	const client = TypeDB.coreClient("localhost:1729");
-	const session = await client.session(database, SessionType.DATA);
+	const driver = TypeDB.coreDriver("localhost:1729");
+	const session = await driver.session(database, SessionType.DATA);
 
 	// creating a write transaction
 	const writeTransaction = await session.transaction(TransactionType.WRITE); // write transaction is open
@@ -80,26 +80,26 @@ async function createTransactions (database) {
 	await readTransaction.close();
 	// a session must always be closed
 	await session.close();
-	// a client must always be closed
-	client.close();
+	// a driver must always be closed
+	driver.close();
 }
 
-createTransactions("social_network");
+await createTransactions("social_network");
 ----
 
 == Querying
 
 Running basic retrieval and insertion queries.
 
-// test-example socialNetworkNodejsClientD.js
+// test-example socialNetworkNodejsDriverD.js
 
 [,javascript]
 ----
-const { TypeDB, SessionType, TransactionType } = require("typedb-client");
+const { TypeDB, SessionType, TransactionType } = require("typedb-driver");
 
 async function runBasicQueries(database) {
-	const client = TypeDB.coreClient("localhost:1729");
-	const session = await client.session(database, SessionType.DATA);
+	const driver = TypeDB.coreDriver("localhost:1729");
+	const session = await driver.session(database, SessionType.DATA);
 
 	// Insert a person using a WRITE transaction
 	const writeTransaction = await session.transaction(TransactionType.WRITE);
@@ -113,16 +113,16 @@ async function runBasicQueries(database) {
 	const readTransaction = await session.transaction(TransactionType.READ);
 
 	// We can either query and consume the iterator lazily
-	let answerStream = await readTransaction.query.match("match $x isa person; get $x; limit 10;");
+	let answerStream = await readTransaction.query.get("match $x isa person; get $x; limit 10;");
 	for await (const aConceptMapAnswer of answerStream) {
 		const person = aConceptMapAnswer.get("x");
 		console.log("Retrieved person with id " + person.iid);
 	}
 
 	// Or query and consume the iterator immediately collecting all the results
-	answerStream = await readTransaction.query.match("match $x isa person; get $x; limit 10;");
+	answerStream = await readTransaction.query.get("match $x isa person; get $x; limit 10;");
 	const persons = await answerStream.collect();
-	persons.forEach( conceptMap => {
+	persons.forEach(conceptMap => {
         person = conceptMap.get("x");
         console.log("Retrieved person with id " + person.iid);
     });
@@ -131,11 +131,11 @@ async function runBasicQueries(database) {
 	await readTransaction.close();
 	// a session must always be closed
 	await session.close();
-	// a client must always be closed
-	client.close();
+	// a driver must always be closed
+	driver.close();
 }
 
-runBasicQueries("social_network");
+await runBasicQueries("social_network");
 ----
 
 [IMPORTANT]

--- a/clients-src/modules/ROOT/pages/nodejs-driver/tutorial.adoc
+++ b/clients-src/modules/ROOT/pages/nodejs-driver/tutorial.adoc
@@ -44,7 +44,7 @@ Instantiate a driver and open a session.
 const { TypeDB, SessionType } = require("typedb-driver");
 
 async function openSession (database) {
-	const driver = TypeDB.coreDriver("localhost:1729");
+	const driver = await TypeDB.coreDriver("localhost:1729");
 	const session = await driver.session(database, SessionType.DATA);
 	// session is open
 	await session.close();
@@ -52,7 +52,7 @@ async function openSession (database) {
 	driver.close();
 };
 
-await openSession("social_network");
+openSession("social_network");
 ----
 
 == Creating transactions
@@ -66,7 +66,7 @@ Create transactions to use for reading and writing data.
 const { TypeDB, SessionType, TransactionType } = require("typedb-driver");
 
 async function createTransactions (database) {
-	const driver = TypeDB.coreDriver("localhost:1729");
+	const driver = await TypeDB.coreDriver("localhost:1729");
 	const session = await driver.session(database, SessionType.DATA);
 
 	// creating a write transaction
@@ -84,7 +84,7 @@ async function createTransactions (database) {
 	driver.close();
 }
 
-await createTransactions("social_network");
+createTransactions("social_network");
 ----
 
 == Querying
@@ -98,12 +98,12 @@ Running basic retrieval and insertion queries.
 const { TypeDB, SessionType, TransactionType } = require("typedb-driver");
 
 async function runBasicQueries(database) {
-	const driver = TypeDB.coreDriver("localhost:1729");
+	const driver = await TypeDB.coreDriver("localhost:1729");
 	const session = await driver.session(database, SessionType.DATA);
 
 	// Insert a person using a WRITE transaction
 	const writeTransaction = await session.transaction(TransactionType.WRITE);
-	const insertStream = await writeTransaction.query.insert('insert $x isa person, has email "x@email.com";');
+	const insertStream = await writeTransaction.query.insert('insert $x isa person, has email "x3@email.com";');
 	const conceptMaps = await insertStream.collect();
 	console.log("Inserted a person with ID: " + conceptMaps[0].get("x").iid);
 	// to persist changes, a write transaction must always be committed (closed)
@@ -135,7 +135,7 @@ async function runBasicQueries(database) {
 	driver.close();
 }
 
-await runBasicQueries("social_network");
+runBasicQueries("social_network");
 ----
 
 [IMPORTANT]

--- a/clients-src/modules/ROOT/pages/overview.adoc
+++ b/clients-src/modules/ROOT/pages/overview.adoc
@@ -5,11 +5,11 @@
 
 A TypeDB Client is any software that can connect to a TypeDB.
 
-All TypeDB Clients use https://github.com/vaticle/typedb-protocol[TypeDB Client RPC,window=_blank] protocol based on
+All TypeDB Clients use https://github.com/vaticle/typedb-protocol[TypeDB Driver RPC,window=_blank] protocol based on
 gRPC framework under the hood to communicate with a TypeDB
 server and to provide more user-friendly interface: API, GUI, or CLI.
 
-To build a custom application capable of connecting to TypeDB via *TypeDB Client RPC* protocol, we can use one of the
+To build a custom application capable of connecting to TypeDB via *TypeDB Driver RPC* protocol, we can use one of the
 existing libraries implementing it, called <<_typedb_drivers,TypeDB Drivers>>, or we can implement it ourselves as a
 xref:new-driver.adoc[new driver].
 
@@ -69,7 +69,7 @@ connections, sessions and transactions, as well as submitting queries and readin
 [#_typedb_drivers]
 == TypeDB Drivers
 
-A TypeDB Driver is a library that implements https://github.com/vaticle/typedb-protocol[TypeDB Client RPC,window=_blank]
+A TypeDB Driver is a library that implements https://github.com/vaticle/typedb-protocol[TypeDB Driver RPC,window=_blank]
 protocol and provides <<_driver_api,TypeDB Driver API>>. TypeDB Drivers are available for some of the most popular
 programming languages, allowing us to build applications that connect to a TypeDB database easily.
 
@@ -91,9 +91,9 @@ or machine interface, opening and managing connections, sessions, and transactio
 submitting queries, processing responses, load-balancing (TypeDB Enterprise & TypeDB Cloud only), and authentication
 (TypeDB Enterprise & TypeDB Cloud only).
 
-The following diagram illustrates the structure of a typical TypeDB Client.
+The following diagram illustrates the structure of a typical TypeDB Driver.
 
-image::client-structure.png[Structure of a TypeDB Client]
+image::client-structure.png[Structure of a TypeDB Dirver]
 
 .See the dependency graph
 [%collapsible]
@@ -101,13 +101,12 @@ image::client-structure.png[Structure of a TypeDB Client]
 image::package-structure.png[]
 ====
 
-Simply put, the main components of any TypeDB Client are the classes and methods to establish a connection to a TypeDB
+Simply put, the main components of any TypeDB Driver are the classes and methods to establish a connection to a TypeDB
 database, execute queries and process responses.
 
 [NOTE]
 ====
-After the release of the Rust Driver we shall see the Java, Python, and Node.js drivers re-implemented as wrappers
-on top of the Rust driver.
+As of version 2.24.x the Java, Python, and C drivers re-implemented as wrappers on top of the Rust driver via an FFI interface.
 ====
 
 [#_driver_api]

--- a/clients-src/modules/ROOT/pages/python-driver.adoc
+++ b/clients-src/modules/ROOT/pages/python-driver.adoc
@@ -28,7 +28,7 @@ pip install typedb-driver
 ====
 [,bash]
 ----
-pip install typedb-driver
+pip install typedb-client
 ----
 ====
 
@@ -54,14 +54,15 @@ include::java-driver.adoc[tag=questions]
 [#_version_compatibility]
 == Version Compatibility
 
-[cols="^.^2,^.^2,^.^2,^.^2,^.^1"]
+[cols="^.^2,^.^1,^.^2,^.^2,^.^1"]
 |===
-| Python Driver | Protocol encoding version | TypeDB | TypeDB Cloud & TypeDB Enterprise | Python
+| Python Driver | Protocol encoding version | TypeDB Core | TypeDB Cloud & TypeDB Enterprise | Python
 
 | 2.25.2
 | 3
 | 2.25.0
 | 2.25.0
+| 3.9 to 3.11
 
 | 2.24.15
 | 2

--- a/clients-src/modules/ROOT/pages/python-driver.adoc
+++ b/clients-src/modules/ROOT/pages/python-driver.adoc
@@ -28,7 +28,7 @@ pip install typedb-driver
 ====
 [,bash]
 ----
-pip install typedb-client
+pip install typedb-driver
 ----
 ====
 

--- a/clients-src/modules/ROOT/pages/python-driver/tutorial.adoc
+++ b/clients-src/modules/ROOT/pages/python-driver/tutorial.adoc
@@ -7,7 +7,7 @@
 == Prerequisites
 
 Make sure to install the Python Driver as per the xref:python-driver.adoc#_install[Installation] guide.
-The TypeDB server also needs to be installed and running.
+The TypeDB server also needs to be xref:home::install.adoc#_core[installed] and running.
 
 == Importing
 
@@ -87,26 +87,26 @@ with TypeDB.core_driver("localhost:1729") as driver:
     with driver.session("social_network", SessionType.DATA) as session:
         ## Insert a Person using a WRITE transaction
         with session.transaction(TransactionType.WRITE) as write_transaction:
-            insert_iterator = write_transaction.query().insert('insert $x isa person, has email "x@email.com";')
+            insert_iterator = write_transaction.query.insert('insert $x isa person, has email "x@email.com";')
             concepts = [ans.get("x") for ans in insert_iterator]
-            print("Inserted a person with ID: {0}".format(concepts[0].get_iid()))
+            print("Inserted a person with id: {0}".format(concepts[0].as_entity().get_iid()))
             ## to persist changes, write transaction must always be committed (closed)
             write_transaction.commit()
 
         ## Read the person using a READ only transaction
         with session.transaction(TransactionType.READ) as read_transaction:
-            answer_iterator = read_transaction.query().get("match $x isa person; get $x; limit 10;")
+            answer_iterator = read_transaction.query.get("match $x isa person; get $x; limit 10;")
 
             for answer in answer_iterator:
                 person = answer.get("x")
-                print("Retrieved person with id " + person.get_iid())
+                print("Retrieved person with id " + person.as_entity().get_iid())
 
         ## Or query and consume the iterator immediately collecting all the results
         with session.transaction(TransactionType.READ) as read_transaction:
-            answer_iterator = read_transaction.query().get("match $x isa person; get $x; limit 10;")
+            answer_iterator = read_transaction.query.get("match $x isa person; get $x; limit 10;")
             persons = [ans.get("x") for ans in answer_iterator]
             for person in persons:
-                print("Retrieved person with id " + person.get_iid())
+                print("Retrieved person with id " + person.as_entity().get_iid())
 
         ## if not using a `with` statement, then we must always close the session and the read transaction
         # read_transaction.close()

--- a/clients-src/modules/ROOT/pages/python-driver/tutorial.adoc
+++ b/clients-src/modules/ROOT/pages/python-driver/tutorial.adoc
@@ -11,18 +11,18 @@ The TypeDB server also needs to be installed and running.
 
 == Importing
 
-In the interpreter or in the source code, import everything from `typedb.client`.
+In the interpreter or in the source code, import everything from `typedb.driver`.
 
-// test-example social_network_python_client_a.py
+// test-example social_network_python_driver_a.py
 
 [,python]
 ----
-from typedb.client import *
+from typedb.driver import *
 ----
 
 == Connecting
 
-Instantiate a TypeDB Core client and open a xref:typedb::development/connect.adoc#_sessions[session] to a
+Instantiate a TypeDB Core driver and open a xref:typedb::development/connect.adoc#_sessions[session] to a
 xref:typedb::development/connect.adoc#_databases[database].
 
 [NOTE]
@@ -37,28 +37,28 @@ The database should have the following data inserted: xref:attachment$data.tql[d
 
 [,python]
 ----
-from typedb.client import *
+from typedb.driver import *
 
-with TypeDB.core_client("localhost:1729") as client:
-    with client.session("social_network", SessionType.DATA) as session:
+with TypeDB.core_driver("localhost:1729") as driver:
+    with driver.session("social_network", SessionType.DATA) as session:
         ## session is open
         pass
     ## session is closed
-## client is closed
+## driver is closed
 ----
 
 == Creating transactions
 
 Create transactions to use for reading and writing data.
 
-// test-example social_network_python_client_c.py
+// test-example social_network_python_driver_c.py
 
 [,python]
 ----
-from typedb.client import *
+from typedb.driver import *
 
-with TypeDB.core_client("localhost:1729") as client:
-    with client.session("social_network", SessionType.DATA) as session:
+with TypeDB.core_driver("localhost:1729") as driver:
+    with driver.session("social_network", SessionType.DATA) as session:
         ## creating a write transaction
         with session.transaction(TransactionType.WRITE) as write_transaction:
             ## write transaction is open
@@ -77,14 +77,14 @@ with TypeDB.core_client("localhost:1729") as client:
 
 Running basic retrieval and insertion queries.
 
-// test-example social_network_python_client_d.py
+// test-example social_network_python_driver_d.py
 
 [,python]
 ----
-from typedb.client import *
+from typedb.driver import *
 
-with TypeDB.core_client("localhost:1729") as client:
-    with client.session("social_network", SessionType.DATA) as session:
+with TypeDB.core_driver("localhost:1729") as driver:
+    with driver.session("social_network", SessionType.DATA) as session:
         ## Insert a Person using a WRITE transaction
         with session.transaction(TransactionType.WRITE) as write_transaction:
             insert_iterator = write_transaction.query().insert('insert $x isa person, has email "x@email.com";')
@@ -95,7 +95,7 @@ with TypeDB.core_client("localhost:1729") as client:
 
         ## Read the person using a READ only transaction
         with session.transaction(TransactionType.READ) as read_transaction:
-            answer_iterator = read_transaction.query().match("match $x isa person; get $x; limit 10;")
+            answer_iterator = read_transaction.query().get("match $x isa person; get $x; limit 10;")
 
             for answer in answer_iterator:
                 person = answer.get("x")
@@ -103,7 +103,7 @@ with TypeDB.core_client("localhost:1729") as client:
 
         ## Or query and consume the iterator immediately collecting all the results
         with session.transaction(TransactionType.READ) as read_transaction:
-            answer_iterator = read_transaction.query().match("match $x isa person; get $x; limit 10;")
+            answer_iterator = read_transaction.query().get("match $x isa person; get $x; limit 10;")
             persons = [ans.get("x") for ans in answer_iterator]
             for person in persons:
                 print("Retrieved person with id " + person.get_iid())
@@ -111,7 +111,7 @@ with TypeDB.core_client("localhost:1729") as client:
         ## if not using a `with` statement, then we must always close the session and the read transaction
         # read_transaction.close()
         # session.close()
-        # client.close()
+        # driver.close()
 ----
 
 [IMPORTANT]

--- a/clients-src/modules/ROOT/pages/rust-driver.adoc
+++ b/clients-src/modules/ROOT/pages/rust-driver.adoc
@@ -47,7 +47,7 @@ include::java-driver.adoc[tag=questions]
 [#_version_compatibility]
 == Version Compatibility
 
-[cols="^.^2,^.^2,^.^2,^.^2,^.^1"]
+[cols="^.^2,^.^1,^.^2,^.^2,^.^1"]
 |===
 | Rust Driver | Protocol encoding version | TypeDB Core | TypeDB Cloud & TypeDB Enterprise | Rust
 
@@ -55,6 +55,7 @@ include::java-driver.adoc[tag=questions]
 | 3
 | 2.25.0
 | 2.25.0
+| 1.68.0+
 
 | 2.24.15
 | 2

--- a/clients-src/modules/ROOT/pages/rust-driver.adoc
+++ b/clients-src/modules/ROOT/pages/rust-driver.adoc
@@ -62,5 +62,4 @@ include::java-driver.adoc[tag=questions]
 | 2.24.17
 | 2.24.17
 | 1.68.0+
-//#todo Add Rust version requirements!
 |===

--- a/clients-src/modules/ROOT/partials/nodejs/answer/Stream_T_.adoc
+++ b/clients-src/modules/ROOT/partials/nodejs/answer/Stream_T_.adoc
@@ -36,7 +36,7 @@ Collects all the answers from this stream into an array
 .Code examples
 [source,nodejs]
 ----
-results = transaction.query.match(query).collect().await;
+results = transaction.query.get(query).collect().await;
 ----
 
 [#_Stream_T_every]
@@ -80,7 +80,7 @@ Returns a new stream from this stream consisting only of elements which satisfy 
 |Name |Description |Type
 a| `filter` a| The condition to evaluate.
 Examples
-``// For a query "match $p isa person, has age $a;", only retrieve results having $a &gt;= 60.results = transaction.query.match(query).filter(cm =&gt; cm.get("a").value &gt; 60).collect();
+``// For a query "match $p isa person, has age $a; get;", only retrieve results having $a &gt;= 60.results = transaction.query.match(query).filter(cm =&gt; cm.get("a").value &gt; 60).collect();
 ``Copy a| `((value) => boolean)`
 |===
 

--- a/home-src/modules/ROOT/pages/install.adoc
+++ b/home-src/modules/ROOT/pages/install.adoc
@@ -13,6 +13,7 @@ or deploy your database through https://cloud.typedb.com/[TypeDB Cloud,window=_b
 //Use the xref:typedb:ROOT:admin/enterprise-deployment.adoc[] guide
 //to install and deploy a TypeDB Enterprise cluster with Kubernetes.
 
+[#_core]
 == TypeDB Core
 
 TypeDB Core is the open-source edition of TypeDB DBMS.

--- a/home-src/modules/ROOT/partials/macos.adoc
+++ b/home-src/modules/ROOT/partials/macos.adoc
@@ -3,7 +3,8 @@ To install TypeDB via `brew`:
 
 [,bash]
 ----
-brew install typedb
+brew tap vaticle/tap
+brew install vaticle/tap/typedb
 ----
 
 For `arm64` architecture (e.g., a MacBook with `M1` processor),

--- a/typedb-src/modules/ROOT/pages/admin/configuration.adoc
+++ b/typedb-src/modules/ROOT/pages/admin/configuration.adoc
@@ -326,7 +326,7 @@ typedb server  \
   --log.logger.traversal.output "[ file, stdout ]"
 ----
 
-== Cluster configuration
+== Enterprise cluster configuration
 
 Every server in a cluster has its own config file that contains a list of known servers in the cluster. A server in a
 cluster will not accept connections from servers that are not on the list.

--- a/typedb-src/modules/ROOT/pages/admin/enterprise-deployment.adoc
+++ b/typedb-src/modules/ROOT/pages/admin/enterprise-deployment.adoc
@@ -70,7 +70,7 @@ To pull the TypeDB Docker image, run:
 
 [,bash]
 ----
-docker pull vaticle/typedb-cluster:latest
+docker pull vaticle/typedb-enterprise:latest
 ----
 
 *Without an External Volume*
@@ -78,7 +78,7 @@ docker pull vaticle/typedb-cluster:latest
 For testing purposes, run:
 [,bash]
 ----
-docker run --name typedb -d -p 1729:1729 vaticle/typedb-cluster:latest
+docker run --name typedb -d -p 1729:1729 vaticle/typedb-enterprise:latest
 ----
 
 *NOTE*: Running the instance without specifying a volume does NOT save the data if the instance is killed.
@@ -89,7 +89,7 @@ To ensure that data is preserved even when the instance is killed or restarted, 
 
 [,bash]
 ----
-docker run --name typedb -d -v $(pwd)/db/:/opt/typedb-cluster-all-linux/server/db/ -p 1729:1729 vaticle/typedb-cluster:latest
+docker run --name typedb -d -v $(pwd)/db/:/opt/typedb-enterprise-all-linux/server/db/ -p 1729:1729 vaticle/typedb-enterprise:latest
 ----
 
 Having started the instance, the TypeDB Enterprise is expected to be running on port `1729` on your machine.
@@ -97,7 +97,7 @@ To interact with xref:clients:ROOT:console.adoc[], run:
 
 [,bash]
 ----
-docker exec -ti typedb bash -c '/opt/typedb-cluster-all-linux/typedb console'
+docker exec -ti typedb bash -c '/opt/typedb-enterprise-all-linux/typedb console'
 ----
 --
 ====
@@ -107,9 +107,9 @@ docker exec -ti typedb bash -c '/opt/typedb-cluster-all-linux/typedb console'
 === Starting
 
 If you have installed TypeDB using a package manager, to start the TypeDB Enterprise, open a terminal and run
-`typedb cluster`.
+`typedb enterprise`.
 
-Otherwise, if you have manually downloaded TypeDB, `cd` into the unzipped folder and run `./typedb cluster`.
+Otherwise, if you have manually downloaded TypeDB, `cd` into the unzipped folder and run `./typedb enterprise`.
 
 === Stopping
 
@@ -126,7 +126,7 @@ one of those servers acts as a leader and the others are followers. Increasing t
 cluster's tolerance to failure: to tolerate N nodes failing, cluster needs to consist of `2N + 1` nodes.
 This section describes how you can set up a 3-node cluster (in this case, one node can fail and no data is lost).
 
-Each node binds to three ports: a client port which TypeDB client drivers connect to (`1729`), and two server ports
+Each node binds to three ports: a client port which TypeDB drivers connect to (`1729`), and two server ports
 (`1730` and `1731`) for server-to-server communication.
 
 For this tutorial, it's assumed that all three nodes are on the same virtual network and have the relevant ports open
@@ -143,7 +143,7 @@ This is how 3-node TypeDB Enterprise would be started on three separate machines
 [,bash]
 ----
 # On 10.0.0.1:
-$ ./typedb cluster \
+$ ./typedb enterprise \
     --server.address=10.0.0.1:1729 \
     --server.internal-address.zeromq=10.0.0.1:1730 \
     --server.internal-address.grpc=10.0.0.1:1731 \
@@ -158,7 +158,7 @@ $ ./typedb cluster \
     --server.peers.peer-3.internal-address.grpc=10.0.0.3:1731
 
 # On 10.0.0.2:
-$ ./typedb cluster \
+$ ./typedb enterprise \
     --server.address=10.0.0.2:1729 \
     --server.internal-address.zeromq=10.0.0.2:1730 \
     --server.internal-address.grpc=10.0.0.2:1731 \
@@ -173,7 +173,7 @@ $ ./typedb cluster \
     --server.peers.peer-3.internal-address.grpc=10.0.0.3:1731
 
 # On 10.0.0.3:
-$ ./typedb cluster \
+$ ./typedb enterprise \
     --server.address=10.0.0.3:1729 \
     --server.internal-address.zeromq=10.0.0.3:1730 \
     --server.internal-address.grpc=10.0.0.3:1731 \
@@ -198,7 +198,7 @@ In order to do so, the relevant external hostname should be passed as arguments 
 
 [,bash]
 ----
-bash $ ./typedb cluster \
+bash $ ./typedb enterprise \
 --server.address=external-host-1:1729 \
 --server.internal-address.zeromq=10.0.0.1:1730 \
 --server.internal-address.grpc=10.0.0.1:1731 \

--- a/typedb-src/modules/ROOT/pages/admin/security.adoc
+++ b/typedb-src/modules/ROOT/pages/admin/security.adoc
@@ -55,7 +55,7 @@ To connect to TypeDB with TypeDB Console provide a username and password (when p
 
 [,bash]
 ----
-typedb console --cluster=<address> --username=<username> --password
+typedb console --enterprise=<address> --username=<username> --password
 ----
 
 After issuing this command we will be prompted to provide a password.

--- a/typedb-src/modules/ROOT/pages/development/connect.adoc
+++ b/typedb-src/modules/ROOT/pages/development/connect.adoc
@@ -35,7 +35,7 @@ Java::
 --
 [,java]
 ----
-TypeDBClient client = TypeDB.coreClient("0.0.0.0:1729");
+TypeDBDriver driver = TypeDB.coreDriver("0.0.0.0:1729");
 ----
 --
 
@@ -44,7 +44,7 @@ Python::
 --
 [,python]
 ----
-client = TypeDB.core_client("0.0.0.0:1729")
+driver = TypeDB.core_driver("0.0.0.0:1729")
 ----
 --
 
@@ -53,14 +53,14 @@ Node.js::
 --
 [,js]
 ----
-client = TypeDB.coreClient("0.0.0.0:1729");
+driver = TypeDB.coreDriver("0.0.0.0:1729");
 ----
 --
 ====
 
 [NOTE]
 ====
-To connect to TypeDB Cloud use `clusterClient`/`cluster_client` instead of `coreClient`/`core_client`.
+To connect to TypeDB Cloud use `enterpriseDriver`/`enterprise_driver` instead of `coreDriver`/`core_driver`.
 It requires a second argument of `TypeDBCredential` type.
 ====
 
@@ -120,15 +120,15 @@ Java::
 [,java]
 ----
 // create database
-client.databases().create("test-db");
+driver.databases().create("test-db");
 // get database schema
-client.databases().get("test-db").schema();
+driver.databases().get("test-db").schema();
 // get all databases
-client.databases().all();
+driver.databases().all();
 // check if database exists
-client.databases().contains("test-db");
+driver.databases().contains("test-db");
 // delete database
-client.databases().get("test-db").delete();
+driver.databases().get("test-db").delete();
 ----
 --
 
@@ -138,15 +138,15 @@ Python::
 [,python]
 ----
 # create database
-client.databases().create("test-db")
+driver.databases().create("test-db")
 # get database schema
-client.databases().get("test-db").schema()
+driver.databases().get("test-db").schema()
 # get all databases
-client.databases().all()
+driver.databases().all()
 # check if database exists
-client.databases().contains("test-db")
+driver.databases().contains("test-db")
 # delete database
-client.databases().get("test-db").delete()
+driver.databases().get("test-db").delete()
 ----
 --
 
@@ -156,15 +156,15 @@ Node.js::
 [,js]
 ----
 // create database
-await client.databases().create("test-db");
+await driver.databases().create("test-db");
 // get database schema
-await client.databases().get("test-db").schema();
+await driver.databases().get("test-db").schema();
 // get all databases
-await client.databases().all();
+await driver.databases().all();
 // check if database exists
-await client.databases().contains("test-db");
+await driver.databases().contains("test-db");
 // delete database
-await (await client.databases().get("test-db")).delete();
+await (await driver.databases().get("test-db")).delete();
 ----
 --
 ====
@@ -244,7 +244,7 @@ Java::
 --
 [,java]
 ----
-TypeDBSession session = client.session("iam", TypeDBSession.Type.DATA);
+TypeDBSession session = driver.session("iam", TypeDBSession.Type.DATA);
 ----
 --
 
@@ -253,7 +253,7 @@ Python::
 --
 [,python]
 ----
-session = client.session("iam", SessionType.DATA)
+session = driver.session("iam", SessionType.DATA)
 ----
 --
 
@@ -262,7 +262,7 @@ Node.js::
 --
 [,js]
 ----
-session = await client.session("iam", SessionType.DATA);
+session = await driver.session("iam", SessionType.DATA);
 ----
 --
 ====
@@ -354,7 +354,7 @@ transaction.query().insert(InsertQuery1);
 transaction.query().insert(InsertQuery2);
 transaction.query().insert(InsertQueryN);
 // commit changes
-transaction.commit();
+await transaction.commit();
 ----
 --
 ====

--- a/typedb-src/modules/ROOT/pages/development/infer.adoc
+++ b/typedb-src/modules/ROOT/pages/development/infer.adoc
@@ -40,7 +40,7 @@ For example (in Python):
 
 [,python]
 ----
-typedb_options = TypeDBOptions.core()  # Initialising a new set of options
+typedb_options = TypeDBOptions()  # Initialising a new set of options
 typedb_options.infer = True  # Enabling inference in this new set of options
 with session.transaction(TransactionType.READ, typedb_options) as transaction:
 ----
@@ -134,7 +134,7 @@ from typedb.client import TypeDB, SessionType, TransactionType, TypeDBOptions
 with TypeDB.core_client("0.0.0.0:1729") as client:  # Connect to TypeDB server
     with client.session("iam", SessionType.DATA) as session:
         print("\nRequest #1: Explain query — Files that Kevin Morrison has view access to (with explanation)")
-        typedb_options = TypeDBOptions.core()  # Initialising a new set of options
+        typedb_options = TypeDBOptions()  # Initialising a new set of options
         typedb_options.infer = True  # Enabling inference in this new set of options
         typedb_options.explain = True
         with session.transaction(TransactionType.READ, typedb_options) as transaction:
@@ -142,7 +142,7 @@ with TypeDB.core_client("0.0.0.0:1729") as client:  # Connect to TypeDB server
                                 "$a isa action, has name 'view_file'; $ac(object: $o, action: $a) isa access;" \
                                 "$pe(subject: $p, access: $ac) isa permission; $p-fname = 'Kevin Morrison';" \
                                 "get $o-path; sort $o-path asc;"
-            iterator = transaction.query().match(typeql_read_query)
+            iterator = transaction.query().get(typeql_read_query)
             i = 0
             for item in iterator:  # Iterating through results
                 i += 1
@@ -171,7 +171,7 @@ with TypeDB.core_client("0.0.0.0:1729") as client:  # Connect to TypeDB server
 ////
 Use enumerate() instead of simple counter:
 
-    iterator = transaction.query().match(typeql_read_query)
+    iterator = transaction.query().get(typeql_read_query)
     for i, item in enumerate(iterator):  # Iterating through results
         explainable_relations = item.explainables().relations()
         for e, explainable in enumerate(explainable_relations):

--- a/typedb-src/modules/ROOT/pages/development/infer.adoc
+++ b/typedb-src/modules/ROOT/pages/development/infer.adoc
@@ -129,10 +129,10 @@ relation `$pe`.
 
 [,python]
 ----
-from typedb.client import TypeDB, SessionType, TransactionType, TypeDBOptions
+from typedb.driver import TypeDB, SessionType, TransactionType, TypeDBOptions
 
-with TypeDB.core_client("0.0.0.0:1729") as client:  # Connect to TypeDB server
-    with client.session("iam", SessionType.DATA) as session:
+with TypeDB.core_driver("0.0.0.0:1729") as driver:  # Connect to TypeDB server
+    with driver.session("iam", SessionType.DATA) as session:
         print("\nRequest #1: Explain query — Files that Kevin Morrison has view access to (with explanation)")
         typedb_options = TypeDBOptions()  # Initialising a new set of options
         typedb_options.infer = True  # Enabling inference in this new set of options

--- a/typedb-src/modules/ROOT/pages/tutorials/new-driver-tutorial.adoc
+++ b/typedb-src/modules/ROOT/pages/tutorials/new-driver-tutorial.adoc
@@ -17,7 +17,7 @@ to be confused by what is what.
 *TypeDB Client* -- any software that can connect to TypeDB and provide us with some kind of interface we
 can use: API, CLI, or GUI.
 
-*TypeDB Driver* -- a library that implements TypeDB Client RPC protocol to connect to TypeDB and provides an API to
+*TypeDB Driver* -- a library that implements TypeDB Driver RPC protocol to connect to TypeDB and provides an API to
 use it. Usually, Drivers are used as a part of other applications to connect to TypeDB.
 
 For convenience, the term TypeDB Clients includes all TypeDB Drivers.
@@ -54,8 +54,8 @@ Java::
 ----
 // TypeDB.java
 public class TypeDB {
-    public static TypeDBClient coreClient(String address) {
-        return new CoreClient(address);
+    public static TypeDBDriver coreDriver(String address) {
+        return new CoreDriver(address);
     }
 }
 ----
@@ -66,11 +66,11 @@ Python::
 --
 [,python]
 ----
-# typedb/client.py (named to allow importing from typedb.client)
+# typedb/driver.py (named to allow importing from typedb.driver)
 class TypeDB:
     @staticmethod
-    def core_client(address: str, parallelisation: int = 2) -> TypeDBClient:
-        return _CoreClient(address, parallelisation)
+    def core_driver(address: str, parallelisation: int = 2) -> TypeDBDriver:
+        return _CoreDriver(address, parallelisation)
 ----
 --
 
@@ -81,8 +81,8 @@ Node.js::
 ----
 // TypeDB.ts
 export namespace TypeDB {
-    export function coreClient(address: string): TypeDBClient {
-        return new CoreClient(address);
+    export function coreDriver(address: string): TypeDBDriver {
+        return new CoreDriver(address);
     }
 }
 ----
@@ -91,11 +91,11 @@ export namespace TypeDB {
 
 == Step 2: Database manager
 
-`TypeDBClient` is not yet defined. Create a new directory named `api/connection` and create a `TypeDBClient` file there:
+`TypeDBDriver` is not yet defined. Create a new directory named `api/connection` and create a `TypeDBDriver` file there:
 
 [NOTE]
 ====
-If the selected language doesn't have interfaces or abstract classes, make `TypeDB.coreClient` return `CoreClient`
+If the selected language doesn't have interfaces or abstract classes, make `TypeDB.coreDriver` return `CoreDriver`
 instead, and skip this step.
 ====
 
@@ -106,8 +106,8 @@ Java::
 --
 [,java]
 ----
-// api/connection/TypeDBClient.java
-public interface TypeDBClient extends AutoCloseable {
+// api/connection/TypeDBDriver.java
+public interface TypeDBDriver extends AutoCloseable {
     DatabaseManager databases();
     void close();
 }
@@ -119,10 +119,10 @@ Python::
 --
 [,python]
 ----
-# typedb/api/connection/client.py
+# typedb/api/connection/driver.py
 from abc import ABC, abstractmethod
 
-class TypeDBClient(ABC):
+class TypeDBDriver(ABC):
     @abstractmethod
     def databases(self) -> DatabaseManager:
         pass
@@ -146,8 +146,8 @@ Node.js::
 --
 [,js]
 ----
-// api/connection/TypeDBClient.ts
-export interface TypeDBClient {
+// api/connection/TypeDBDriver.ts
+export interface TypeDBDriver {
     readonly databases: DatabaseManager;
     close(): Promise<void>;
 }
@@ -157,11 +157,11 @@ export interface TypeDBClient {
 
 == Step 3: gRPC connection implementation
 
-The next step is to implement `connection/TypeDBClient` and its subclass `connection/core/CoreClient`.
+The next step is to implement `connection/TypeDBDriver` and its subclass `connection/core/CoreDriver`.
 Create the directory structure: `connection/core` in the root of the project.
 
-Name the classes depending on language conventions: in Java/TypeScript, `TypeDBClientImpl` and `CoreClient`; in Python,
-`_TypeDBClient` and `_CoreClient`.
+Name the classes depending on language conventions: in Java/TypeScript, `TypeDBDriverImpl` and `CoreDriver`; in Python,
+`_TypeDBDriver` and `_CoreDriver`.
 
 Ensure that gRPC is imported into the project, and refer to the https://grpc.io/docs/languages/[gRPC docs,window=_blank]
 to learn how to create a Channel -- the code varies by language.
@@ -179,11 +179,11 @@ Java::
 --
 [,java]
 ----
-// connection/TypeDBClientImpl.java
-public abstract class TypeDBClientImpl implements TypeDBClient {
+// connection/TypeDBDriverImpl.java
+public abstract class TypeDBDriverImpl implements TypeDBDriver {
     private final TypeDBDatabaseManagerImpl databaseMgr;
 
-    protected TypeDBClientImpl() {
+    protected TypeDBDriverImpl() {
         databaseMgr = new TypeDBDatabaseManagerImpl(this);
     }
 
@@ -206,12 +206,12 @@ public abstract class TypeDBClientImpl implements TypeDBClient {
     }
 }
 
-// connection/core/CoreClient.java
-public class CoreClient extends TypeDBClientImpl {
+// connection/core/CoreDriver.java
+public class CoreDriver extends TypeDBDriverImpl {
     private final ManagedChannel channel;
     private final TypeDBStub stub;
 
-    public CoreClient(String address) {
+    public CoreDriver(String address) {
         super();
         channel = NettyChannelBuilder.forTarget(address).usePlaintext().build();
         stub = CoreStub.create(channel);
@@ -235,8 +235,8 @@ Python::
 --
 [,python]
 ----
-# typedb/connection/client.py
-class _TypeDBClientImpl(TypeDBClient):
+# typedb/connection/driver.py
+class _TypeDBDriverImpl(TypeDBDriver):
     def __init__(self):
         pass
 
@@ -257,12 +257,12 @@ class _TypeDBClientImpl(TypeDBClient):
     def close(self) -> None:
         pass
 
-# typedb/connection/core/client.py
+# typedb/connection/core/driver.py
 from grpc import Channel, insecure_channel
 
-class _CoreClient(_TypeDBClientImpl):
+class _CoreDriver(_TypeDBDriverImpl):
     def __init__(self, address: str):
-        super(_CoreClient, self).__init__()
+        super(_CoreDriver, self).__init__()
         self._channel = insecure_channel(address)
         self._stub = _CoreStub(self._channel)
         self._databases = _TypeDBDatabaseManagerImpl(self._stub)
@@ -284,8 +284,8 @@ Node.js::
 --
 [,js]
 ----
-// connection/TypeDBClientImpl.ts
-export abstract class TypeDBClientImpl implements TypeDBClient {
+// connection/TypeDBDriverImpl.ts
+export abstract class TypeDBDriverImpl implements TypeDBDriver {
     private _isOpen: boolean;
 
     protected constructor() {
@@ -307,8 +307,8 @@ export abstract class TypeDBClientImpl implements TypeDBClient {
     }
 }
 
-// connection/core/CoreClient.ts
-export class CoreClient extends TypeDBClientImpl {
+// connection/core/CoreDriver.ts
+export class CoreDriver extends TypeDBDriverImpl {
     private readonly _stub: CoreStub;
     private readonly _databases: TypeDBDatabaseManagerImpl;
 
@@ -361,10 +361,10 @@ public interface DatabaseManager {
 import com.vaticle.typedb.protocol.CoreDatabaseProto;
 
 public class TypeDBDatabaseManagerImpl implements DatabaseManager {
-    private final TypeDBClientImpl client;
+    private final TypeDBDriverImpl driver;
 
-    public TypeDBDatabaseManagerImpl(TypeDBClientImpl client) {
-        this.client = client;
+    public TypeDBDatabaseManagerImpl(TypeDBDriverImpl driver) {
+        this.driver = driver;
     }
 
     @Override
@@ -373,7 +373,7 @@ public class TypeDBDatabaseManagerImpl implements DatabaseManager {
     }
 
     TypeDBStub stub() {
-        return client.stub();
+        return driver.stub();
     }
 }
 
@@ -474,7 +474,7 @@ Node.js::
 --
 [,js]
 ----
-// api/connection/database/TypeDBClient.ts
+// api/connection/database/TypeDBDriver.ts
 export interface DatabaseManager {
     create(name: string): Promise<void>;
 }
@@ -485,8 +485,8 @@ import { CoreDatabaseManager } from "typedb-protocol/core/core_database_pb";
 export class TypeDBDatabaseManagerImpl implements DatabaseManager {
     private readonly _stub: TypeDBStub;
 
-    constructor(client: TypeDBStub) {
-        this._stub = client;
+    constructor(driver: TypeDBStub) {
+        this._stub = driver;
     }
 
     public create(name: string): Promise<void> {
@@ -500,7 +500,7 @@ export class TypeDBDatabaseManagerImpl implements DatabaseManager {
 
 // common/rpc/TypeDBStub.ts
 import { CoreDatabaseManager } from "typedb-protocol/core/core_database_pb";
-import { TypeDBClient } from "typedb-protocol/core/core_service_grpc_pb";
+import { TypeDBDriver } from "typedb-protocol/core/core_service_grpc_pb";
 
 export abstract class TypeDBStub {
     databasesCreate(req: CoreDatabaseManager.Create.Req): Promise<void> {
@@ -512,22 +512,22 @@ export abstract class TypeDBStub {
         });
     }
 
-    abstract stub(): TypeDBClient;
+    abstract stub(): TypeDBDriver;
 }
 
 // connection/core/CoreStub.ts
 import { ChannelCredentials } from "@grpc/grpc-js";
-import { TypeDBClient } from "typedb-protocol/core/core_service_grpc_pb";
+import { TypeDBDriver } from "typedb-protocol/core/core_service_grpc_pb";
 
 export class CoreStub extends TypeDBStub {
-    private readonly _stub: TypeDBClient;
+    private readonly _stub: TypeDBDriver;
 
     constructor(address: string) {
         super();
-        this._stub = new TypeDBClient(address, ChannelCredentials.createInsecure());
+        this._stub = new TypeDBDriver(address, ChannelCredentials.createInsecure());
     }
 
-    stub(): TypeDBClient {
+    stub(): TypeDBDriver {
         return this._stub;
     }
 
@@ -552,9 +552,9 @@ Java::
 --
 [,java]
 ----
-public static void typeDBClientTest() {
-    try (TypeDBClient client = TypeDB.coreClient("127.0.0.1:1729")) {
-        client.databases().create("typedb");
+public static void typeDBDriverTest() {
+    try (TypeDBDriver driver = TypeDB.coreDriver("127.0.0.1:1729")) {
+        driver.databases().create("typedb");
     }
 }
 ----
@@ -565,9 +565,9 @@ Python::
 --
 [,python]
 ----
-def typedb_client_test():
-    with TypeDB.core_client("127.0.0.1:1729") as client:
-        client.databases().create("typedb")
+def typedb_driver_test():
+    with TypeDB.core_driver("127.0.0.1:1729") as driver:
+        driver.databases().create("typedb")
 ----
 --
 
@@ -576,12 +576,12 @@ Node.js::
 --
 [,js]
 ----
-async function typeDBClientTest() {
+async function typeDBDriverTest() {
     try {
-        const client = TypeDB.coreClient("127.0.0.1:1729");
-        await client.databases().create("typedb");
+        const driver = TypeDB.coreDriver("127.0.0.1:1729");
+        await driver.databases().create("typedb");
     } finally {
-        client?.close();
+        driver?.close();
     }
 }
 ----

--- a/typedb-src/modules/ROOT/pages/tutorials/sample-app.adoc
+++ b/typedb-src/modules/ROOT/pages/tutorials/sample-app.adoc
@@ -50,6 +50,7 @@ TypeQL query used:
 [,typeql]
 ----
 match $u isa user, has full-name $n, has email $e;
+get;
 ----
 
 *Simple explanation*: we go through all entities of `user` subtype (assigning a variable `$u` for those) that have
@@ -76,7 +77,8 @@ TypeQL query used:
 [,typeql]
 ----
 match $u isa user, has full-name 'Kevin Morrison'; $p($u, $pa) isa permission;
-      $o isa object, has path $fp; $pa($o, $va) isa access; get $fp;
+      $o isa object, has path $fp; $pa($o, $va) isa access;
+get $fp;
 ----
 --
 
@@ -87,7 +89,7 @@ TypeQL query builder clause used:
 
 [,java]
 ----
-TypeQLMatch.Filtered getQuery = TypeQL.match( // Java query builder to prepare TypeQL query string
+TypeQLGet getQuery = TypeQL.match( // Java query builder to prepare TypeQL query string
         cVar("u").isa("user").has("full-name", "Kevin Morrison"),
         cVar("p").rel(cVar("u")).rel(cVar("pa")).isa("permission"),
         cVar("o").isa("object").has("path", cVar("fp")),
@@ -123,7 +125,9 @@ TypeQL query used:
 ----
 match $u isa user, has full-name 'Kevin Morrison'; $p($u, $pa) isa permission;
       $o isa object, has path $fp; $pa($o, $va) isa access;
-      $va isa action, has name 'view_file'; get $fp; sort $fp asc; offset 0; limit 5;
+      $va isa action, has name 'view_file';
+get $fp;
+sort $fp asc; offset 0; limit 5;
 ----
 --
 
@@ -134,7 +138,7 @@ TypeQL query builder clause #1 used:
 
 [,java]
 ----
-TypeQLMatch.Limited getQuery = TypeQL.match( // Java query builder to prepare TypeQL query string
+TypeQLGet getQuery = TypeQL.match( // Java query builder to prepare TypeQL query string
         cVar("u").isa("user").has("full-name", "Kevin Morrison"),
         cVar("p").rel(cVar("u")).rel(cVar("pa")).isa("permission"),
         cVar("o").isa("object").has("path", cVar("fp")),
@@ -223,8 +227,9 @@ Java Builder syntax::
 insertQuery = TypeQL.match( // Java query builder to prepare TypeQL query string
         cVar("f").isa("file").has("path", "logs/2023-06-30T12:04:36.351.log"),
         cVar("vav").isa("action").has("name", "view_file")
-                )
-        .insert(cVar("pa").rel(cVar("vav")).rel(cVar("f")).isa("access"));
+).insert(
+        cVar("pa").rel(cVar("vav")).rel(cVar("f")).isa("access")
+);
 ----
 --
 ====

--- a/typedb-src/modules/ROOT/partials/kubernetes.adoc
+++ b/typedb-src/modules/ROOT/partials/kubernetes.adoc
@@ -36,19 +36,19 @@ Please note that an external certificate is always bound to URL address, not IP 
 
 The internal certificate can be generated using the `create-encryption-mq-key.sh` tool bundled with TypeDB Enterprise
 distribution, which can be downloaded from
-https://repo.vaticle.com/#browse/browse:private-artifact:vaticle_typedb_cluster[repo.vaticle.com]:
+https://repo.vaticle.com/#browse/browse:private-artifact:vaticle_typedb_enterprise[repo.vaticle.com]:
 
 [,bash]
 ----
  $ # unpack distribution of TypeDB Enterprise into `dist` folder
- $ ./dist/typedb-cluster-all-<platform>-<version>/tool/create-encryption-mq-key.sh
+ $ ./dist/typedb-enterprise-all-<platform>-<version>/tool/create-encryption-mq-key.sh
 ----
 
 Once the external and internal certificates are all generated, we can proceed to upload it to Kubernetes Secrets:
 
 [,bash]
 ----
- $ kubectl create secret generic typedb-cluster \
+ $ kubectl create secret generic typedb-enterprise \
    --from-file rpc-private-key.pem \
    --from-file rpc-certificate.pem \
    --from-file rpc-root-ca.pem="$(mkcert -CAROOT)/rootCA.pem" \
@@ -56,7 +56,7 @@ Once the external and internal certificates are all generated, we can proceed to
    --from-file mq-public-key
 ----
 
-Additionally, the secret name in Kubernetes Secret needs to be identical to the Helm release name (`typedb-cluster`)
+Additionally, the secret name in Kubernetes Secret needs to be identical to the Helm release name (`typedb-enterprise`)
 and contain exactly these keys (`rpc-private-key.pem`, `rpc-certificate.pem`, `rpc-root-ca.pem`, `mq-secret-key`,
 `mq-public-key`).
 
@@ -75,30 +75,30 @@ In order to select this mode, ensure that the `exposed` flag is set to `false`.
 
 [,bash]
 ----
-helm install typedb-cluster vaticle/typedb-cluster --set "exposed=false,encrypted=false"
+helm install typedb-enterprise vaticle/typedb-enterprise --set "exposed=false,encrypted=false"
 ----
 
 Once the deployment has been completed, the servers would be accessible via the internal hostname within the Kubernetes
-network, ie., `typedb-cluster-0.typedb-cluster`, `typedb-cluster-1.typedb-cluster`, and
-`typedb-cluster-2.typedb-cluster`.
+network, ie., `typedb-enterprise-0.typedb-enterprise`, `typedb-enterprise-1.typedb-enterprise`, and
+`typedb-enterprise-2.typedb-enterprise`.
 
 *Deploying with in-flight encryption*
 
 Should you need to enable in-flight encryption for your private cluster, make sure the `encrypted` flag is set to `true`.
 
 Also make sure that the external certificate is bound to `*.<helm-release-name>`. For example, for a Helm release
-named `typedb-cluster`, the certificate needs to be bound to `*.typedb-cluster`.
+named `typedb-enterprise`, the certificate needs to be bound to `*.typedb-enterprise`.
 
 Once done, let's perform the deployment:
 
 [,bash]
 ----
-helm install typedb-cluster vaticle/typedb-cluster --set "exposed=false,encrypted=true"
+helm install typedb-enterprise vaticle/typedb-enterprise --set "exposed=false,encrypted=true"
 ----
 
 Once the deployment has been completed, the servers would be accessible via the internal hostname within the Kubernetes
-network, ie., `typedb-cluster-0.typedb-cluster`, `typedb-cluster-1.typedb-cluster`, and
-`typedb-cluster-2.typedb-cluster`.
+network, ie., `typedb-enterprise-0.typedb-enterprise`, `typedb-enterprise-1.typedb-enterprise`, and
+`typedb-enterprise-2.typedb-enterprise`.
 
 === Deploying a Public Cluster
 
@@ -115,7 +115,7 @@ running on.
 
 [,bash]
 ----
-helm install typedb-cluster vaticle/typedb-cluster --set "exposed=true"
+helm install typedb-enterprise vaticle/typedb-enterprise --set "exposed=true"
 ----
 
 Once the deployment has completed, the servers would be accessible via public IPs/hostnames assigned to the Kubernetes
@@ -123,7 +123,7 @@ Once the deployment has completed, the servers would be accessible via public IP
 
 [,bash]
 ----
-kubectl get svc -l external-ip-for=typedb-cluster \
+kubectl get svc -l external-ip-for=typedb-enterprise \
 -o='custom-columns=NAME:.metadata.name,IP OR HOSTNAME:.status.loadBalancer.ingress[0].*'
 ----
 
@@ -137,7 +137,7 @@ Given a "domain name" and "Helm release name", The address structure of the serv
 
 [,bash]
 ----
-typedb-cluster-{0..n}.<helm-release-name>.<domain-name>
+typedb-enterprise-{0..n}.<helm-release-name>.<domain-name>
 ----
 
 The format must be taken into account when generating the external certificate of all servers such that they're properly
@@ -151,7 +151,7 @@ Once done, let's perform the deployment:
 
 [,bash]
 ----
-helm install typedb-cluster vaticle/typedb-cluster --set "exposed=true,encrypted=true,domain=<domain-name>"
+helm install typedb-enterprise vaticle/typedb-enterprise --set "exposed=true,encrypted=true,domain=<domain-name>"
 ----
 
 After the deployment has been completed, we need to configure these URL addresses to correctly point to the servers.
@@ -160,9 +160,9 @@ trusted DNS provider:
 
 [,bash]
 ----
-typedb-cluster-0.typedb-cluster.example.com => public IP/hostname of typedb-cluster-0 service
-typedb-cluster-1.typedb-cluster.example.com => public IP/hostname of typedb-cluster-1 service
-typedb-cluster-2.typedb-cluster.example.com => public IP/hostname of typedb-cluster-2 service
+typedb-enterprise-0.typedb-enterprise.example.com => public IP/hostname of typedb-enterprise-0 service
+typedb-enterprise-1.typedb-enterprise.example.com => public IP/hostname of typedb-enterprise-1 service
+typedb-enterprise-2.typedb-enterprise.example.com => public IP/hostname of typedb-enterprise-2 service
 ----
 
 === Deploying a Public Cluster (Minikube)
@@ -178,7 +178,7 @@ run on a Minikube instance on your local machine.
 
 [,bash]
 ----
-helm install vaticle/typedb-cluster --generate-name \
+helm install vaticle/typedb-enterprise --generate-name \
 --set "cpu=2,replicas=3,singlePodPerNode=false,storage.persistent=true,storage.size=10Gi,exposed=true"
 ----
 
@@ -268,7 +268,7 @@ executing `kubectl get secret/private-docker-hub`. Correct state looks like this
 === One or more pods of TypeDB Enterprise are stuck in `Pending` state
 
 This might mean pods requested more resources than available. To check if that's the case, run
-`kubectl describe pod/typedb-cluster-0` on a stuck pod (e.g. `typedb-cluster-0`). Error message similar to
+`kubectl describe pod/typedb-enterprise-0` on a stuck pod (e.g. `typedb-enterprise-0`). Error message similar to
 `0/1 nodes are available: 1 Insufficient cpu.` or
 `0/1 nodes are available: 1 pod has unbound immediate PersistentVolumeClaims.`
 indicates that `cpu` or `storage.size` values need to be decreased.
@@ -276,7 +276,7 @@ indicates that `cpu` or `storage.size` values need to be decreased.
 === One or more pods of TypeDB Enterprise are stuck in `CrashLoopBackOff` state
 
 This might indicate any misconfiguration of TypeDB Enterprise. Please obtain the logs by executing
-`kubectl logs pod/typedb-cluster-0` and share them with TypeDB Enterprise developers.
+`kubectl logs pod/typedb-enterprise-0` and share them with TypeDB Enterprise developers.
 
 == Current Limitations
 

--- a/typedb-src/modules/ROOT/partials/sample-app-java.adoc
+++ b/typedb-src/modules/ROOT/partials/sample-app-java.adoc
@@ -19,14 +19,14 @@ requests performed in the sample app.
 ----
 package org.example2;
 
-import com.vaticle.typedb.client.api.TypeDBClient;
-import com.vaticle.typedb.client.api.TypeDBOptions;
-import com.vaticle.typedb.client.api.TypeDBSession;
-import com.vaticle.typedb.client.api.TypeDBTransaction;
-import com.vaticle.typedb.client.TypeDB;
+import com.vaticle.typedb.driver.api.TypeDBDriver;
+import com.vaticle.typedb.driver.api.TypeDBOptions;
+import com.vaticle.typedb.driver.api.TypeDBSession;
+import com.vaticle.typedb.driver.api.TypeDBTransaction;
+import com.vaticle.typedb.driver.TypeDB;
 import com.vaticle.typeql.lang.TypeQL;
 import static com.vaticle.typeql.lang.TypeQL.*;
-import com.vaticle.typeql.lang.query.TypeQLMatch;
+import com.vaticle.typeql.lang.query.TypeQLGet;
 import com.vaticle.typeql.lang.query.TypeQLInsert;
 
 import java.text.SimpleDateFormat;
@@ -38,16 +38,16 @@ public class Main {
         System.out.println("IAM Sample App");
 
         System.out.println("Connecting to the server");
-        TypeDBClient client = TypeDB.coreClient("0.0.0.0:1729"); // client is connected to the server
+        TypeDBDriver driver = TypeDB.coreDriver("0.0.0.0:1729"); // driver is connected to the server
         System.out.println("Connecting to the `iam` database");
-        try (TypeDBSession session = client.session("iam", TypeDBSession.Type.DATA)) { // session is open
+        try (TypeDBSession session = driver.session("iam", TypeDBSession.Type.DATA)) { // session is open
 
             System.out.println("");
             System.out.println("Request #1: User listing");
             try (TypeDBTransaction readTransaction = session.transaction(TypeDBTransaction.Type.READ)) { // READ transaction is open
                 k = 0; // reset the counter
-                readTransaction.query().match( // Executing query
-                        "match $u isa user, has full-name $n, has email $e;" // TypeQL query
+                readTransaction.query().get( // Executing query
+                        "match $u isa user, has full-name $n, has email $e; get;" // TypeQL query
                 ).forEach(result -> { // Iterating through results
                     String name = result.get("n").asAttribute().asString().getValue();
                     String email = result.get("e").asAttribute().asString().getValue();
@@ -62,14 +62,14 @@ public class Main {
             try (TypeDBTransaction readTransaction = session.transaction(TypeDBTransaction.Type.READ)) { // READ transaction is open
                 // String getQuery = "match $u isa user, has full-name 'Kevin Morrison'; $p($u, $pa) isa permission; " +
                 //        "$o isa object, has path $fp; $pa($o, $va) isa access; get $fp;"; // Example of the same TypeQL query
-                TypeQLMatch.Filtered getQuery = TypeQL.match( // Java query builder to prepare TypeQL query string
+                TypeQLGet getQuery = TypeQL.match( // Java query builder to prepare TypeQL query string
                         cVar("u").isa("user").has("full-name", "Kevin Morrison"),
                         cVar("p").rel(cVar("u")).rel(cVar("pa")).isa("permission"),
                         cVar("o").isa("object").has("path", cVar("fp")),
                         cVar("pa").rel(cVar("o")).rel(cVar("va")).isa("access")
                 ).get(cVar("fp"));
                 k = 0; // reset the counter
-                readTransaction.query().match(getQuery).forEach(result -> { // Executing query
+                readTransaction.query().get(getQuery).forEach(result -> { // Executing query
                     k += 1;
                     System.out.println("File #" + k + ": " + result.get("fp").asAttribute().asString().getValue());
                 });
@@ -78,14 +78,14 @@ public class Main {
 
             System.out.println("");
             System.out.println("Request #3: Files that Kevin Morrison has view access to (with inference)");
-            try (TypeDBTransaction readTransaction = session.transaction(TypeDBTransaction.Type.READ, TypeDBOptions.core().infer(true))) { // READ transaction is open
+            try (TypeDBTransaction readTransaction = session.transaction(TypeDBTransaction.Type.READ, TypeDBOptions(infer=true))) { // READ transaction is open
                 // String getQuery = "match $u isa user, has full-name 'Kevin Morrison';
                 // $p($u, $pa) isa permission;
                 // $o isa object, has path $fp;
                 // $pa($o, $va) isa access;
                 // $va isa action, has name 'view_file';
                 // get $fp; sort $fp asc; offset 0; limit 5;"
-                TypeQLMatch.Limited getQuery = TypeQL.match( // Java query builder to prepare TypeQL query string
+                TypeQLGet getQuery = TypeQL.match( // Java query builder to prepare TypeQL query string
                         cVar("u").isa("user").has("full-name", "Kevin Morrison"),
                         cVar("p").rel(cVar("u")).rel(cVar("pa")).isa("permission"),
                         cVar("o").isa("object").has("path", cVar("fp")),
@@ -93,7 +93,7 @@ public class Main {
                         cVar("va").isa("action").has("name", "view_file")
                 ).get(cVar("fp")).sort(cVar("fp")).offset(0).limit(5);
                 k = 0; // reset the counter
-                readTransaction.query().match(getQuery).forEach(result -> { // Executing query
+                readTransaction.query().get(getQuery).forEach(result -> { // Executing query
                     k += 1;
                     System.out.println("File #" + k + ": " + result.get("fp").asAttribute().asString().getValue());
                 });
@@ -105,7 +105,7 @@ public class Main {
                         cVar("pa").rel(cVar("o")).rel(cVar("va")).isa("access"),
                         cVar("va").isa("action").has("name", "view_file")
                 ).get(cVar("fp")).sort(cVar("fp")).offset(5).limit(5);
-                readTransaction.query().match(getQuery).forEach(result -> { // Executing query
+                readTransaction.query().get(getQuery).forEach(result -> { // Executing query
                     k += 1;
                     System.out.println("File #" + k + ": " + result.get("fp").asAttribute().asString().getValue());
                 });
@@ -126,14 +126,15 @@ public class Main {
                 insertQuery = TypeQL.match( // Java query builder to prepare TypeQL query string
                         cVar("f").isa("file").has("path", filepath),
                         cVar("vav").isa("action").has("name", "view_file")
-                                )
-                        .insert(cVar("pa").rel(cVar("vav")).rel(cVar("f")).isa("access"));
+                ).insert(
+                    cVar("pa").rel(cVar("vav")).rel(cVar("f")).isa("access")
+                );
                 System.out.println("Adding view access to the file");
                 writeTransaction.query().insert(insertQuery); // Executing query
                 writeTransaction.commit(); // to persist changes, a 'write' transaction must be committed
             }
         }
-        client.close(); // closing server connection
+        driver.close(); // closing server connection
     }
 }
 ----

--- a/typedb-src/modules/ROOT/partials/sample-app-node.adoc
+++ b/typedb-src/modules/ROOT/partials/sample-app-node.adoc
@@ -21,29 +21,29 @@ requests performed in the sample app.
 
 [,javascript]
 ----
-const { TypeDB } = require("typedb-client/TypeDB");
-const { SessionType } = require("typedb-client/api/connection/TypeDBSession");
-const { TransactionType } = require("typedb-client/api/connection/TypeDBTransaction");
-const { TypeDBOptions } = require("typedb-client/api/connection/TypeDBOptions");
+const { TypeDB } = require("typedb-driver/TypeDB");
+const { SessionType } = require("typedb-driver/api/connection/TypeDBSession");
+const { TransactionType } = require("typedb-driver/api/connection/TypeDBTransaction");
+const { TypeDBOptions } = require("typedb-driver/api/connection/TypeDBOptions");
 
 async function main() {
     console.log("IAM Sample App");
 
     console.log("Connecting to the server");
-    const client = await TypeDB.coreClient("0.0.0.0:1729"); // client is connected to the server
+    const driver = await TypeDB.coreDriver("0.0.0.0:1729"); // driver is connected to the server
     console.log("Connecting to the `iam` database");
     let k; // define counter
     let session // define session for later use
     try {
-        session = await client.session("iam", SessionType.DATA); // session is open
+        session = await driver.session("iam", SessionType.DATA); // session is open
 
         console.log("");
         console.log("Request #1: User listing");
         let transaction;
         try {
             transaction = await session.transaction(TransactionType.READ); // READ transaction is open
-            let match_query = "match $u isa user, has full-name $n, has email $e;"; // TypeQL query
-            let iterator = transaction.query.match(match_query); // Executing query
+            let get_query = "match $u isa user, has full-name $n, has email $e; get;"; // TypeQL query
+            let iterator = transaction.query.get(get_query); // Executing query
             let answers = await iterator.collect();
             let result = await Promise.all(
                 answers.map(answer =>
@@ -65,8 +65,8 @@ async function main() {
         console.log("Request #2: Files that Kevin Morrison has access to");
         try {
             transaction = await session.transaction(TransactionType.READ); // READ transaction is open
-            match_query = "match $u isa user, has full-name 'Kevin Morrison'; $p($u, $pa) isa permission; $o isa object, has path $fp; $pa($o, $va) isa access; get $fp;";
-            iterator = transaction.query.match(match_query); // Executing query
+            get_query = "match $u isa user, has full-name 'Kevin Morrison'; $p($u, $pa) isa permission; $o isa object, has path $fp; $pa($o, $va) isa access; get $fp;";
+            iterator = transaction.query.get(get_query); // Executing query
             answers = await iterator.collect();
             result = await Promise.all(
                 answers.map(answer =>
@@ -80,17 +80,17 @@ async function main() {
             }
             console.log("Files found: " + k);
         } finally {
-        await transaction.close();
+            await transaction.close();
         };
 
         console.log("");
         console.log("Request #3: Files that Kevin Morrison has view access to (with inference)");
-        let options = TypeDBOptions.core();
+        let options = TypeDBOptions();
         options.infer = true; // set option to enable inference
         try {
             transaction = await session.transaction(TransactionType.READ, options); // READ transaction is open
-            match_query = "match $u isa user, has full-name 'Kevin Morrison'; $p($u, $pa) isa permission; $o isa object, has path $fp; $pa($o, $va) isa access; $va isa action, has name 'view_file'; get $fp; sort $fp asc; offset 0; limit 5;"
-            iterator = transaction.query.match(match_query); // Executing query
+            get_query = "match $u isa user, has full-name 'Kevin Morrison'; $p($u, $pa) isa permission; $o isa object, has path $fp; $pa($o, $va) isa access; $va isa action, has name 'view_file'; get $fp; sort $fp asc; offset 0; limit 5;"
+            iterator = transaction.query.get(get_query); // Executing query
             answers = await iterator.collect();
             result = await Promise.all(
                 answers.map(answer =>
@@ -102,8 +102,8 @@ async function main() {
                 k++;
                 console.log("File #" + k + ": " + result[i]);
             };
-            match_query = "match $u isa user, has full-name 'Kevin Morrison'; $p($u, $pa) isa permission; $o isa object, has path $fp; $pa($o, $va) isa access; $va isa action, has name 'view_file'; get $fp; sort $fp asc; offset 5; limit 5;"
-            iterator = transaction.query.match(match_query); // Executing query
+            get_query = "match $u isa user, has full-name 'Kevin Morrison'; $p($u, $pa) isa permission; $o isa object, has path $fp; $pa($o, $va) isa access; $va isa action, has name 'view_file'; get $fp; sort $fp asc; offset 5; limit 5;"
+            iterator = transaction.query.get(get_query); // Executing query
             answers = await iterator.collect();
             result = await Promise.all(
                 answers.map(answer =>
@@ -133,11 +133,11 @@ async function main() {
             await transaction.query.insert(insert_query); // Executing query
             await transaction.commit(); // to persist changes, a 'write' transaction must be committed
         } finally {
-        if (transaction.isOpen()) {await transaction.close()};
+            if (transaction.isOpen()) {await transaction.close()};
         };
     } finally {
         await session?.close(); // close session
-        client.close(); // close server connection
+        driver.close(); // close server connection
     };
 };
 

--- a/typedb-src/modules/ROOT/partials/sample-app-python.adoc
+++ b/typedb-src/modules/ROOT/partials/sample-app-python.adoc
@@ -10,19 +10,19 @@ requests performed in the sample app.
 
 [,python]
 ----
-from typedb.client import TypeDB, SessionType, TransactionType, TypeDBOptions
+from typedb.driver import TypeDB, SessionType, TransactionType, TypeDBOptions
 from datetime import datetime
 
 print("IAM Sample App")
 
 print("Connecting to the server")
-with TypeDB.core_client("0.0.0.0:1729") as client:  # Connect to TypeDB server
+with TypeDB.core_driver("0.0.0.0:1729") as driver:  # Connect to TypeDB server
     print("Connecting to the `iam` database")
-    with client.session("iam", SessionType.DATA) as session:  # Access data in the `iam` database as Session
+    with driver.session("iam", SessionType.DATA) as session:  # Access data in the `iam` database as Session
         print("Request #1: User listing")
         with session.transaction(TransactionType.READ) as transaction:  # Open transaction to read
-            typeql_read_query = "match $u isa user, has full-name $n, has email $e;"
-            iterator = transaction.query().match(typeql_read_query)  # Executing query
+            typeql_read_query = "match $u isa user, has full-name $n, has email $e; get;"
+            iterator = transaction.query().get(typeql_read_query)  # Executing query
             k = 0  # Reset counter
             for item in iterator:  # Iterating through results
                 k += 1
@@ -33,7 +33,7 @@ with TypeDB.core_client("0.0.0.0:1729") as client:  # Connect to TypeDB server
         with session.transaction(TransactionType.READ) as transaction:  # Open transaction to read
             typeql_read_query = "match $u isa user, has full-name 'Kevin Morrison'; $p($u, $pa) isa permission; " \
                                 "$o isa object, has path $fp; $pa($o, $va) isa access; get $fp;"
-            iterator = transaction.query().match(typeql_read_query)  # Executing query
+            iterator = transaction.query().get(typeql_read_query)  # Executing query
             k = 0  # Reset counter
             for item in iterator:  # Iterating through results
                 k += 1
@@ -41,11 +41,11 @@ with TypeDB.core_client("0.0.0.0:1729") as client:  # Connect to TypeDB server
             print("Files found:", k)  # Print number of results
 
         print("\nRequest #3: Files that Kevin Morrison has view access to (with inference)")
-        with session.transaction(TransactionType.READ, TypeDBOptions.core().set_infer(True)) as transaction:  # Open transaction to read with inference
+        with session.transaction(TransactionType.READ, TypeDBOptions(infer=True)) as transaction:  # Open transaction to read with inference
             typeql_read_query = "match $u isa user, has full-name 'Kevin Morrison'; $p($u, $pa) isa permission; " \
                                 "$o isa object, has path $fp; $pa($o, $va) isa access; " \
                                 "$va isa action, has name 'view_file'; get $fp; sort $fp asc; offset 0; limit 5;"
-            iterator = transaction.query().match(typeql_read_query)  # Executing query
+            iterator = transaction.query().get(typeql_read_query)  # Executing query
             k = 0  # Reset counter
             for item in iterator:  # Iterating through results
                 k += 1
@@ -54,7 +54,7 @@ with TypeDB.core_client("0.0.0.0:1729") as client:  # Connect to TypeDB server
             typeql_read_query = "match $u isa user, has full-name 'Kevin Morrison'; $p($u, $pa) isa permission; " \
                                 "$o isa object, has path $fp; $pa($o, $va) isa access; " \
                                 "$va isa action, has name 'view_file'; get $fp; sort $fp asc; offset 5; limit 5;"
-            iterator = transaction.query().match(typeql_read_query)  # Executing query
+            iterator = transaction.query().get(typeql_read_query)  # Executing query
             for item in iterator:  # Iterating through results
                 k += 1
                 print("File #" + str(k) + ": " + item.get("fp").get_value())

--- a/typeql-src/modules/ROOT/pages/data/advanced.adoc
+++ b/typeql-src/modules/ROOT/pages/data/advanced.adoc
@@ -143,6 +143,7 @@ the xref:typeql::fundamentals.adoc#_thing_type[Thing type] section.
 [,typeql]
 ----
 match $t sub thing;
+get;
 ----
 
 include::typedb::partial$thing-warning.adoc[]
@@ -155,6 +156,7 @@ Use a `subtype` pattern to find a specific type and all of its subtypes.
 [,typeql]
 ----
 match $o sub object;
+get;
 ----
 
 The above pattern finds the `object` type and all of its nested subtypes: direct (i.e., `resource` and `resource-collection`)
@@ -168,6 +170,7 @@ Use a `subtype` pattern with an exclamation mark (`!`) to find the direct subtyp
 [,typeql]
 ----
 match $o sub! object;
+get;
 ----
 
 The above query finds all direct subtypes of the `object` type (i.e., `resource` and `resource-collection`).
@@ -180,6 +183,7 @@ Use an `attribute subtype` pattern to find all attribute types with a specific v
 [,typeql]
 ----
 match $a sub attribute, value boolean;
+get;
 ----
 
 The above query finds all attribute types that have a `boolean` value type.
@@ -192,6 +196,7 @@ Use a `type` pattern to find a specific type, excluding any nested subtypes (dir
 [,typeql]
 ----
 match $o type object;
+get;
 ----
 
 The above query returns the `object` type, and none of its nested subtypes (direct or indirect).
@@ -204,6 +209,7 @@ Use a "players type in a relation" pattern to find all types that play a specifi
 [,typeql]
 ----
 match $p plays permission:subject;
+get;
 ----
 
 The above query finds all types that can play the `subject` role in the `permission` relation type.
@@ -216,6 +222,7 @@ Use an `owners of attribute type` pattern to find all types that own a specific 
 [,typeql]
 ----
 match $o owns full-name;
+get;
 ----
 
 The above query finds all types that own the `full-name` attribute.
@@ -228,6 +235,7 @@ Use the `role types in a relation` pattern to find all roles in a specific relat
 [,typeql]
 ----
 match permission relates $r;
+get;
 ----
 
 The above query finds all the roles defined in the `permission` relation type (`permission:access` and
@@ -253,6 +261,7 @@ Use an `instance` pattern with type `thing` to find all entities, relations, and
 [,typeql]
 ----
 match $t isa thing;
+get;
 ----
 
 For more information on `thing` type see the xref:typeql::fundamentals.adoc#_thing_type[Thing type] section.
@@ -269,6 +278,7 @@ Use an `instance` pattern to find all entities of a specific entity type (and of
 [,typeql]
 ----
 match $p isa person;
+get;
 ----
 
 The above query returns all entities of the `person` entity and any of its subtypes.
@@ -289,6 +299,7 @@ Use an `instance` pattern with an exclamation mark (`!`) to find all entities of
 [,typeql]
 ----
 match $u isa! user;
+get;
 ----
 
 The above query finds all `user` entities. It excludes any entities whose type is a subtype of `user`,
@@ -302,6 +313,7 @@ specific type.
 [,typeql]
 ----
 match $p isa person, has full-name $n;
+get;
 ----
 
 The above query finds all `person` entities that own a `full-name` attribute.
@@ -314,6 +326,7 @@ attributes, each of a specific type.
 [,typeql]
 ----
 match $p isa person, has full-name $n, has email $email, has credential $cr;
+get;
 ----
 
 The above query finds all `person` entities that have `full-name`, `email`, and `credential` attributes.
@@ -326,6 +339,7 @@ with a specific value.
 [,typeql]
 ----
 match $p isa person, has full-name “Kevin Morrison”;
+get;
 ----
 
 The above query finds all `person` entities that have a `full-name` attribute with a value of "`Kevin Morrison`".
@@ -338,6 +352,7 @@ have a specific attribute whose value is within a specific range.
 [,typeql]
 ----
 match $f isa file, has size-kb < 100;
+get;
 ----
 
 However, if the attribute value itself is required in the query response, combine a `has-attribute statement`
@@ -379,6 +394,7 @@ specific attribute with a specific value.
 [,typeql]
 ----
 match $pe (subject: $p, access: $ac) isa permission, has validity true;
+get;
 ----
 
 The above query finds all `permission` relations which have a `validity` attribute whose value is `true`.
@@ -390,6 +406,7 @@ The relation variable can be omitted when only the role players are needed.
 [,typeql]
 ----
 match (subject: $p, access: $ac) isa permission;
+get;
 ----
 
 ===== With no role names
@@ -399,6 +416,7 @@ The names of a relation's roles can be omitted.
 [,typeql]
 ----
 match $pe ($p, $ac) isa permission;
+get;
 ----
 
 This will match any valid combination of roles.
@@ -415,6 +433,7 @@ Use a variable and an attribute value to find all attributes with a specific val
 [,typeql]
 ----
 match $x "Masako Holley";
+get;
 ----
 
 The above query finds all attributes with a value of "`Masako Holley`", regardless of their type.
@@ -436,6 +455,7 @@ Or use this compact form:
 [,typeql]
 ----
 match $n "Masako Holley" isa full-name;
+get;
 ----
 
 The above queries finds all `full-name` attributes with a value of `Masako Holley`.
@@ -447,6 +467,7 @@ Use an `attribute` pattern with `contains` keyword to find all attributes whose 
 [,typeql]
 ----
 match $name contains "Masako";
+get;
 ----
 
 The above query finds all attributes whose value contains the text `Masako`, regardless of their type.
@@ -459,6 +480,7 @@ the specified regular expression pattern.
 [,typeql]
 ----
 match $x like "(Masako Holley|Kevin Morrison)";
+get;
 ----
 
 The above query finds all attributes whose value is `Masako Holley` or `Kevin Morrison`, regardless of their type.

--- a/typeql-src/modules/ROOT/pages/fundamentals.adoc
+++ b/typeql-src/modules/ROOT/pages/fundamentals.adoc
@@ -805,6 +805,7 @@ Now to read that data, we can use the xref:typeql::data/get.adoc[Get] query:
 [,typeql]
 ----
 match $p isa person;
+get;
 ----
 
 This should return to us all instances of the `person` type. But yet again -- what is the use for entities without their

--- a/typeql-src/modules/ROOT/pages/grammar-rrd.adoc
+++ b/typeql-src/modules/ROOT/pages/grammar-rrd.adoc
@@ -82,36 +82,36 @@ referenced by:
 * query
 * query_update
 
-== query_match
+== query_get
 
-image::diagram/query_match.png[query_match]
-
-referenced by:
-
-* query
-* query_match_aggregate
-* query_match_group
-* query_match_group_agg
-
-== query_match_aggregate
-
-image::diagram/query_match_aggregate.png[query_match_aggregate]
+image::diagram/query_match.png[query_get]
 
 referenced by:
 
 * query
+* query_get_aggregate
+* query_get_group
+* query_get_group_agg
 
-== query_match_group
+== query_get_aggregate
 
-image::diagram/query_match_group.png[query_match_group]
+image::diagram/query_match_aggregate.png[query_get_aggregate]
 
 referenced by:
 
 * query
 
-== query_match_group_agg
+== query_get_group
 
-image::diagram/query_match_group_agg.png[query_match_group_agg]
+image::diagram/query_match_group.png[query_get_group]
+
+referenced by:
+
+* query
+
+== query_get_group_agg
+
+image::diagram/query_match_group_agg.png[query_get_group_agg]
 
 referenced by:
 
@@ -123,7 +123,7 @@ image::diagram/modifiers.png[modifiers]
 
 referenced by:
 
-* query_match
+* query_get
 
 == filter
 
@@ -165,14 +165,14 @@ referenced by:
 
 * modifiers
 
-== match_aggregate
+== get_aggregate
 
-image::diagram/match_aggregate.png[match_aggregate]
+image::diagram/match_aggregate.png[get_aggregate]
 
 referenced by:
 
-* query_match_aggregate
-* query_match_group_agg
+* query_get_aggregate
+* query_get_group_agg
 
 == aggregate_method
 
@@ -180,16 +180,16 @@ image::diagram/aggregate_method.png[aggregate_method]
 
 referenced by:
 
-* match_aggregate
+* get_aggregate
 
-== match_group
+== get_group
 
-image::diagram/match_group.png[match_group]
+image::diagram/match_group.png[get_group]
 
 referenced by:
 
-* query_match_group
-* query_match_group_agg
+* query_get_group
+* query_get_group_agg
 
 == definables
 
@@ -221,7 +221,7 @@ referenced by:
 * pattern_negation
 * query_delete
 * query_insert
-* query_match
+* query_get
 * schema_rule
 
 == pattern
@@ -698,8 +698,8 @@ referenced by:
 * attribute
 * expression_base
 * filter
-* match_aggregate
-* match_group
+* get_aggregate
+* get_group
 * player
 * predicate_value
 * type
@@ -728,8 +728,8 @@ referenced by:
 * attribute
 * expression_base
 * filter
-* match_aggregate
-* match_group
+* get_aggregate
+* get_group
 * predicate_value
 * var_order
 * variable_value

--- a/typeql-src/modules/ROOT/pages/schema/define-types.adoc
+++ b/typeql-src/modules/ROOT/pages/schema/define-types.adoc
@@ -176,6 +176,7 @@ The following query can be run in a new tab in *Schema* / *Read* mode to see the
 [,typeql]
 ----
 match $s sub thing;
+get;
 ----
 
 As the result of the above query TypeDB Studio should display a graph visualization of the schema defined earlier.


### PR DESCRIPTION
## What is the goal of this PR?

We do a pass through the documentation to replace usages of `Match` queries with the new terminology of `Get` queries (as of 2.25.x releases). This also required adding `get` clauses to queries that did not previously require them.

We also replace usages of 'cluster' that we found should have been 'enterprise', as well as outdated usages of 'client' replaced by 'driver'.


## What are the changes implemented in this PR?

* Replace TypeQLMatch with TypeQLGet
* Add 'get;' to match queries that did not previously have them
* Replace usages of 'Client' with 'Driver' where appropriate, in particular in code samples to make sure the imports and class names were correct
* Replace usages of 'Cluster' with 'Enterprise' where appropriate, in particular in code samples to make sure the imports and class names were correct
* Replace TypeDBOptions.core() with just TypeDBOptions() (mostly in Python examples)

