### PR TITLE
Repo.vaticle.com migration

### DIFF
--- a/drivers-src/modules/ROOT/pages/java/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/java/overview.adoc
@@ -31,8 +31,8 @@ Be sure to replace the `\{version}` placeholder tag with the version of the Java
 
 <repositories>
     <repository>
-        <id>repo.vaticle.com</id>
-        <url>https://repo.vaticle.com/repository/maven/</url>
+        <id>repo.typedb.com</id>
+        <url>https://repo.typedb.com/public/public-release/maven/</url>
     </repository>
 </repositories>
 <dependencies>
@@ -42,21 +42,6 @@ Be sure to replace the `\{version}` placeholder tag with the version of the Java
     <version>{version}</version>
 </dependency>
 </dependencies>
-----
-
-If we want to depend on snapshot versions of Client Java, by referring to the GitHub commit `sha`, we can add our
-snapshot repository to our list of Maven repositories.
-
-[,xml]
-----
-
-<repositories>
-    <repository>
-        <id>repo.vaticle.com.snapshot</id>
-        <name>repo.vaticle.comai</name>
-        <url>https://repo.vaticle.com/repository/maven-snapshot/</url>
-    </repository>
-</repositories>
 ----
 
 === (Optional) Add logging config

--- a/drivers-src/modules/ROOT/pages/java/query-builder.adoc
+++ b/drivers-src/modules/ROOT/pages/java/query-builder.adoc
@@ -10,18 +10,18 @@ To use TypeQL, we first add it as a dependency to our `pom.xml`.
 
 [IMPORTANT]
 ====
-Don't forget to replace the `\{version}` placeholder with exact version of the library.
+Don't forget to replace the `\{version}` placeholder with an exact version of the library.
 ====
 
 The latest version of `typeql-lang` can be found in the
-https://repo.vaticle.com/#browse/browse:maven:com%2Fvaticle%2Ftypeql%2Ftypeql-lang[Vaticle's public Maven repository,window=_blank].
+https://cloudsmith.io/~typedb/repos/public-release/packages/detail/maven/typeql-lang/latest/a=noarch;xg=com.vaticle.typeql/#versions[Vaticle's public Maven repository,window=_blank].
 
 [,xml]
 ----
 <repositories>
     <repository>
-        <id>repo.vaticle.com</id>
-        <url>https://repo.vaticle.com/repository/maven/</url>
+        <id>repo.typedb.com</id>
+        <url>https://repo.typedb.com/public/public-release/maven/</url>
     </repository>
 </repositories>
 <dependencies>

--- a/drivers-src/modules/resources/pages/downloads.adoc
+++ b/drivers-src/modules/resources/pages/downloads.adoc
@@ -58,7 +58,7 @@ include::partial$all-versions.adoc[]
 Rust::
 +
 --
-Please follow the xref:drivers:ROOT:rust/overview.adoc#_install_rust[installation guide] to add TypeDB Rust driver to a
+Use the xref:drivers:ROOT:rust/overview.adoc#_install_rust[installation guide] to add TypeDB Rust driver to a
 project/application.
 
 To download TypeDB Rust driver, you can use any of the following options:
@@ -74,7 +74,7 @@ https://github.com/vaticle/typedb-driver/releases[release notes,window=_blank].
 Python::
 +
 --
-Please follow the xref:drivers:ROOT:python/overview.adoc#_install_python[installation guide] to add TypeDB Python driver to a
+Use the xref:drivers:ROOT:python/overview.adoc#_install_python[installation guide] to add TypeDB Python driver to a
 project/application.
 
 To download TypeDB Python driver, you can use any of the following options:
@@ -90,12 +90,12 @@ https://github.com/vaticle/typedb-driver/releases[release notes,window=_blank].
 Java::
 +
 --
-Please follow the xref:drivers:ROOT:java/overview.adoc#_install_java[installation guide] to add TypeDB Java driver to a
+Use the xref:drivers:ROOT:java/overview.adoc#_install_java[installation guide] to add TypeDB Java driver to a
 project/application.
 
 Alternatively, you can download TypeDB Java driver by the following link:
 
-- https://repo.vaticle.com/service/rest/repository/browse/maven/com/vaticle/typedb/typedb-driver/
+- https://cloudsmith.io/~typedb/repos/public-release/packages/detail/maven/typedb-driver/latest/a=noarch;xg=com.vaticle.typedb/#versions[cloudsmith.io/~typedb/repos/public-release/packages/detail/maven/typedb-driver]
 
 For more information on the driver versions, check the
 xref:drivers:ROOT:java/overview.adoc#_version_compatibility[version compatibility] table and
@@ -105,7 +105,7 @@ https://github.com/vaticle/typedb-driver/releases[release notes,window=_blank].
 Node.js::
 +
 --
-Please follow the xref:drivers:ROOT:nodejs/overview.adoc#_install_nodejs[installation guide] to add TypeDB Node.js driver to a
+Use the xref:drivers:ROOT:nodejs/overview.adoc#_install_nodejs[installation guide] to add TypeDB Node.js driver to a
 project/application.
 
 To download TypeDB Node.js driver, you can use the following command:

--- a/home-src/modules/ROOT/partials/linux.adoc
+++ b/home-src/modules/ROOT/partials/linux.adoc
@@ -5,9 +5,9 @@
 [,bash]
 ----
 sudo apt install software-properties-common apt-transport-https gpg
-gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 8F3DA4B5E9AEF44C
-gpg --export 8F3DA4B5E9AEF44C | sudo tee /etc/apt/trusted.gpg.d/vaticle.gpg > /dev/null
-echo "deb https://repo.vaticle.com/repository/apt/ trusty main" | sudo tee /etc/apt/sources.list.d/vaticle.list > /dev/null
+gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 17507562824cfdcc
+gpg --export 17507562824cfdcc | sudo tee /etc/apt/trusted.gpg.d/vaticle.gpg > /dev/null
+echo "deb https://repo.typedb.com/public/public-release/deb/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/vaticle.list > /dev/null
 sudo apt update
 ----
 . Ensure Java 11+ is installed:
@@ -19,36 +19,6 @@ sudo apt install default-jre
 +
 TypeDB supports https://jdk.java.net[OpenJDK,window=_blank] and
 https://www.oracle.com/java/technologies/downloads/#java11[Oracle JDK,window=_blank].
-+
-////
-. Check the latest version number for `typedb-server` and its dependencies:
-+
-[,bash]
-----
-apt show typedb-server
-----
-+
-The above command's output:
-+
-[,bash]
-----
-Package: typedb-server
-Version: 2.15.0
-Priority: optional
-Section: contrib/devel
-Maintainer: Vaticle <community@vaticle.com>
-Installed-Size: unknown
-Depends: openjdk-11-jre, typedb-bin (=2.12.0)
-Download-Size: 71.8 MB
-APT-Sources: https://repo.vaticle.com/repository/apt trusty/main all Packages
-Description: TypeDB (server)
-----
-+
-Take note of the latest `typedb-server` version in the `Version` field and the corresponding `typedb-bin`
-package version in the `Depends` field.
-The `typedb-console` version can be seen with the command `apt show typedb-all=2.15.0`, where `2.15.0` is the version
-of `typedb-server` from the output above.
-////
 . Install `typedb`:
 +
 [,bash]

--- a/typedb-src/modules/ROOT/pages/managing/self-hosted-deployment.adoc
+++ b/typedb-src/modules/ROOT/pages/managing/self-hosted-deployment.adoc
@@ -86,7 +86,7 @@ docker stop typedb
 
 Make sure to have access to the main repository https://repo.typedb.com.
 
-Download the latest TypeDB Cloud release, unzip it in a
+https://repo.typedb.com/basic/private-release/raw/[Download] the latest TypeDB Cloud release, unzip it in a
 location on your machine that is easily accessible via terminal.
 
 If TypeDB Cloud doesn't have a distribution you need, please open an issue

--- a/typedb-src/modules/ROOT/pages/managing/self-hosted-deployment.adoc
+++ b/typedb-src/modules/ROOT/pages/managing/self-hosted-deployment.adoc
@@ -84,9 +84,9 @@ docker stop typedb
 [#_manual_download_and_installation]
 === Manual download and installation
 
-Make sure to have access to the main repository https://repo.vaticle.com.
+Make sure to have access to the main repository https://repo.typedb.com.
 
-Download the https://repo.vaticle.com/#browse/browse:private-artifact[latest release], unzip it in a
+Download the latest TypeDB Cloud release, unzip it in a
 location on your machine that is easily accessible via terminal.
 
 If TypeDB Cloud doesn't have a distribution you need, please open an issue

--- a/typedb-src/modules/ROOT/pages/tutorials/sample-app.adoc
+++ b/typedb-src/modules/ROOT/pages/tutorials/sample-app.adoc
@@ -153,8 +153,8 @@ You can specify dependencies in a `pom.xml` file. See an example below.
 
     <repositories>
         <repository>
-            <id>repo.vaticle.com</id>
-            <url>https://repo.vaticle.com/repository/maven/</url>
+            <id>repo.typedb.com</id>
+                <url>https://repo.typedb.com/public/public-release/maven</url>
         </repository>
     </repositories>
 
@@ -162,7 +162,7 @@ You can specify dependencies in a `pom.xml` file. See an example below.
         <dependency>
             <groupId>com.vaticle.typedb</groupId>
             <artifactId>typedb-driver</artifactId>
-            <version>2.25.2</version>
+            <version>2.26.5</version>
         </dependency>
     </dependencies>
 

--- a/typedb-src/modules/ROOT/partials/kubernetes.adoc
+++ b/typedb-src/modules/ROOT/partials/kubernetes.adoc
@@ -24,7 +24,7 @@ Next, add the Vaticle Helm repo:
 
 [,bash]
 ----
-helm repo add vaticle https://repo.vaticle.com/repository/helm/
+helm repo add vaticle https://repo.typedb.com/basic/private-release/helm/charts/
 ----
 
 == Encryption setup (optional)
@@ -56,8 +56,8 @@ The `encryption-gen.jar` generates three directories:
 
 All files from the directory
 named after external domain shall be copied to the proper directory on every server in a cluster.
-By default, they are stored in `/server/conf/encryption` inside the TypeDB Cloud main directory.
-For example, `typedb-cloud-all-mac-x86_64-2.25.12/server/conf/encryption`.
+By default, they are stored inside the TypeDB Cloud's main directory in `/server/conf/encryption`.
+For example, `typedb-cloud-all-mac-{latest-version}/server/conf/encryption`.
 The path to each file is configured in the `encryption` section of the TypeDB Cloud config file.
 
 Once the external and internal certificates are all generated, we can upload it to Kubernetes Secrets.


### PR DESCRIPTION
## What is the goal of this PR?

Update links to Vaticle repo for the new domain name.

## What are the changes implemented in this PR?

repo.vaticle.com => repo.typedb.com
Also, update file paths as the internal structure and repo implementation changed.