### PR TITLE
2.25.6 installation update

### DIFF
--- a/home-src/modules/ROOT/pages/install.adoc
+++ b/home-src/modules/ROOT/pages/install.adoc
@@ -7,11 +7,9 @@
 
 == TypeDB Enterprise and Cloud
 
-Contact our mailto:sales@vaticle.com[sales team] to get your license for TypeDB Enterprise
-or deploy your database through https://cloud.typedb.com/[TypeDB Cloud,window=_blank].
-
-//Use the xref:typedb:ROOT:admin/enterprise-deployment.adoc[] guide
-//to install and deploy a TypeDB Enterprise cluster with Kubernetes.
+To deploy through TypeDB Cloud, proceed to https://cloud.typedb.com/[cloud.typedb.com,window=_blank].
+To get your TypeDB Enterprise licence for an on-premises solution, contact our mailto:sales@vaticle.com[sales team]
+and follow the installation guide on the xref:typedb::admin/enterprise-deployment.adoc[Enterprise Deployment] page.
 
 [#_core]
 == TypeDB Core

--- a/home-src/modules/ROOT/pages/install.adoc
+++ b/home-src/modules/ROOT/pages/install.adoc
@@ -8,8 +8,8 @@
 == TypeDB Enterprise and Cloud
 
 To deploy through TypeDB Cloud, proceed to https://cloud.typedb.com/[cloud.typedb.com,window=_blank].
-To get your TypeDB Enterprise licence for an on-premises solution, contact our mailto:sales@vaticle.com[sales team]
-and follow the installation guide on the xref:typedb::admin/enterprise-deployment.adoc[Enterprise Deployment] page.
+To deploy TypeDB Enterprise, contact our mailto:sales@vaticle.com[sales team] and see the
+xref:typedb::admin/enterprise-deployment.adoc[Enterprise Deployment] page.
 
 [#_core]
 == TypeDB Core

--- a/home-src/modules/ROOT/partials/linux.adoc
+++ b/home-src/modules/ROOT/partials/linux.adoc
@@ -8,11 +8,6 @@ sudo apt install software-properties-common apt-transport-https gpg
 gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 8F3DA4B5E9AEF44C
 gpg --export 8F3DA4B5E9AEF44C | sudo tee /etc/apt/trusted.gpg.d/vaticle.gpg > /dev/null
 echo "deb https://repo.vaticle.com/repository/apt/ trusty main" | sudo tee /etc/apt/sources.list.d/vaticle.list > /dev/null
-----
-. Update the package cache:
-+
-[,bash]
-----
 sudo apt update
 ----
 . Ensure Java 11+ is installed:
@@ -25,6 +20,8 @@ sudo apt install openjdk-11-jre
 +
 TypeDB supports https://jdk.java.net[OpenJDK,window=_blank] and
 https://www.oracle.com/java/technologies/downloads/#java11[Oracle JDK,window=_blank].
++
+////
 . Check the latest version number for `typedb-server` and its dependencies:
 +
 [,bash]
@@ -52,18 +49,27 @@ Take note of the latest `typedb-server` version in the `Version` field and the c
 package version in the `Depends` field.
 The `typedb-console` version can be seen with the command `apt show typedb-all=2.15.0`, where `2.15.0` is the version
 of `typedb-server` from the output above.
-. Install `typedb-server`, `typedb-console`, and `typedb-bin` packages using the versions from the previous commands:
+////
+. Install `typedb`:
 +
 [,bash]
 ----
-sudo apt install typedb-server=2.15.0 typedb-console=2.15.0 typedb-bin=2.12.0
+sudo apt install typedb
 ----
-
++
+If you had an older version (≤`2.25.5`) of TypeDB installed, it might be needed to uninstall older packages to avoid
+conflicts:
++
+[,bash]
+----
+sudo apt remove typedb-server typedb-bin typedb-console
+----
+////
 The `typedb-server` and `typedb-console` packages are updated more often than `typedb-bin`, so their
 version numbers might differ. By default, APT will look for the exact same version of `typedb-bin`,
 resulting in an error. To prevent this, use `apt show`, as shown above, to find a compatible version first, and then
 invoke an `apt install` command with the specific version for every package.
-
+////
 // end::install-apt[]
 
 // tag::manual-install[]

--- a/typedb-src/antora.yml
+++ b/typedb-src/antora.yml
@@ -3,7 +3,7 @@ title: TypeDB
 version: 2.x
 asciidoc:
   attributes:
-    latest-version: x86_64-2.24.17@
+    latest-version: x86_64-2.25.6@
 nav:
 - modules/ROOT/nav.adoc
 start_page: typedb::overview.adoc

--- a/typedb-src/modules/resources/partials/all-versions.adoc
+++ b/typedb-src/modules/resources/partials/all-versions.adoc
@@ -1,4 +1,12 @@
 
+| https://github.com/vaticle/typedb/releases/tag/2.25.6[2.25.6]
+| https://github.com/vaticle/typedb/releases/download/2.25.6/typedb-all-mac-x86_64-2.25.6.zip[x86_64] / https://github.com/vaticle/typedb/releases/download/2.25.6/typedb-all-mac-arm64-2.25.6.zip[arm64]
+// Check: PASSED PASSED 
+| https://github.com/vaticle/typedb/releases/download/2.25.6/typedb-all-linux-x86_64-2.25.6.tar.gz[x86_64] / https://github.com/vaticle/typedb/releases/download/2.25.6/typedb-all-linux-arm64-2.25.6.tar.gz[arm64]
+// Check: PASSED PASSED 
+| https://github.com/vaticle/typedb/releases/download/2.25.6/typedb-all-windows-x86_64-2.25.6.zip[x86_64]
+// Check: PASSED
+
 | https://github.com/vaticle/typedb/releases/tag/2.25.0[2.25.0]
 | https://github.com/vaticle/typedb/releases/download/2.25.0/typedb-all-mac-x86_64-2.25.0.zip[x86_64] / https://github.com/vaticle/typedb/releases/download/2.25.0/typedb-all-mac-arm64-2.25.0.zip[arm64]
 // Check: PASSED PASSED 

--- a/typedb-src/modules/resources/partials/latest-version.adoc
+++ b/typedb-src/modules/resources/partials/latest-version.adoc
@@ -1,17 +1,17 @@
 
-| https://github.com/vaticle/typedb/releases/tag/2.25.0[2.25.0]
+| https://github.com/vaticle/typedb/releases/tag/2.25.6[2.25.6]
 |
 // tag::mac[]
-https://github.com/vaticle/typedb/releases/download/2.25.0/typedb-all-mac-x86_64-2.25.0.zip[x86_64] / https://github.com/vaticle/typedb/releases/download/2.25.0/typedb-all-mac-arm64-2.25.0.zip[arm64]
+https://github.com/vaticle/typedb/releases/download/2.25.6/typedb-all-mac-x86_64-2.25.6.zip[x86_64] / https://github.com/vaticle/typedb/releases/download/2.25.6/typedb-all-mac-arm64-2.25.6.zip[arm64]
 // end::mac[]
 // Check: PASSED PASSED 
 |
 // tag::lin[]
-https://github.com/vaticle/typedb/releases/download/2.25.0/typedb-all-linux-x86_64-2.25.0.tar.gz[x86_64] / https://github.com/vaticle/typedb/releases/download/2.25.0/typedb-all-linux-arm64-2.25.0.tar.gz[arm64]
+https://github.com/vaticle/typedb/releases/download/2.25.6/typedb-all-linux-x86_64-2.25.6.tar.gz[x86_64] / https://github.com/vaticle/typedb/releases/download/2.25.6/typedb-all-linux-arm64-2.25.6.tar.gz[arm64]
 // end::lin[]
 // Check: PASSED PASSED 
 |
 // tag::win[]
-https://github.com/vaticle/typedb/releases/download/2.25.0/typedb-all-windows-x86_64-2.25.0.zip[x86_64]
+https://github.com/vaticle/typedb/releases/download/2.25.6/typedb-all-windows-x86_64-2.25.6.zip[x86_64]
 // end::win[]
 // Check: PASSED


### PR DESCRIPTION
## What is the goal of this PR?

Update Linux installation instructions for the 2.25.6 version update.

## What are the changes implemented in this PR?

Simplified Linux installation with `typedb package`.
Multiple minor optimizations.
Update TypeDB's latest version.
