### PR TITLE
Update TypeQL queries for the TypeDB in 25 queries and Quickstart pages

### DIFF
--- a/home-src/modules/ROOT/attachments/quickstart-schema.tql
+++ b/home-src/modules/ROOT/attachments/quickstart-schema.tql
@@ -1,5 +1,9 @@
 define
 
+id sub attribute, value long;
+email sub attribute, value string;
+full-name sub attribute, value string;
+
 user sub entity,
     owns id @key,
     owns email,
@@ -8,6 +12,3 @@ user sub entity,
 person sub user,
     owns full-name;
 
-id sub attribute, value long;
-email sub attribute, value string;
-full-name sub attribute, value string;

--- a/home-src/modules/ROOT/pages/25-queries.adoc
+++ b/home-src/modules/ROOT/pages/25-queries.adoc
@@ -81,21 +81,21 @@ Let's insert two users, two files, and set permissions:
 [,typeql]
 ----
 insert
-    $p isa person,
-        has name "Charlie";
-    $u1 isa user,
-        has name "Bob",
-        has username "bob_93",
-        has email "bob@vaticle.com";
-    $u2 isa user,
-        has username "al-capucino";
-    $f1 isa file,
-        has path "README.md";
-    $f2 isa file,
-        has path "docs/quickstart-guide.adoc",
-        has size-kb 3458761;
-    $p1(subject:$u1, object:$f1) isa permission, has updated 2023-10-27T12:04:36;
-    $p2(subject:$u2, object:$f2) isa permission;
+$p isa person,
+    has name "Charlie";
+$u1 isa user,
+    has name "Bob",
+    has username "bob_93",
+    has email "bob@vaticle.com";
+$u2 isa user,
+    has username "al-capucino";
+$f1 isa file,
+    has path "README.md";
+$f2 isa file,
+    has path "docs/quickstart-guide.adoc",
+    has size-kb 3458761;
+$p1(subject:$u1, object:$f1) isa permission, has updated 2023-10-27T12:04:36;
+$p2(subject:$u2, object:$f2) isa permission;
 ----
 
 The above query xref:typeql:ROOT:data/insert.adoc[inserts] one instance of the `person` type,
