### PR TITLE
Update Core install page, Manual API ref links, and update for 2.26.6 release

### DIFF
--- a/drivers-src/modules/resources/partials/.all-versions-generator.py
+++ b/drivers-src/modules/resources/partials/.all-versions-generator.py
@@ -21,6 +21,10 @@ def get_versions(url):
     for json_element in json_data:
         count += 1
         # print(json_element["tag_name"] + ": " + json_element["name"])
+        if "rc" in json_element["name"]:
+            print(str(count) + ": version " + json_element["tag_name"]
+                  + " IGNORED: skipping a release candidate version.")
+            continue
         if ("TypeDB" in json_element["name"]) \
                 and ("TypeDB Workbase" not in json_element["name"]) \
                 and ("alpha" not in json_element["name"]):

--- a/drivers-src/modules/resources/partials/all-versions.adoc
+++ b/drivers-src/modules/resources/partials/all-versions.adoc
@@ -1,4 +1,12 @@
 
+| https://github.com/vaticle/typedb-studio/releases/tag/2.26.6[2.26.6]
+| https://repo.typedb.com/public/public-release/raw/names/typedb-studio-windows-x86_64/versions/2.26.6/typedb-studio-windows-x86_64-2.26.6.exe[x86_x64]
+// Check: manual
+| https://repo.typedb.com/public/public-release/raw/names/typedb-studio-linux-x86_64/versions/2.26.6/typedb-studio-linux-x86_64-2.26.6.tar.gz[x86_x64] / https://repo.typedb.com/public/public-release/raw/names/typedb-studio-linux-arm64/versions/2.26.6/typedb-studio-linux-arm64-2.26.6.tar.gz[arm64]
+// Check: manual
+| https://repo.typedb.com/public/public-release/raw/names/typedb-studio-mac-x86_64/versions/2.26.6/typedb-studio-mac-x86_64-2.26.6.dmg[x86_64] / https://cloudsmith.io/~typedb/repos/public-release/packages/detail/raw/typedb-studio-mac-arm64/2.26.6/[arm64]
+// Check: manual
+
 | https://github.com/vaticle/typedb-studio/releases/tag/2.26.0[2.26.0]
 | https://github.com/vaticle/typedb-studio/releases/download/2.26.0/typedb-studio-windows-x86_64-2.26.0.exe[Download]
 // Check: PASSED

--- a/drivers-src/modules/resources/partials/latest-version.adoc
+++ b/drivers-src/modules/resources/partials/latest-version.adoc
@@ -1,8 +1,8 @@
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.26.0[2.26.0]
-| https://github.com/vaticle/typedb-studio/releases/download/2.26.0/typedb-studio-windows-x86_64-2.26.0.exe[Download]
-// Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.26.0/typedb-studio-linux-x86_64-2.26.0.tar.gz[Download]
-// Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.26.0/typedb-studio-mac-x86_64-2.26.0.dmg[Download]
-// Check: PASSED
+| https://github.com/vaticle/typedb-studio/releases/tag/2.26.6[2.26.6]
+| https://repo.typedb.com/public/public-release/raw/names/typedb-studio-windows-x86_64/versions/2.26.6/typedb-studio-windows-x86_64-2.26.6.exe[x86_x64]
+// Check: manual
+| https://repo.typedb.com/public/public-release/raw/names/typedb-studio-linux-x86_64/versions/2.26.6/typedb-studio-linux-x86_64-2.26.6.tar.gz[x86_x64] / https://repo.typedb.com/public/public-release/raw/names/typedb-studio-linux-arm64/versions/2.26.6/typedb-studio-linux-arm64-2.26.6.tar.gz[arm64]
+// Check: manual
+| https://repo.typedb.com/public/public-release/raw/names/typedb-studio-mac-x86_64/versions/2.26.6/typedb-studio-mac-x86_64-2.26.6.dmg[x86_64] / https://repo.typedb.com/public/public-release/raw/names/typedb-studio-mac-arm64/versions/2.26.6/typedb-studio-mac-arm64-2.26.6.dmg[arm64]
+// Check: manual

--- a/home-src/modules/ROOT/pages/install/console.adoc
+++ b/home-src/modules/ROOT/pages/install/console.adoc
@@ -42,8 +42,8 @@ macOS::
 +
 --
 . Download the latest package for your systems architecture:
