### PR TITLE
Renaming TypeDB docs sections

### DIFF
--- a/typedb-src/modules/ROOT/pages/fundamentals/inference.adoc
+++ b/typedb-src/modules/ROOT/pages/fundamentals/inference.adoc
@@ -59,7 +59,7 @@ include::typeql::schema/define-rules.adoc[tag=rule_validation]
 
 This was the last page of the *Fundamentals* section.
 
-We recommend to continue exploring TypeDB by going through the *Development* section:
+We recommend continuing exploration of TypeDB by going through the *Developing with TypeDB* section:
 
 * xref:development/connect.adoc[]
 * xref:development/schema.adoc[]

--- a/typedb-src/modules/ROOT/pages/fundamentals/patterns.adoc
+++ b/typedb-src/modules/ROOT/pages/fundamentals/patterns.adoc
@@ -289,11 +289,11 @@ and neither people to have the full-name `Masako Holley`.
 
 This was the third page of the *Fundamentals* section.
 
-Only one page left to go for fundamentals section:
+Only one page left to go for the fundamentals section:
 
     1. xref:typedb::fundamentals/inference.adoc[]
 
-If you want to skip inference for now, continue to the *Development* section, starting from the
+If you want to skip inference for now, continue to the *Developing with TypeDB* section, starting from the
 xref:typedb::development/connect.adoc[] page.
 
 For more advanced TypeQL patterns, see the xref:typeql::data/advanced.adoc[,window=_blank] page in the TypeQL

--- a/typedb-src/modules/ROOT/pages/home/overview.adoc
+++ b/typedb-src/modules/ROOT/pages/home/overview.adoc
@@ -26,10 +26,10 @@ a symbolic reasoning engine.
 [#_fundamentals]
 * Fundamentals -- essential knowledge to learn before practicing TypeDB
 
-[#_development]
+[#_developing]
 * Developing with TypeDB -- learn how to connect and send queries to TypeDB
 
-[#_operations]
+[#_managing]
 * Managing TypeDB -- learn about configuring and using a production-ready TypeDB installation
 
 [#_tutorials]

--- a/typedb-src/modules/ROOT/pages/introduction.adoc
+++ b/typedb-src/modules/ROOT/pages/introduction.adoc
@@ -112,7 +112,7 @@ xref:fundamentals/types.adoc[],
 xref:fundamentals/queries.adoc[],
 xref:fundamentals/patterns.adoc[], and
 xref:fundamentals/inference.adoc[].
-* the *Development* for the in-detail documentation of the TypeDB development workflow, including:
+* the *Developing with TypeDB* for the in-detail documentation of the TypeDB development workflow, including:
 xref:development/connect.adoc[],
 xref:development/schema.adoc[],
 xref:development/write.adoc[], and

--- a/typedb-src/modules/ROOT/pages/overview.adoc
+++ b/typedb-src/modules/ROOT/pages/overview.adoc
@@ -21,8 +21,8 @@ Check the layout of the TypeDB documentation below.
 ** xref:fundamentals/patterns.adoc[] -- essential information on pattern matching
 ** xref:fundamentals/inference.adoc[] -- essential information on rules and reasoning (inference)
 
-[#_development]
-== Development
+[#_developing]
+== Developing with TypeDB
 
 ** xref:development/connect.adoc[] -- TypeDB server and database connections
 ** xref:development/schema.adoc[] -- database schema definition
@@ -34,8 +34,8 @@ Check the layout of the TypeDB documentation below.
 // #todo Consider moving API to Clients section with tabs
 ** xref:development/best.adoc[] -- schema and query design tips
 
-[#_operations]
-== Operations
+[#_managing]
+== Managing TypeDB
 
 ** xref:admin/configuration.adoc[] -- TypeDB server configuration parameters and host machine requirements
 ** xref:admin/export-import.adoc[] -- exporting and importing database schema and data
@@ -61,8 +61,8 @@ Then xref:installation.adoc[install] TypeDB and use xref:home/quickstart-guide.a
 To learn more about TypeDB, check the major sections of the documentation:
 
 * the <<_fundamentals,Fundamentals>> for essential knowledge about TypeDB,
-* the <<_development,Development>> for the in-detail documentation of the TypeDB development workflow,
-* the <<_operations,Operations>> for the instructions for setting up a production environment, or
+* the <<_developing,Developing with TypeDB>> for the in-detail documentation of the TypeDB development workflow,
+* the <<_managing,Managing TypeDB>> for the instructions for setting up a production environment, or
 * the <<_tutorials,Tutorials>> for how-to guides and the xref:tutorials/iam-schema.adoc[].
 
 Check our documentation for xref:typeql::overview.adoc[TypeQL] and xref:clients::clients.adoc[TypeDB Clients].

--- a/typeql-src/modules/ROOT/pages/data/advanced.adoc
+++ b/typeql-src/modules/ROOT/pages/data/advanced.adoc
@@ -493,7 +493,7 @@ match
   ?x = ($s + 5) * 2;
 ----
 
-In the above example parentheses are used to change order of operations: addition inside the parentheses will happen
+In the above example, parentheses are used to change order of operations: addition inside the parentheses will happen
 before multiplication.
 
 [#_using_exponentiation]


### PR DESCRIPTION
## What is the goal of this PR?

Renaming TypeDB documentation sections:
Development -> Developing with TypeDB
Operations -> Managing TypeDB

## What are the changes implemented in this PR?

Update overview pages and other references. Nav menu got updated earlier.