@@ -117,11 +117,11 @@ To get usernames of all users that have permission for the file with path `READM
 [,typeql]
 ----
 match
-    $u isa user,
-        has username $un;
-    $f isa file,
-        has path "README.md";
-    $p(subject:$u, object:$f) isa permission;
+$u isa user,
+    has username $un;
+$f isa file,
+    has path "README.md";
+$p(subject:$u, object:$f) isa permission;
 get $un;
 ----
 
@@ -176,12 +176,12 @@ Now let's do a match insert by adding a new file and a relevant permission for a
 [,typeql]
 ----
 match
-    $u isa user;
-    $f isa file,
-        has path "README.md";
-    not { ($u, $f) isa permission; };
+$u isa user;
+$f isa file,
+    has path "README.md";
+not { ($u, $f) isa permission; };
 insert
-    ($u, $f) isa permission;
+($u, $f) isa permission;
 ----
 
 The above query matches the file with path `README.md` and all users, that are not in a `permission` relation.
@@ -200,11 +200,11 @@ Deleting data requires matching the data to delete first:
 [,typeql]
 ----
 match
-    $u isa user,
-        has username "al-capucino";
-    $p(subject:$u) isa permission;
+$u isa user,
+    has username "al-capucino";
+$p(subject:$u) isa permission;
 delete
-    $p isa permission;
+$p isa permission;
 ----
 
 The above query will delete all permission relations for the user with username `al-capucino`.
@@ -232,11 +232,11 @@ and an optional `get` clause to filter the results.
 [,typeql]
 ----
 match
-    $p isa person;
-    $p has name $p-name;
-    $p-name == "Bob";
-    $p has $x;
-    not {$x isa name;};
+$p isa person;
+$p has name $p-name;
+$p-name == "Bob";
+$p has $x;
+not {$x == $p-name;};
 get $x;
 ----
 
@@ -273,6 +273,7 @@ Let's try one of the most generic patterns in TypeQL:
 [,typeql]
 ----
 match $x isa! $t;
+get $x, $t;
 ----
 
 The above query returns pairs of `$x` and `$t` concepts,
@@ -295,6 +296,7 @@ Match a supertype can match its subtypes.
 [,typeql]
 ----
 match $x isa entity;
+get $x;
 ----
 
 The query above matches `$x` by  its type.
@@ -314,6 +316,7 @@ Interface polymorphism lets us query for everything with a specific property, fo
 [,typeql]
 ----
 match $x has name $name;
+get $x, $name;
 ----
 
 The above query matches every instance, that has any name.
@@ -335,6 +338,7 @@ Now we can do the following query:
 [,typeql]
 ----
 match $x has id $id;
+get $x, $id;
 ----
 
 The above query can't retrieve any instances of `id` type because it is an abstract type.
@@ -357,12 +361,13 @@ Like in the following example:
 [,typeql]
 ----
 match
-    $u isa user,
-        has name "Bob";
+$u isa user,
+    has name "Bob";
+get $u;
 ----
 
 We match a user with name `Bob`.
-The `user` type inherits the ability to own  the `name` attribute type from its supertype -- the `person` type.
+The `user` type inherits the ability to own the `name` attribute type from its supertype -- the `person` type.
 See the schema from the <<_schema,query #1>>.
 
 == #{counter:query}: Overriding inheritance
@@ -428,14 +433,15 @@ Now let's add a role player for this role for a relation, that was inserted befo
 [,typeql]
 ----
 match
-    $u isa user,
-        has name "Bob";
-    $f isa file,
-        has path "README.md";
-    $p($u, $f) isa permission;
+$u isa user,
+    has name "Bob";
+$f isa file,
+    has path "README.md";
+$p($u, $f) isa permission;
 insert
-    $a isa action, has name "edit";
-    $p(permitted-action:$a);
+$a isa action,
+    has name "edit";
+$p(permitted-action:$a);
 ----
 
 The above query adds `action` entity with name `edit` to the `permission` for the user with name `Bob`
@@ -468,12 +474,11 @@ and adding a new ownership of the attribute of type `name` with the new value.
 [,typeql]
 ----
 match
-    $p isa person, has name "Charlie";
-
+$p isa person, has name "Charlie";
 insert
-    $p has name "Bob";
-    $b isa person, has name "Bob", has name "Another Bob";
-    $a isa action, has name "Bob";
+$p has name "Bob";
+$b isa person, has name "Bob", has name "Another Bob";
+$a isa action, has name "Bob";
 ----
 
 The above query matches the person with name `Charlie`,
@@ -516,12 +521,12 @@ Now let's see what will happen, if we'll try to violate these annotations by usi
 [,typeql]
 ----
 insert
-    $u isa user;
-    $u isa user,
-        has username "Bob";
-    $u isa user,
-        has username "Totally-not-Bob",
-        has email "bob@vaticle.com";
+$u isa user;
+$u isa user,
+    has username "Bob";
+$u isa user,
+    has username "Totally-not-Bob",
+    has email "bob@vaticle.com";
 ----
 
 The above query fails as it violates the following annotation constraints:
@@ -548,9 +553,10 @@ We can limit possible values that an attribute can take by using a regular expre
 ----
 define
 
+status sub attribute, value string, regex "^(STARTED|STOPPED|DELETED)$";
+
 task sub entity,
     owns status;
-status sub attribute, value string, regex "^(STARTED|STOPPED|DELETED)$";
 ----
 
 The `status` attribute type has a value type of string, but its value is limited by a regular expression.
@@ -576,8 +582,9 @@ Use the `like` keyword with a regular expression to set constraints for an attri
 [,typeql]
 ----
 match
-    $f isa file, has path $p;
-    $p like "^docs/.*$";
+$f isa file, has path $p;
+$p like "^docs/.*$";
+get $f, $p;
 ----
 
 The query above will find all files with path starting with `docs/`.
@@ -595,12 +602,12 @@ Let's insert a few files with different sizes, that are calculated:
 [,typeql]
 ----
 match
-    $f isa file, has path "docs/quickstart-guide.adoc", has size-kb $s;
-    ?x = ($s * 2) + 200;
-    ?y = abs ((?x * 3) - 1);
+$f isa file, has path "docs/quickstart-guide.adoc", has size-kb $s;
+?x = ($s * 2) + 200;
+?y = abs ((?x * 3) - 1);
 insert
-    $f1 isa file, has path "config.yaml", has size-kb ?x;
-    $f2 isa file, has path "logs.zip", has size-kb ?y;
+$f1 isa file, has path "config.yaml", has size-kb ?x;
+$f2 isa file, has path "logs.zip", has size-kb ?y;
 ----
 
 The above query inserts two files with `size-kb` values calculated based on the value of the `size-kb`
@@ -623,12 +630,11 @@ and send a xref:typeql:ROOT:data/get.adoc[Get] query.
 ----
 define
 
-rule every-person-is-a-dude:
-    when {
-        $p isa person;
-    } then {
-        $p has name "Dude";
-    };
+rule every-person-is-a-dude: when {
+    $p isa person;
+} then {
+    $p has name "Dude";
+};
 ----
 
 The above query adds exactly one rule:
@@ -647,9 +653,10 @@ Let's use the `every-person-is-a-dude` rule from the previous query <<_rule_base
 [,typeql]
 ----
 match
-    $p isa person,
-        has name "Bob",
-        has name $p-name;
+$p isa person,
+    has name "Bob",
+    has name $p-name;
+get $p, $p-name;
 ----
 
 The above query produces the following result with inference
@@ -670,29 +677,27 @@ Rules can be applied one after another in a chain.
 ----
 define
 
-file owns size-mb,
-    owns size-gb;
-
 size-mb sub attribute, value long;
 size-gb sub attribute, value long;
 
-rule compute-mb:
-    when {
-        $f isa file,
-            has size-kb $kb;
-        ?mb = round($kb / 1024);
-    } then {
-        $f has size-mb ?mb;
-    };
+file owns size-mb,
+    owns size-gb;
 
-rule compute-gb:
-    when {
-        $f isa file,
-            has size-mb $mb;
-        ?gb = round($mb / 1024);
-    } then {
-        $f has size-gb ?gb;
-    };
+rule compute-mb: when {
+    $f isa file,
+        has size-kb $kb;
+    ?mb = round($kb / 1024);
+} then {
+    $f has size-mb ?mb;
+};
+
+rule compute-gb: when {
+    $f isa file,
+        has size-mb $mb;
+    ?gb = round($mb / 1024);
+} then {
+    $f has size-gb ?gb;
+};
 ----
 
 The above schema adds two rules and necessary attributes.
@@ -711,9 +716,10 @@ Let's use the rules from the previous query <<_rule_chaining>>:
 [,typeql]
 ----
 match
-    $f isa file,
-        has size-gb $g,
-        has path $p;
+$f isa file,
+    has size-gb $g,
+    has path $p;
+get $f, $g, $p;
 ----
 
 The above query produces the following result with inference
@@ -740,6 +746,8 @@ Using rules for transitivity can greatly simplify your TypeQL queries.
 ----
 define
 
+name sub attribute, value string;
+
 group-membership sub relation,
     relates group,
     relates member;
@@ -753,15 +761,12 @@ user-group sub entity,
     plays group-membership:group,
     plays group-membership:member;
 
-name sub attribute, value string;
-
-rule transitive-group-membership:
-   when {
-      (group: $g1, member: $g2) isa group-membership;
-      (group: $g2, member: $u) isa group-membership;
-   } then {
-      (group: $g1, member: $u) isa group-membership;
-   };
+rule transitive-group-membership: when {
+  (group: $g1, member: $g2) isa group-membership;
+  (group: $g2, member: $u) isa group-membership;
+} then {
+  (group: $g1, member: $u) isa group-membership;
+};
 ----
 
 The above schema defines `group-membership` relation with two roles: `group` and `member`.
@@ -797,17 +802,17 @@ To try relation transitivity, insert the following sample data for the schema in
 [,typeql]
 ----
 insert
-    $u1 isa user, has name "Alice";
-    $u2 isa user, has name "Bob";
-    $u3 isa user, has name "Charlie";
-    $uga isa user-group, has name "Group A";
-    $ugb isa user-group, has name "Group B";
-    $ugc isa user-group, has name "Group C";
-    (group:$ugb, member:$uga) isa group-membership;
-    (group:$ugc, member:$ugb) isa group-membership;
-    (group:$uga, member:$u1) isa group-membership;
-    (group:$ugb, member:$u2) isa group-membership;
-    (group:$ugc, member:$u3) isa group-membership;
+$u1 isa user, has name "Alice";
+$u2 isa user, has name "Bob";
+$u3 isa user, has name "Charlie";
+$uga isa user-group, has name "Group A";
+$ugb isa user-group, has name "Group B";
+$ugc isa user-group, has name "Group C";
+(group:$ugb, member:$uga) isa group-membership;
+(group:$ugc, member:$ugb) isa group-membership;
+(group:$uga, member:$u1) isa group-membership;
+(group:$ugb, member:$u2) isa group-membership;
+(group:$ugc, member:$u3) isa group-membership;
 ----
 
 In the query above, we insert three users, three user groups and assign a membership in the following way:

--- a/home-src/modules/ROOT/pages/quickstart.adoc
+++ b/home-src/modules/ROOT/pages/quickstart.adoc
@@ -136,9 +136,9 @@ To xref:typedb::development/read.adoc#_get[get] all instances of a `person` type
 [,typeql]
 ----
 match
-    $p isa person,
-        has full-name $f,
-        has email $e;
+$p isa person,
+    has full-name $f,
+    has email $e;
 get $p, $f, $e;
 ----
 
@@ -150,8 +150,8 @@ To xref:typedb::development/read.adoc#_get[get] all instances of a `person` type
 [,typeql]
 ----
 match
-    $p isa person,
-        has $a;
+$p isa person,
+    has $a;
 get $p, $a;
 ----
 
@@ -164,10 +164,10 @@ To xref:typedb::development/read.adoc#_get[get] all emails owned by every person
 [,typeql]
 ----
 match
-    $p isa person,
-        has full-name $fn;
-    $fn contains "Kevin";
-    $p has email $e;
+$p isa person,
+    has full-name $fn;
+$fn contains "Kevin";
+$p has email $e;
 get $e;
 ----
 
@@ -180,9 +180,9 @@ that contains "Kevin":
 [,typeql]
 ----
 match
-    $p isa person,
-        has full-name $fn;
-    $fn contains "Kevin";
+$p isa person,
+    has full-name $fn;
+$fn contains "Kevin";
 insert $p has email "kevin@gmail.com";
 ----
 
@@ -197,11 +197,11 @@ for every person with a full name that contains "Kevin":
 [,typeql]
 ----
 match
-    $p isa person,
-        has full-name $fn,
-        has email $e;
-    $fn contains "Kevin";
-    $e = "kevin@gmail.com";
+$p isa person,
+    has full-name $fn,
+    has email $e;
+$fn contains "Kevin";
+$e = "kevin@gmail.com";
 delete $p has $e;
 insert $p has email "kevin2@gmail.com";
 ----
@@ -221,11 +221,11 @@ for every person with a full name that contains "Kevin":
 [,typeql]
 ----
 match
-    $p isa person,
-        has full-name $fn,
-        has email $e;
-    $fn contains "Kevin";
-    $e = "kevin2@gmail.com";
+$p isa person,
+    has full-name $fn,
+    has email $e;
+$fn contains "Kevin";
+$e = "kevin2@gmail.com";
 delete $p has $e;
 ----
 


### PR DESCRIPTION
## What is the goal of this PR?

Update TypeDB in 25 queries page for 2.25 version Get queries.

## What are the changes implemented in this PR?

Add `get` clause to every Get query.
Fix indentation in TypeQL.
Fix the order of types in Define queries.