-https://github.com/vaticle/typedb-console/releases/download/2.26.5/typedb-console-mac-x86_64.zip[x86/x64] |
-https://github.com/vaticle/typedb-console/releases/download/2.26.5/typedb-console-mac-arm64.zip[arm64]. +
+https://repo.typedb.com/public/public-release/raw/names/typedb-console-mac-x86_64/versions/2.26.6/typedb-console-mac-x86_64-2.26.6.zip[x86/x64] |
+https://repo.typedb.com/public/public-release/raw/names/typedb-console-mac-arm64/versions/2.26.6/typedb-console-mac-arm64-2.26.6.zip[arm64]. +
 For other versions, see the
 https://cloudsmith.io/~typedb/repos/public-release/packages/?q=format%3Araw+name%3A%5Etypedb-console-mac&sort=-version[Downloads repository] page.
 . Extract the archive into a new directory:
@@ -65,8 +65,8 @@ Linux::
 +
 --
 . Download the latest package for your systems architecture:
-https://github.com/vaticle/typedb-console/releases/download/2.26.5/typedb-console-linux-x86_64.tar.gz[x86/x64] |
-https://github.com/vaticle/typedb-console/releases/download/2.26.5/typedb-console-linux-arm64.tar.gz[arm64]. +
+https://repo.typedb.com/public/public-release/raw/names/typedb-console-linux-x86_64/versions/2.26.6/typedb-console-linux-x86_64-2.26.6.tar.gz[x86/x64] |
+https://repo.typedb.com/public/public-release/raw/names/typedb-console-linux-arm64/versions/2.26.6/typedb-console-linux-arm64-2.26.6.tar.gz[arm64]. +
 For other versions, see the
 https://cloudsmith.io/~typedb/repos/public-release/packages/?q=format%3Araw+name%3A%5Etypedb-console-linux&sort=-version[Downloads repository] page.
 . Extract the archive into a new directory:
@@ -89,7 +89,7 @@ Windows::
 +
 --
 . Download the latest package for your systems architecture:
-https://github.com/vaticle/typedb-console/releases/download/2.26.5/typedb-console-windows-x86_64.zip[x86/x64]. +
+https://repo.typedb.com/public/public-release/raw/names/typedb-console-windows-x86_64/versions/2.26.6/typedb-console-windows-x86_64-2.26.6.zip[x86/x64]. +
 For other versions, see the
 https://cloudsmith.io/~typedb/repos/public-release/packages/?q=format%3Araw+name%3A%5Etypedb-console-win&sort=-version[Downloads repository] page.
 
@@ -121,7 +121,7 @@ To run TypeDB Console:
 typedb console
 ----
 
