### PR TITLE
Add Rust announcement, adjust first login

### DIFF
--- a/home-src/modules/ROOT/pages/install.adoc
+++ b/home-src/modules/ROOT/pages/install.adoc
@@ -6,6 +6,8 @@
 :tabs-sync-option:
 :experimental:
 
+include::home::overview.adoc[tag=rust-rewrite]
+
 == TypeDB Cloud
 
 image::cloud-hero.png[TypeDB Cloud hero image, role=framed, width = 75%, window=_blank, link=https://cloud.typedb.com/]

--- a/home-src/modules/ROOT/pages/overview.adoc
+++ b/home-src/modules/ROOT/pages/overview.adoc
@@ -5,6 +5,18 @@
 
 Welcome to the TypeDB, TypeQL and TypeDB Clients technical documentation.
 
+// tag::rust-rewrite[]
+[NOTE]
+====
+TypeDB & TypeQL are in the process of being ported over and rewritten in Rust.
+There will be changes that won't be backwards compatible,
+as we refine the language further to extend its expressivity,
+as well as changes to the byte storage data structure to further boost performance significantly.
+We're aiming to complete this by February/March 2024,
+released as TypeDB 3.0, along with preliminary benchmarks of TypeDB.
+====
+// end::rust-rewrite[]
+
 == Home
 //home?
 

--- a/home-src/modules/ROOT/pages/overview.adoc
+++ b/home-src/modules/ROOT/pages/overview.adoc
@@ -18,7 +18,6 @@ released as TypeDB 3.0, along with preliminary benchmarks of TypeDB.
 // end::rust-rewrite[]
 
 == Home
-//home?
 
 //* xref:home::what-is-typedb.adoc[]
 * xref:home::install.adoc[] -- download and install TypeDB and TypeDB Clients

--- a/home-src/modules/ROOT/pages/quickstart.adoc
+++ b/home-src/modules/ROOT/pages/quickstart.adoc
@@ -50,7 +50,7 @@ Click btn:[Connect to TypeDB] on the right side of the top toolbar.
 
 [IMPORTANT]
 =====
-If you are using TypeDB Cloud/Enterprise: remember to
+If you are using TypeDB Cloud/Enterprise:
 xref:typedb::managing/user-management.adoc#_first_login[change the default password] before going any further.
 =====
 

--- a/home-src/modules/ROOT/pages/quickstart.adoc
+++ b/home-src/modules/ROOT/pages/quickstart.adoc
@@ -8,6 +8,8 @@
 
 This Quickstart guide shows how to set up a TypeDB database and run queries.
 
+include::home::overview.adoc[tag=rust-rewrite]
+
 == Run TypeDB
 
 To start TypeDB, select the TypeDB edition below and follow the instructions.
@@ -46,6 +48,12 @@ Click btn:[Connect to TypeDB] on the right side of the top toolbar.
 
 //image::quickstart-studio.png[TypeDB Studio, width = 75%, link=self]
 
+[IMPORTANT]
+=====
+If you are using TypeDB Cloud/Enterprise: remember to
+xref:typedb::managing/user-management.adoc#_first_login[change the default password] before going any further.
+=====
+
 [tabs]
 ====
 Cloud::
@@ -60,12 +68,6 @@ Close the Address management window.
 . Fill in the `Username` (default: `admin`) and `Password` (default: `password`) fields.
 . Turn on the `Enable TLS` option and leave the `CA Certificate` field empty.
 . Click `Connect`.
-
-[IMPORTANT]
-=====
-Don't forget to change the default username and password.
-You can use xref:typedb::managing/user-management.adoc#_current_user_password[TypeDB Console] to do that.
-=====
 --
 
 Enterprise::
@@ -80,12 +82,6 @@ Close the Address management window.
 . Fill in the `Username` (default: `admin`) and `Password` (default: `password`) fields.
 . Turn on the `Enable TLS` option and select the CA certificate for your on-premise cluster.
 . Click `Connect`.
-
-[IMPORTANT]
-=====
-Don't forget to change the default username and password.
-You can use xref:typedb::managing/user-management.adoc#_current_user_password[TypeDB Console] to do that.
-=====
 --
 
 Core::

--- a/typedb-src/modules/ROOT/pages/managing/user-management.adoc
+++ b/typedb-src/modules/ROOT/pages/managing/user-management.adoc
@@ -30,6 +30,7 @@ xref:drivers::nodejs/api-reference.adoc#_UserManager[Node.js] API Reference page
 
 The First thing you need to do is to change the default admin password:
 
+[caption="step"]
 1. Connect with TypeDB Console (see above).
 Use the default credentials to do so:
 +

--- a/typedb-src/modules/ROOT/pages/managing/user-management.adoc
+++ b/typedb-src/modules/ROOT/pages/managing/user-management.adoc
@@ -25,18 +25,28 @@ xref:drivers::rust/api-reference.adoc#_struct_UserManager[Rust],
 xref:drivers::java/api-reference.adoc#_UserManager[Java],
 xref:drivers::nodejs/api-reference.adoc#_UserManager[Node.js] API Reference pages.
 
-[#_default_credentials]
-== Default credentials
+[#_first_login]
+== Change password on first login
 
-By default, all TypeDB Cloud deployments and TypeDB Enterprise installations have only one account:
+The First thing you need to do is to change the default admin password:
 
+1. Connect with TypeDB Console (see above).
+Use the default credentials to do so:
++
 * Username: `admin`
 * Password: `password`
+2. Change the password for the default `admin` user:
++
+[,bash]
+----
+user password-update
+----
 
+By default, all TypeDB Cloud deployments and TypeDB Enterprise installations have only one account: `admin`.
 This is the administrator account with maximum privileges.
 Only this account can use most of the user management features, including creating new users.
 
-[NOTE]
+[WARNING]
 ====
 In TypeDB Cloud, you must change the administrator's password to something different from the default value.
 Until you change the password, you cannot perform *any* operations other than changing the password.
@@ -45,7 +55,7 @@ Until you change the password, you cannot perform *any* operations other than ch
 == Operations
 
 The <<_current_user_password>> operation is available for any user.
-All other user management operations are restricted to the built-in <<_default_credentials,administrator>> account only.
+All other user management operations are restricted to the built-in `admin` account only.
 
 [#_list_all_users]
 === List all users


### PR DESCRIPTION
## What is the goal of this PR?

Add an info block on Rust rewrite and potential breaking changes.
Adjust our messaging of changing the admin password on the first login.

## What are the changes implemented in this PR?

Added the Rust rewrite announcement block to the home-overview and included it on the Install and Quickstart pages.
Changed the Default credential section to Change password on first login. 
Adjusted content to be a step-by-step guide.
Adjusted the change password warning in the Quickstart guide and moved it before the Connecting tab.
