### PR TITLE
2.26.3 TypeDB release update - Diagnostics

### DIFF
--- a/drivers-src/modules/ROOT/pages/cpp/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/cpp/overview.adoc
@@ -70,9 +70,9 @@ include::../java/overview.adoc[tag=questions]
 |===
 | C++ driver | Protocol encoding version | TypeDB Core | TypeDB Cloud | C++
 
-| 2.26.1
+| 2.26.3
 | 3
-| 2.26.0
+| 2.26.3
 | 2.26.0
 | https://www.iso.org/standard/68564.html[17]
 |===

--- a/drivers-src/modules/ROOT/pages/java/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/java/overview.adoc
@@ -120,9 +120,9 @@ Learn to use native Java syntax to build TypeQL queries with xref:java/query-bui
 |===
 | Java driver | Protocol encoding version | TypeDB Core | TypeDB Cloud
 
-| 2.26.1
+| 2.26.3
 | 3
-| 2.26.0
+| 2.26.3
 | 2.26.0
 
 | 2.25.8

--- a/drivers-src/modules/ROOT/pages/nodejs/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/nodejs/overview.adoc
@@ -58,9 +58,9 @@ include::../java/overview.adoc[tag=questions]
 |===
 | Node.js driver | Protocol encoding version | TypeDB Core | TypeDB Cloud | Node
 
-| 2.26.1
+| 2.26.3
 | 3
-| 2.26.0
+| 2.26.3
 | 2.26.0
 | >= 14.15
 

--- a/drivers-src/modules/ROOT/pages/python/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/python/overview.adoc
@@ -61,9 +61,9 @@ include::../java/overview.adoc[tag=questions]
 |===
 | Python driver | Protocol encoding version | TypeDB Core | TypeDB Cloud | Python
 
-| 2.26.1
+| 2.26.3
 | 3
-| 2.26.0
+| 2.26.3
 | 2.26.0
 | 3.9 to 3.11
 

--- a/drivers-src/modules/ROOT/pages/rust/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/rust/overview.adoc
@@ -71,9 +71,9 @@ include::../java/overview.adoc[tag=questions]
 |===
 | Rust driver | Protocol encoding version | TypeDB Core | TypeDB Cloud | Rust
 
-| 2.26.1
+| 2.26.3
 | 3
-| 2.26.0
+| 2.26.3
 | 2.26.0
 | 1.68.0+
 

--- a/typedb-src/modules/ROOT/pages/connecting/console.adoc
+++ b/typedb-src/modules/ROOT/pages/connecting/console.adoc
@@ -511,9 +511,9 @@ Database 'test' deleted
 |===
 | TypeDB Console | Protocol encoding version | TypeDB Core | TypeDB Cloud
 
-| 2.26.0
+| 2.26.3
 | 3
-| 2.26.0
+| 2.26.3
 | 2.26.0
 
 | 2.25.7

--- a/typedb-src/modules/ROOT/pages/connecting/console.adoc
+++ b/typedb-src/modules/ROOT/pages/connecting/console.adoc
@@ -184,6 +184,10 @@ Default value: `localhost:1729`. +
 | `--version`
 | `-V`
 | Print version information and exit.
+
+| `--diagnostics-disable=true`
+|
+| Disable anonymous error reporting.
 |===
 
 === Scripting

--- a/typedb-src/modules/ROOT/pages/managing/configuration.adoc
+++ b/typedb-src/modules/ROOT/pages/managing/configuration.adoc
@@ -63,7 +63,7 @@ For any change in the configuration file to take effect, restart the TypeDB serv
 ====
 
 [#_the_default_location_of_the_config_file]
-=== The default location of the config file
+=== Config file location
 
 TypeDB ships with a default configuration file. The location of this file varies based on how TypeDB has been installed.
 
@@ -91,41 +91,52 @@ Here is a sample configuration file for TypeDB:
 ----
 server:
   address: 0.0.0.0:1729
+
 storage:
   data: server/data
   database-cache:
     # configure storage-layer data and index cache per database
-    # it is recommended to keep these at equal sizes
+    # for large datasets, it is more important to have a large index cache than a large data cache
     data: 500mb
     index: 500mb
+
 log:
   output:
-    stdout:   # note: this is a user-defined name
+    stdout:
       type: stdout
-    file:     # note: this is a user-defined name
+    file:
       type: file
       base-dir: server/logs
       file-size-limit: 50mb
       archive-grouping: month
       archive-age-limit: 1 year
       archives-size-limit: 1gb
+
   logger:
-    default:  # note: the default logger must be defined
+    default:
       level: warn
       output: [ stdout, file ]
-    typedb:   # note: this is a user-defined name
+    typedb:
       filter: com.vaticle.typedb.core
       level: info
       output: [ stdout, file ]
     storage:
       filter: com.vaticle.typedb.core.database
-      level: info
+      level: info # on 'debug' the server will periodically log database storage properties
       output: [ stdout, file ]
   debugger:
-    reasoner: # note: this is a user-defined name
+    reasoner-tracer:
       enable: false
       type: reasoner-tracer
       output: file
+    reasoner-perf-counters:
+      enable: false
+      type: reasoner-perf-counters
+
+diagnostics:
+  reporting:
+    enable: true
+
 vaticle-factory:
   enable: false
 ----
@@ -292,8 +303,29 @@ log:
 ====
 ////
 
+=== Diagnostics
+
+We implement completely anonymous diagnostics reporting in TypeDB Core using Sentry.
+This includes sending unexpected errors and occasional (daily) system status updates for number and size of databases
+to the backend reporting system.
+////
+We also submit occasional system status updates for number of databases/database size (daily)
+and periodically profile a transaction.
+This instrumentation should help get real-world usage and error analysis to help guide the development
+and efforts in TypeDB.
+////
+
+To disable error and diagnostic reporting set the `diagnostics.reporting.enabled` to false in the config file:
+
+[,yml]
+----
+diagnostics:
+  reporting:
+    enable: false
+----
+
 [#_configuration_file_options_via_command_line_arguments]
-== Configuration file options via command line arguments
+== Command line arguments
 
 Use command line arguments to override any option in the configuration file.
 

--- a/typedb-src/modules/ROOT/pages/managing/configuration.adoc
+++ b/typedb-src/modules/ROOT/pages/managing/configuration.adoc
@@ -305,7 +305,7 @@ log:
 
 === Diagnostics
 
-We implement completely anonymous diagnostics reporting in TypeDB Core using Sentry.
+We implement completely anonymous diagnostics reporting in TypeDB Core using https://sentry.io/[Sentry].
 This includes sending unexpected errors and occasional (daily) system status updates for number and size of databases
 to the backend reporting system.
 ////


### PR DESCRIPTION
## What is the goal of this PR?

Update docs for the 2.26.3 release of TypeDB Core and TypeDB Console.

## What are the changes implemented in this PR?

Update Compatibility tables.
Add diagnostics to the Config file.
Add diagnostics to the Console arguments.