### PR TITLE
Fix Cloud server launch and Console connect to Core

### DIFF
--- a/typedb-src/modules/ROOT/pages/connecting/overview.adoc
+++ b/typedb-src/modules/ROOT/pages/connecting/overview.adoc
@@ -39,14 +39,20 @@ TypeDB Console::
 .Connect to TypeDB Core
 [,bash]
 ----
-typedb console --core=127.0.0.1:1729
+typedb console
 ----
+
+By default, TypeDB Console connects to your local TypeDB Core installation with the `localhost:1729` address.
+To connect to a different address use the `--core` argument followed by a TypeDB server IP address and port,
+for example, `typedb console --core=10.1.2.3:1729`.
 
 .Connect to TypeDB Cloud
 [,bash]
 ----
-typedb console --cloud=127.0.0.1:1729 --username=admin --password --tls-enabled=true
+typedb console --cloud=10.1.2.3:1729 --username=admin --password --tls-enabled=true
 ----
+Use `--cloud` argument to select address and port to connect to a TypeDB Cloud cluster.
+
 For more information on CLI commands, see the xref:typedb::connecting/console.adoc[] page.
 --
 

--- a/typedb-src/modules/ROOT/pages/managing/self-hosted-deployment.adoc
+++ b/typedb-src/modules/ROOT/pages/managing/self-hosted-deployment.adoc
@@ -101,7 +101,7 @@ To start TypeDB Cloud manually:
 +
 [,bash]
 ----
-./typedb cloud
+./typedb server
 ----
 
 Now TypeDB Cloud should show a welcome screen with its version, address, and bootup time.
@@ -175,7 +175,7 @@ To run TypeDB server #1:
 
 [,bash]
 ----
-./typedb cloud \
+./typedb server \
     --server.address=10.0.0.1:1729 \
     --server.internal-address.zeromq=10.0.0.1:1730 \
     --server.internal-address.grpc=10.0.0.1:1731 \
@@ -199,7 +199,7 @@ To run TypeDB server #2:
 
 [,bash]
 ----
-./typedb cloud \
+./typedb server \
     --server.address=10.0.0.2:1729 \
     --server.internal-address.zeromq=10.0.0.2:1730 \
     --server.internal-address.grpc=10.0.0.2:1731 \
@@ -223,7 +223,7 @@ To run TypeDB server #3:
 
 [,bash]
 ----
-./typedb cloud \
+./typedb server \
     --server.address=10.0.0.3:1729 \
     --server.internal-address.zeromq=10.0.0.3:1730 \
     --server.internal-address.grpc=10.0.0.3:1731 \
@@ -253,7 +253,7 @@ The relevant external hostname should be passed as arguments using the `--server
 
 [,bash]
 ----
-./typedb cloud \
+./typedb server \
     --server.address=external-host-1:1729 \
     --server.internal-address.zeromq=10.0.0.1:1730 \
     --server.internal-address.grpc=10.0.0.1:1731 \


### PR DESCRIPTION
## What is the goal of this PR?

Fix some minor issues with CLI commands.

## What are the changes implemented in this PR?

Fix commands to run TypeDB Cloud and shorten a command to connect to TypeDB Core with TypeDB Console.