### PR TITLE
Add the mandatory get warning

### DIFF
--- a/clients-src/modules/resources/pages/downloads.adoc
+++ b/clients-src/modules/resources/pages/downloads.adoc
@@ -58,7 +58,7 @@ include::partial$all-versions.adoc[]
 Rust::
 +
 --
-Please follow the xref:ROOT:rust-driver/overview.adoc#_install[installation guide] to add TypeDB Rust Driver to a
+Please follow the xref:clients:ROOT:rust-driver/overview.adoc#_install[installation guide] to add TypeDB Rust Driver to a
 project/application.
 
 To download TypeDB Rust Driver, you can use any of the following options:
@@ -67,14 +67,14 @@ To download TypeDB Rust Driver, you can use any of the following options:
 - https://crates.io/crates/typedb-driver/[,window=_blank]
 
 For more information on the Driver versions, check the
-xref:ROOT:rust-driver/overview.adoc#_version_compatibility[version compatibility] table and
+xref:clients:ROOT:rust-driver/overview.adoc#_version_compatibility[version compatibility] table and
 https://github.com/vaticle/typedb-driver/releases[release notes,window=_blank].
 --
 
 Python::
 +
 --
-Please follow the xref:ROOT:python-driver/overview.adoc#_install[installation guide] to add TypeDB Python Driver to a
+Please follow the xref:clients:ROOT:python-driver/overview.adoc#_install[installation guide] to add TypeDB Python Driver to a
 project/application.
 
 To download TypeDB Python Driver, you can use any of the following options:
@@ -83,14 +83,14 @@ To download TypeDB Python Driver, you can use any of the following options:
 - https://pypi.org/project/typedb-driver#files[,window=_blank]
 
 For more information on the Driver versions, check the
-xref:ROOT:python-driver/overview.adoc#_version_compatibility[version compatibility] table and
+xref:clients:ROOT:python-driver/overview.adoc#_version_compatibility[version compatibility] table and
 https://github.com/vaticle/typedb-driver/releases[release notes,window=_blank].
 --
 
 Java::
 +
 --
-Please follow the xref:ROOT:java-driver/overview.adoc#_install[installation guide] to add TypeDB Java Driver to a
+Please follow the xref:clients:ROOT:java-driver/overview.adoc#_install[installation guide] to add TypeDB Java Driver to a
 project/application.
 
 Alternatively, you can download TypeDB Java Driver by the following link:
@@ -98,14 +98,14 @@ Alternatively, you can download TypeDB Java Driver by the following link:
 - https://repo.vaticle.com/service/rest/repository/browse/maven/com/vaticle/typedb/typedb-driver/
 
 For more information on the Driver versions, check the
-xref:ROOT:java-driver/overview.adoc#_version_compatibility[version compatibility] table and
+xref:clients:ROOT:java-driver/overview.adoc#_version_compatibility[version compatibility] table and
 https://github.com/vaticle/typedb-driver/releases[release notes,window=_blank].
 --
 
 Node.js::
 +
 --
-Please follow the xref:ROOT:nodejs-driver/overview.adoc#_install[installation guide] to add TypeDB Node.js Driver to a
+Please follow the xref:clients:ROOT:nodejs-driver/overview.adoc#_install[installation guide] to add TypeDB Node.js Driver to a
 project/application.
 
 To download TypeDB Node.js Driver, you can use the following command:
@@ -113,7 +113,7 @@ To download TypeDB Node.js Driver, you can use the following command:
 - `npm install typedb-driver`
 
 For more information on the Driver versions, check the
-xref:ROOT:nodejs-driver/overview.adoc#_version_compatibility[version compatibility] table and
+xref:clients:ROOT:nodejs-driver/overview.adoc#_version_compatibility[version compatibility] table and
 https://github.com/vaticle/typedb-driver/releases[release notes,window=_blank].
 --
 ====

--- a/typeql-src/modules/ROOT/pages/data/fetch.adoc
+++ b/typeql-src/modules/ROOT/pages/data/fetch.adoc
@@ -36,11 +36,11 @@ Fetch queries are written in TypeQL with the following syntax:
 [,typeql]
 ----
 match <pattern>
-fetch (
-    variable [as <label>] ;
-  | variable [as <label>] : [<attribute-type> [as <label>], ...] ;
-  | <subquery-label>      : { <fetch_query> | <get_aggregate_query> } ;
-)
+fetch {
+    variable [as <label>]
+  | variable [as <label>] [: <attribute-type> [as <label>], ...]
+  | <subquery-label>      : { <fetch_query> | <get_aggregate_query> }
+  }; ...
 [<modifiers>]
 ----
 

--- a/typeql-src/modules/ROOT/pages/data/get.adoc
+++ b/typeql-src/modules/ROOT/pages/data/get.adoc
@@ -37,6 +37,12 @@ The variables mentioned in a `get` clause must be bound (set) in a `match` claus
 
 A `get` clause works like a filter for variables in matched answers.
 
+[WARNING]
+====
+Since the `2.25.0` version of TypeDB a `get` clause is mandatory in a Get query.
+To get all variables, use an empty `get` clause without any variables, for example: `get;`.
+====
+
 Modifiers (e.g., `sort`, `group`, etc.) are used at the end of a query.
 
 [#_variables]

--- a/typeql-src/modules/ROOT/pages/data/get.adoc
+++ b/typeql-src/modules/ROOT/pages/data/get.adoc
@@ -33,15 +33,16 @@ For more information on `match` clause patterns, see the
 xref:data/basic-patterns.adoc#_patterns_overview[Pattern syntax] section.
 //#todo update the link after introducing the Match clause page
 
-The variables mentioned in a `get` clause must be bound (set) in a `match` clause of the same query.
-
 A `get` clause works like a filter for variables in matched answers.
+
+The variables mentioned in a `get` clause must be bound (set) in a `match` clause of the same query.
 
 [WARNING]
 ====
 Since the `2.25.0` version of TypeDB a `get` clause is mandatory in a Get query.
-To get all variables, use an empty `get` clause without any variables, for example: `get;`.
 ====
+
+Use the `get;` to get all matched variables.
 
 Modifiers (e.g., `sort`, `group`, etc.) are used at the end of a query.
 

--- a/typeql-src/modules/ROOT/pages/data/get.adoc
+++ b/typeql-src/modules/ROOT/pages/data/get.adoc
@@ -21,12 +21,12 @@ Get queries are written in TypeQL with the following syntax:
 [,bash]
 ----
 match <pattern>
-[get <variable> [(, <variable>)...];]
+[get <variable> [{, <variable>}...];]
 [sort <variable> [asc|desc];]
 [offset <value>;]
 [limit <value>;]
 [group <variable>;]
-[count;] [sum|max|min|mean|median|std <variable>;]
+[count;] [{sum|max|min|mean|median|std <variable>};]
 ----
 
 For more information on `match` clause patterns, see the


### PR DESCRIPTION
## What is the goal of this PR?

Add a warning for the Get query about the `get` clause being mandatory since 2.25.

## What are the changes implemented in this PR?

Add a Warning block to the Get query page.
Fix fetch and get query syntax statements.
Fix links to Driver installation for the top-level installation page.
