### PR TITLE
Remove TypeDB Console package management installation

### DIFF
--- a/home-src/antora.yml
+++ b/home-src/antora.yml
@@ -3,7 +3,7 @@ title: Home
 version: 2.x
 asciidoc:
   attributes:
-    latest-version: x86_64-2.24.17@
+    latest-version: x86_64-2.25.7@
 nav:
 - modules/ROOT/nav.adoc
 start_page: home::overview.adoc

--- a/home-src/modules/ROOT/pages/25-queries.adoc
+++ b/home-src/modules/ROOT/pages/25-queries.adoc
@@ -392,7 +392,7 @@ And then fetches all attributes owned by the user.
 The result should look like the following JSON:
 
 .Inherited attributes result example
-[,json]
+[,js]
 ----
 {
     "Bob": {
@@ -637,7 +637,7 @@ It also has `users` xref:typeql::data/fetch.adoc#_subqueries[subquery] that fetc
 that have a permission to access the matched file.
 
 .Result example
-[,json]
+[,js]
 ----
 {
     "p": { "value": "docs/quickstart-guide.adoc", "value_type": "string", "type": { "label": "path", "root": "attribute" } },

--- a/home-src/modules/ROOT/pages/install.adoc
+++ b/home-src/modules/ROOT/pages/install.adoc
@@ -106,39 +106,6 @@ To install TypeDB Console separately, use the guide below.
 If you are not sure which version of TypeDB Console you need,
 check the xref:clients::console.adoc#_version_compatibility[compatibility table].
 
-[discrete]
-=== Install with a package manager
-
-[tabs]
-====
-macOS::
-+
---
-No package manager available for macOS, use the <<_console_manual>> section below.
---
-
-Linux::
-+
---
-To install TypeDB Console via `apt`:
-
-[,bash]
-----
-sudo apt install typedb-console
-----
---
-
-Windows::
-+
---
-No package manager available for Windows, use the <<_console_manual>> section below.
---
-====
-
-[discrete]
-[#_console_manual]
-=== Download and install manually
-
 [tabs]
 ====
 macOS::
@@ -149,8 +116,8 @@ TypeDB supports https://jdk.java.net[OpenJDK,window=_blank] and
 https://www.oracle.com/java/technologies/downloads/#java11[Oracle JDK,window=_blank].
 
 . Navigate to the https://github.com/vaticle/typedb-console/releases[Releases,window=_blank] page,
-select a required version, download the `typedb-console-mac-x86_64.zip`
-or the `typedb-console-mac-arm64.zip` artifact depending on your architecture.
+select a required version. Depending on your architecture, download the `typedb-console-mac-x86_64`
+or the `typedb-console-mac-arm64` archive.
 
 . Extract the archive with TypeDB Console into a new directory:
 +
@@ -176,8 +143,8 @@ TypeDB supports https://jdk.java.net[OpenJDK,window=_blank] and
 https://www.oracle.com/java/technologies/downloads/#java11[Oracle JDK,window=_blank].
 
 . Navigate to the https://github.com/vaticle/typedb-console/releases[Releases,window=_blank] page,
-select a required version, download the `typedb-console-linux-x86_64.tar.gz`
-or the `typedb-console-linux-arm64.tar.gz` artifact depending on your architecture.
+select a required version. Depending on your architecture, download the `typedb-console-linux-x86_64`
+or the `typedb-console-linux-arm64` archive.
 
 . Extract the archive with TypeDB Console into a new directory:
 +
@@ -203,7 +170,7 @@ TypeDB supports https://jdk.java.net[OpenJDK,window=_blank] and
 https://www.oracle.com/java/technologies/downloads/#java11[Oracle JDK,window=_blank].
 
 . Navigate to the https://github.com/vaticle/typedb-console/releases[Releases,window=_blank] page,
-select a required version, download the `typedb-console-windows-x86_64.zip` artifact for the selected version.
+select a required version, download the `typedb-console-windows-x86_64` archive.
 
 . Extract the archive with TypeDB Console into a new directory:
 +


### PR DESCRIPTION
## What is the goal of this PR?

Remove the package management option for TypeDB Console from the Install page.

## What are the changes implemented in this PR?

Removed the section and updated the structure.
Minor wording and syntax highlighting fixes.