-To learn how to use TypeDB Console, see the xref:manual::console.adoc[] page.
+For more information on how to use TypeDB Console, see the xref:manual::console.adoc[] page.
 
 [#_version_compatibility]
 == Version Compatibility
@@ -130,10 +130,10 @@ To learn how to use TypeDB Console, see the xref:manual::console.adoc[] page.
 |===
 | TypeDB Console | Protocol encoding version | TypeDB Core | TypeDB Cloud
 
-| https://github.com/vaticle/typedb-console/releases/tag/2.26.5[2.26.5]
+| https://github.com/vaticle/typedb-console/releases/tag/2.26.6[2.26.6]
 | 3
-| 2.26.3
-| 2.26.0
+| 2.26.6
+| 2.26.6
 
 | https://github.com/vaticle/typedb-console/releases/tag/2.25.7[2.25.7]
 | 3

--- a/home-src/modules/ROOT/pages/install/core.adoc
+++ b/home-src/modules/ROOT/pages/install/core.adoc
@@ -111,3 +111,33 @@ For a Docker container:
 
 include::home::partial$docker.adoc[tag=stop]
 ////
+
+== Learn more
+
+
+[cols-2]
+--
+.xref:home::install/studio.adoc[]
+[.clickable]
+****
+Install an IDE that facilitates the development process for TypeDB.
+****
+
+.xref:home::quickstart.adoc[]
+[.clickable]
+****
+Learn how to run TypeDB, connect to it, and run queries.
+****
+
+.xref:home::25-queries.adoc[]
+[.clickable]
+****
+Try the features of TypeDB with these carefully selected queries.
+****
+
+.xref:learn::course-overview.adoc[Learning course]
+[.clickable]
+****
+Check out our dedicated Learning course for TypeDB.
+****
+--

--- a/home-src/modules/ROOT/pages/install/studio.adoc
+++ b/home-src/modules/ROOT/pages/install/studio.adoc
@@ -104,10 +104,10 @@ For more information on how to use TypeDB Studio, see the xref:manual::studio.ad
 | TypeDB Core
 | TypeDB Cloud
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.26.0[2.26.0]
+| https://github.com/vaticle/typedb-studio/releases/tag/2.26.6[2.26.6]
 | 3
-| 2.26.3
-| 2.26.0
+| 2.26.6
+| 2.26.6
 
 | https://github.com/vaticle/typedb-studio/releases/tag/2.25.11[2.25.11]
 | 3

--- a/home-src/modules/ROOT/pages/overview.adoc
+++ b/home-src/modules/ROOT/pages/overview.adoc
@@ -135,6 +135,7 @@ user management.
 ****
 --
 
+[#_typedb_drivers]
 == TypeDB drivers
 
 Client-side libraries with native API to connect to TypeDB. +

--- a/manual-src/modules/ROOT/pages/objects/explanation.adoc
+++ b/manual-src/modules/ROOT/pages/objects/explanation.adoc
@@ -158,7 +158,7 @@ C++::
 include::manual::partial$cpp-manual-code.cpp[tag=explain]
 ----
 For more information, see the
-xref:drivers::cpp/api-reference.adoc#_ExplanationIterable_TypeDBQueryManagerexplain_const_Explainable_explainable_const_Options_Options_const[Explain query]
+xref:drivers::cpp/api-reference.adoc#_ExplanationIterable_TypeDBQueryManagerexplain___const_Explainable__explainable__const_Options___Options_____const[Explain query]
 and
 xref:drivers::cpp/api-reference.adoc#_Explainable[Explainable class] methods.
 --

--- a/manual-src/modules/ROOT/pages/objects/overview.adoc
+++ b/manual-src/modules/ROOT/pages/objects/overview.adoc
@@ -1,13 +1,15 @@
 = Programming objects
 //Programming concepts / Stateful objects / Stateful programming
 
-TypeDB can retrieve data by projecting values to JSON objects.
-Alternatively, you can get stateful objects from TypeDB either in response to a Get query or via API methods.
+//TypeDB can retrieve data by projecting values to JSON objects.
 
-See below practical guides on how to use API methods to interact with types, rules, and data from a TypeDB database
-without TypeQL queries.
+You can use ORM-like objects to manipulate schema and data of a TypeDB databases
+and process explanations of inferred data.
+//To get these stateful objects, you can use either TypeQL Get query or driver API methods.
 
-Make sure to xref:home::install/overview.adoc[install] one of the TypeDB drivers before proceeding.
+See below practical guides on how to use stateful schema objects, stateful data objects, and explanation objects.
+
+Make sure to xref:home::install/overview.adoc#_typedb_drivers[install] one of the TypeDB drivers before proceeding.
 
 // tag::nav-blocks[]
 [cols-2]

--- a/manual-src/modules/ROOT/pages/reading/fetch.adoc
+++ b/manual-src/modules/ROOT/pages/reading/fetch.adoc
@@ -34,7 +34,6 @@ fetch
 $u: name, email;
 ----
 . Run the query by clicking the btn:[Run query] button (image:home::studio-icons/run.png[run]).
-. Commit the changes by clicking the btn:[Commit query] button (image:home::studio-icons/commit.png[Commit]).
 --
 
 Console::
@@ -57,11 +56,11 @@ $u: name, email;
 ----
 +
 Push btn:[Enter] twice to send the query.
-. Commit the changes:
+. Close the transaction:
 +
 [,bash]
 ----
-commit
+close
 ----
 --
 ====
@@ -103,10 +102,15 @@ Rust::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `read` transaction, and use the
-xref:drivers::rust/api-reference.adoc#_struct_QueryManager_fetch__[`transaction.query.fetch()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a read transaction, and use the
+xref:drivers::rust/api-reference.adoc#_struct_QueryManager_fetch__[transaction.query.fetch()]
 method:
+++++
 
 [,rust,indent=0]
 ----
@@ -119,10 +123,15 @@ Python::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `read` transaction, and use the
-xref:drivers::python/api-reference.adoc#_QueryManager_fetch__query_str{scores}options_TypeDBOptions__None[`transaction.query.fetch()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a read transaction, and use the
+xref:drivers::python/api-reference.adoc#_QueryManager_fetch__query_str__options_TypeDBOptions__None[transaction.query.fetch()]
 method:
+++++
 
 [,python,indent=0]
 ----
@@ -134,10 +143,15 @@ Java::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `read` transaction, and use the
-xref:drivers::java/api-reference.adoc#_QueryManager_fetch__com_vaticle_typeql_lang_query_TypeQLFetch[`transaction.query.fetch()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a read transaction, and use the
+xref:drivers::java/api-reference.adoc#_QueryManager_fetch__com_vaticle_typeql_lang_query_TypeQLFetch[transaction.query.fetch()]
 method:
+++++
 
 [,java,indent=0]
 ----
@@ -149,10 +163,15 @@ Node.js::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `read` transaction, and use the
-xref:drivers::nodejs/api-reference.adoc#_QueryManager_fetch{scores}query_string__options_TypeDBOptions[`transaction.query.fetch()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a read transaction, and use the
+xref:drivers::nodejs/api-reference.adoc#_QueryManager_fetch__query_string__options_TypeDBOptions[transaction.query.fetch()]
 method:
+++++
 
 [,js,indent=0]
 ----
@@ -164,10 +183,15 @@ C++::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `read` transaction, and use the
-xref:drivers::cpp/api-reference.adoc#_JSONIterable_TypeDBQueryManagerfetch_const_stdstring_query_const_Options_options_Options_const[`transaction.query.fetch()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a read transaction, and use the
+xref:drivers::cpp/api-reference.adoc#_JSONIterable_TypeDBQueryManagerfetch_const_stdstring_query_const_Options_options_Options_const[transaction.query.fetch()]
 method:
+++++
 
 [,cpp,indent=0]
 ----

--- a/manual-src/modules/ROOT/pages/reading/get.adoc
+++ b/manual-src/modules/ROOT/pages/reading/get.adoc
@@ -35,7 +35,6 @@ get
 $u, $e;
 ----
 . Run the query by clicking the btn:[Run query] button (image:home::studio-icons/run.png[run]).
-. Commit the changes by clicking the btn:[Commit query] button (image:home::studio-icons/commit.png[Commit]).
 --
 
 Console::
@@ -58,11 +57,11 @@ $u, $e;
 ----
 +
 Push btn:[Enter] twice to send the query.
-. Commit the changes:
+. Close the transaction:
 +
 [,bash]
 ----
-commit
+close
 ----
 --
 ====
@@ -93,10 +92,15 @@ Rust::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `read` transaction, and use the
-xref:drivers::rust/api-reference.adoc#_struct_QueryManager_get__[`transaction.query().get()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a read transaction, and use the
+xref:drivers::rust/api-reference.adoc#_struct_QueryManager_get__[transaction.query().get()]
 method:
+++++
 
 [,rust,indent=0]
 ----
@@ -109,10 +113,15 @@ Python::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `read` transaction, and use the
-xref:drivers::python/api-reference.adoc#_QueryManager_get{scores}query_str__options_TypeDBOptions__None[`transaction.query.get()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a read transaction, and use the
+xref:drivers::python/api-reference.adoc#_QueryManager_get__query_str__options_TypeDBOptions__None[transaction.query.get()]
 method:
+++++
 
 [,python,indent=0]
 ----
@@ -124,10 +133,15 @@ Java::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `read` transaction, and use the
-xref:drivers::java/api-reference.adoc#_QueryManager_get__com_vaticle_typeql_lang_query_TypeQLGet[`transaction.query().get()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a read transaction, and use the
+xref:drivers::java/api-reference.adoc#_QueryManager_get__com_vaticle_typeql_lang_query_TypeQLGet[transaction.query().get()]
 method:
+++++
 
 [,java,indent=0]
 ----
@@ -139,10 +153,15 @@ Node.js::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `read` transaction, and use the
-xref:drivers::nodejs/api-reference.adoc#_QueryManager_get{scores}query_string__options_TypeDBOptions[`transaction.query.get()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a read transaction, and use the
+xref:drivers::nodejs/api-reference.adoc#_QueryManager_get__query_string__options_TypeDBOptions[transaction.query.get()]
 method:
+++++
 
 [,js,indent=0]
 ----
@@ -154,10 +173,15 @@ C++::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `read` transaction, and use the
-xref:drivers::cpp/api-reference.adoc#_ConceptMapIterable_TypeDBQueryManagerget_const_stdstring_query_const_Options_options_Options_const[`transaction.query.get()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a read transaction, and use the
+xref:drivers::cpp/api-reference.adoc#_ConceptMapIterable_TypeDBQueryManagerget_const_stdstring_query_const_Options_options_Options_const[transaction.query.get()]
 method:
+++++
 
 [,cpp,indent=0]
 ----

--- a/manual-src/modules/ROOT/pages/reading/infer.adoc
+++ b/manual-src/modules/ROOT/pages/reading/infer.adoc
@@ -79,6 +79,12 @@ $u: name;
 ----
 +
 Push btn:[Enter] twice to send the query.
+. Close the transaction:
++
+[,bash]
+----
+close
+----
 --
 ====
 
@@ -125,10 +131,14 @@ Rust::
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
 to connect the `driver` to TypeDB Cloud or TypeDB Core.
-Open a `read` transaction, and use the
-xref:drivers::rust/api-reference.adoc#_struct_QueryManager_fetch__[`transaction.query().fetch()`] or
-xref:drivers::rust/api-reference.adoc#_struct_QueryManager_get__[`transaction.query().get()`]
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a read transaction, and use the
+xref:drivers::rust/api-reference.adoc#_struct_QueryManager_fetch__[transaction.query().fetch()] or
+xref:drivers::rust/api-reference.adoc#_struct_QueryManager_get__[transaction.query().get()]
 method to retrieve data with inference:
+++++
 
 [,rust,indent=0]
 ----
@@ -142,10 +152,14 @@ Python::
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
 to connect the `driver` to TypeDB Cloud or TypeDB Core.
-Open a `read` transaction, and use the
-xref:drivers::python/api-reference.adoc#_QueryManager_fetch{scores}query_str__options_TypeDBOptions__None[`transaction.query.fetch()`] or
-xref:drivers::python/api-reference.adoc#_QueryManager_get{scores}query_str__options_TypeDBOptions__None[`transaction.query.get()`]
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a read transaction, and use the
+xref:drivers::python/api-reference.adoc#_QueryManager_fetch__query_str__options_TypeDBOptions__None[transaction.query.fetch()] or
+xref:drivers::python/api-reference.adoc#_QueryManager_get__query_str__options_TypeDBOptions__None[transaction.query.get()]
 method to retrieve data with inference:
+++++
 
 [,python,indent=0]
 ----
@@ -158,10 +172,14 @@ Java::
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
 to connect the `driver` to TypeDB Cloud or TypeDB Core.
-Open a `read` transaction, and use the
-xref:drivers::java/api-reference.adoc#_QueryManager_fetch__com_vaticle_typeql_lang_query_TypeQLFetch[`transaction.query().fetch()`] or
-xref:drivers::java/api-reference.adoc#_QueryManager_get__com_vaticle_typeql_lang_query_TypeQLGet__TypeDBOptions[`transaction.query().get()`]
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a read transaction, and use the
+xref:drivers::java/api-reference.adoc#_QueryManager_fetch__com_vaticle_typeql_lang_query_TypeQLFetch[transaction.query().fetch()] or
+xref:drivers::java/api-reference.adoc#_QueryManager_get__com_vaticle_typeql_lang_query_TypeQLGet__TypeDBOptions[transaction.query().get()]
 method to retrieve data with inference:
+++++
 
 [,java,indent=0]
 ----
@@ -174,10 +192,14 @@ Node.js::
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
 to connect the `driver` to TypeDB Cloud or TypeDB Core.
-Open a `read` transaction, and use the
-xref:drivers::nodejs/api-reference.adoc#_QueryManager_fetch__query_string__options_TypeDBOptions[`transaction.query.fetch()`] or
-xref:drivers::nodejs/api-reference.adoc#_QueryManager_get__query_string__options_TypeDBOptions[`transaction.query.get()`]
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a read transaction, and use the
+xref:drivers::nodejs/api-reference.adoc#_QueryManager_fetch__query_string__options_TypeDBOptions[transaction.query.fetch()] or
+xref:drivers::nodejs/api-reference.adoc#_QueryManager_get__query_string__options_TypeDBOptions[transaction.query.get()]
 method to retrieve data with inference:
+++++
 
 [,js,indent=0]
 ----
@@ -190,10 +212,14 @@ C++::
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
 to connect the `driver` to TypeDB Cloud or TypeDB Core.
-Open a `read` transaction, and use the
-xref:drivers::cpp/api-reference.adoc#_JSONIterable_TypeDBQueryManagerfetch_const_stdstring_query_const_Options_options_Options_const[`transaction.query.fetch()`] or
-xref:drivers::cpp/api-reference.adoc#_ConceptMapIterable_TypeDBQueryManagerget_const_stdstring_query_const_Options_options_Options_const[`transaction.query.get()`]
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a read transaction, and use the
+xref:drivers::cpp/api-reference.adoc#_JSONIterable_TypeDBQueryManagerfetch___const_stdstring__query__const_Options__options__Options_____const[transaction.query.fetch()] or
+xref:drivers::cpp/api-reference.adoc#_ConceptMapIterable_TypeDBQueryManagerget___const_stdstring__query__const_Options__options__Options_____const[transaction.query.get()]
 method to retrieve data with inference:
+++++
 
 [,cpp,indent=0]
 ----

--- a/manual-src/modules/ROOT/pages/writing/delete.adoc
+++ b/manual-src/modules/ROOT/pages/writing/delete.adoc
@@ -79,10 +79,15 @@ Rust::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
-xref:drivers::rust/api-reference.adoc#_struct_QueryManager_delete__[`transaction.query().delete()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
+xref:drivers::rust/api-reference.adoc#_struct_QueryManager_delete__[transaction.query().delete()]
 method:
+++++
 
 [,rust,indent=0]
 ----
@@ -94,10 +99,15 @@ Python::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
-xref:drivers::python/api-reference.adoc#_QueryManager_delete{scores}query_str__options_TypeDBOptions__None[`transaction.query.delete()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
+xref:drivers::python/api-reference.adoc#_QueryManager_delete{scores}query_str__options_TypeDBOptions__None[transaction.query.delete()]
 method:
+++++
 
 [,python,indent=0]
 ----
@@ -109,10 +119,15 @@ Java::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
-xref:drivers::java/api-reference.adoc#_QueryManager_delete__java_lang_String[`transaction.query().delete()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
+xref:drivers::java/api-reference.adoc#_QueryManager_delete__java_lang_String[transaction.query().delete()]
 method:
+++++
 
 [,java,indent=0]
 ----
@@ -124,10 +139,15 @@ Node.js::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
-xref:drivers::nodejs/api-reference.adoc#_QueryManager_delete__query_string__options_TypeDBOptions[`transaction.query.delete()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
+xref:drivers::nodejs/api-reference.adoc#_QueryManager_delete__query_string__options_TypeDBOptions[transaction.query.delete()]
 method:
+++++
 
 [,js, indent=0]
 ----
@@ -139,10 +159,15 @@ C++::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
-xref:drivers::cpp/api-reference.adoc#_VoidFuture_TypeDBQueryManagermatchDelete_const_stdstring_query_const_Options_options_Options_const[`transaction.query.delete()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
+xref:drivers::cpp/api-reference.adoc#_VoidFuture_TypeDBQueryManagermatchDelete___const_stdstring__query__const_Options__options__Options_____const[transaction.query.delete()]
 method:
+++++
 
 [,cpp,indent=0]
 ----

--- a/manual-src/modules/ROOT/pages/writing/insert.adoc
+++ b/manual-src/modules/ROOT/pages/writing/insert.adoc
@@ -76,10 +76,15 @@ Rust::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
-xref:drivers::rust/api-reference.adoc#_struct_QueryManager_insert__[`transaction.query().insert()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
+xref:drivers::rust/api-reference.adoc#_struct_QueryManager_insert__[transaction.query().insert()]
 method:
+++++
 
 [,rust,indent=0]
 ----
@@ -92,10 +97,15 @@ Python::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
-xref:drivers::python/api-reference.adoc#_QueryManager_insert{scores}query_str__options_TypeDBOptions__None[`transaction.query.insert()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
+xref:drivers::python/api-reference.adoc#_QueryManager_insert__query_str__options_TypeDBOptions__None[transaction.query.insert()]
 method:
+++++
 
 [,python,indent=0]
 ----
@@ -107,10 +117,15 @@ Java::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
-xref:drivers::java/api-reference.adoc#_QueryManager_insert__java_lang_String[`transaction.query().insert()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
+xref:drivers::java/api-reference.adoc#_QueryManager_insert__java_lang_String[transaction.query().insert()]
 method:
+++++
 
 [,java,indent=0]
 ----
@@ -122,10 +137,15 @@ Node.js::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
-xref:drivers::nodejs/api-reference.adoc#_QueryManager_insert{scores}query_string__options_TypeDBOptions[`transaction.query.insert()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
+xref:drivers::nodejs/api-reference.adoc#_QueryManager_insert__query_string__options_TypeDBOptions[transaction.query.insert()]
 method:
+++++
 
 [,js,indent=0]
 ----
@@ -137,10 +157,15 @@ C++::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
 xref:drivers::cpp/api-reference.adoc#_ConceptMapIterable_TypeDBQueryManagerinsert_const_stdstring_query_const_Options_options_Options_const[`transaction.query.insert()`]
 method:
+++++
 
 [,cpp,indent=0]
 ----
@@ -210,10 +235,15 @@ Rust::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
-xref:drivers::rust/api-reference.adoc#_struct_QueryManager_insert__[`transaction.query().insert()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
+xref:drivers::rust/api-reference.adoc#_struct_QueryManager_insert__[transaction.query().insert()]
 method:
+++++
 
 [,rust,indent=0]
 ----
@@ -226,10 +256,15 @@ Python::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
-xref:drivers::python/api-reference.adoc#_QueryManager_insert{scores}query_str__options_TypeDBOptions__None[`transaction.query.insert()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
+xref:drivers::python/api-reference.adoc#_QueryManager_insert__query_str__options_TypeDBOptions__None[transaction.query.insert()]
 method:
+++++
 
 [,python,indent=0]
 ----
@@ -241,10 +276,15 @@ Java::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
-xref:drivers::java/api-reference.adoc#_QueryManager_insert__java_lang_String[`transaction.query().insert()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
+xref:drivers::java/api-reference.adoc#_QueryManager_insert__java_lang_String[transaction.query().insert()]
 method:
+++++
 
 [,java,indent=0]
 ----
@@ -256,10 +296,15 @@ Node.js::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
-xref:drivers::nodejs/api-reference.adoc#_QueryManager_insert{scores}query_string__options_TypeDBOptions[`transaction.query.insert()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
+xref:drivers::nodejs/api-reference.adoc#_QueryManager_insert__query_string__options_TypeDBOptions[transaction.query.insert()]
 method:
+++++
 
 [,js,indent=0]
 ----
@@ -271,10 +316,15 @@ C++::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
-xref:drivers::cpp/api-reference.adoc#_ConceptMapIterable_TypeDBQueryManagerinsert_const_stdstring_query_const_Options_options_Options_const[`transaction.query.insert()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
+xref:drivers::cpp/api-reference.adoc#_ConceptMapIterable_TypeDBQueryManagerinsert___const_stdstring__query__const_Options__options__Options_____const[`transaction.query.insert()`]
 method:
+++++
 
 [,cpp,indent=0]
 ----

--- a/manual-src/modules/ROOT/pages/writing/update.adoc
+++ b/manual-src/modules/ROOT/pages/writing/update.adoc
@@ -81,10 +81,15 @@ Rust::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
-xref:drivers::rust/api-reference.adoc#_struct_QueryManager_update__[`transaction.query().delete()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
+xref:drivers::rust/api-reference.adoc#_struct_QueryManager_update__[transaction.query().delete()]
 method:
+++++
 
 [,rust,indent=0]
 ----
@@ -97,10 +102,15 @@ Python::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
 xref:drivers::python/api-reference.adoc#_QueryManager_update{scores}query_str__options_TypeDBOptions__None[`transaction.query.delete()`]
 method:
+++++
 
 [,python,indent=0]
 ----
@@ -112,10 +122,15 @@ Java::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
 xref:drivers::java/api-reference.adoc#_QueryManager_update__com_vaticle_typeql_lang_query_TypeQLUpdate[`transaction.query().delete()`]
 method:
+++++
 
 [,java,indent=0]
 ----
@@ -127,10 +142,15 @@ Node.js::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
 xref:drivers::nodejs/api-reference.adoc#_QueryManager_update{scores}query_string__options_TypeDBOptions[`transaction.query.delete()`]
 method:
+++++
 
 [,js,indent=0]
 ----
@@ -142,10 +162,15 @@ C++::
 +
 --
 Follow the xref:manual::connecting/connection.adoc[connection guide]
-to connect the `driver` to TypeDB Cloud or TypeDB Core, then open a `data` session to the selected database,
-open a `write` transaction, and use the
-xref:drivers::cpp/api-reference.adoc#_ConceptMapIterable_TypeDBQueryManagerupdate_const_stdstring_query_const_Options_Options_const[`transaction.query.delete()`]
+to connect the `driver` to TypeDB Cloud or TypeDB Core.
+
+[subs="macros, post_replacements, replacements"]
+++++
+Open a data session to the selected database,
+open a write transaction, and use the
+xref:drivers::cpp/api-reference.adoc#_ConceptMapIterable_TypeDBQueryManagerupdate___const_stdstring__query__const_Options___Options_____const[`transaction.query.delete()`]
 method:
+++++
 
 [,cpp,indent=0]
 ----

--- a/manual-src/modules/resources/partials/.all-versions-generator.py
+++ b/manual-src/modules/resources/partials/.all-versions-generator.py
@@ -60,6 +60,9 @@ def get_versions(url):
     response = requests.get(f"{url}?per_page=100")
     releases = response.json()
     for release in releases:
+        if "rc" in release["name"]:
+            print("Version " + release["tag_name"] + " IGNORED: skipping a release candidate version.")
+            continue
         if "TypeDB" in release["name"]:
             print("Version " + release["tag_name"] + " will be processed.")
             result.append(get_release_data(release))

--- a/manual-src/modules/resources/partials/all-versions.adoc
+++ b/manual-src/modules/resources/partials/all-versions.adoc
@@ -1,4 +1,12 @@
 
+| https://github.com/vaticle/typedb/releases/tag/2.26.6[2.26.6]
+| https://github.com/vaticle/typedb/releases/download/2.26.6/typedb-all-mac-x86_64-2.26.6.zip[x86_64] / https://github.com/vaticle/typedb/releases/download/2.26.6/typedb-all-mac-arm64-2.26.6.zip[arm64]
+// Check: PASSED PASSED
+| https://github.com/vaticle/typedb/releases/download/2.26.6/typedb-all-linux-x86_64-2.26.6.tar.gz[x86_64] / https://github.com/vaticle/typedb/releases/download/2.26.6/typedb-all-linux-arm64-2.26.6.tar.gz[arm64]
+// Check: PASSED PASSED
+| https://github.com/vaticle/typedb/releases/download/2.26.6/typedb-all-windows-x86_64-2.26.6.zip[x86_64]
+// Check: PASSED
+
 | https://github.com/vaticle/typedb/releases/tag/2.26.3[2.26.3]
 | https://github.com/vaticle/typedb/releases/download/2.26.3/typedb-all-mac-x86_64-2.26.3.zip[x86_64] / https://github.com/vaticle/typedb/releases/download/2.26.3/typedb-all-mac-arm64-2.26.3.zip[arm64]
 // Check: PASSED PASSED

--- a/manual-src/modules/resources/partials/latest-version.adoc
+++ b/manual-src/modules/resources/partials/latest-version.adoc
@@ -1,17 +1,17 @@
 
-| https://github.com/vaticle/typedb/releases/tag/2.26.3[2.26.3]
-|
+| https://github.com/vaticle/typedb/releases/tag/2.26.6[2.26.6]
+| 
 // tag::mac[]
-https://github.com/vaticle/typedb/releases/download/2.26.3/typedb-all-mac-x86_64-2.26.3.zip[x86_64] / https://github.com/vaticle/typedb/releases/download/2.26.3/typedb-all-mac-arm64-2.26.3.zip[arm64]
+https://github.com/vaticle/typedb/releases/download/2.26.6/typedb-all-mac-x86_64-2.26.6.zip[x86_64] / https://github.com/vaticle/typedb/releases/download/2.26.6/typedb-all-mac-arm64-2.26.6.zip[arm64]
 // end::mac[]
 // Check: PASSED PASSED
-|
+| 
 // tag::lin[]
-https://github.com/vaticle/typedb/releases/download/2.26.3/typedb-all-linux-x86_64-2.26.3.tar.gz[x86_64] / https://github.com/vaticle/typedb/releases/download/2.26.3/typedb-all-linux-arm64-2.26.3.tar.gz[arm64]
+https://github.com/vaticle/typedb/releases/download/2.26.6/typedb-all-linux-x86_64-2.26.6.tar.gz[x86_64] / https://github.com/vaticle/typedb/releases/download/2.26.6/typedb-all-linux-arm64-2.26.6.tar.gz[arm64]
 // end::lin[]
 // Check: PASSED PASSED
-|
+| 
 // tag::win[]
-https://github.com/vaticle/typedb/releases/download/2.26.3/typedb-all-windows-x86_64-2.26.3.zip[x86_64]
+https://github.com/vaticle/typedb/releases/download/2.26.6/typedb-all-windows-x86_64-2.26.6.zip[x86_64]
 // end::win[]
 // Check: PASSED


### PR DESCRIPTION
## What is the goal of this PR?

Update TypeDB Core Installation guide.
Update the Manual section for fixing specific API reference links.
Update the docs for the `2.26.6` release.

## What are the changes implemented in this PR?

Add a Learn more section at the end of the TypeDB Core Installation guide.
Update releases and download links for the 2.26.6 version.
Update version download links generator for excluding release candidates.
Minor fixes.