### PR TITLE
Add a filename placeholder in the install guides

### DIFF
--- a/home-src/modules/ROOT/pages/install/console.adoc
+++ b/home-src/modules/ROOT/pages/install/console.adoc
@@ -48,16 +48,18 @@ For other versions, see the
 https://cloudsmith.io/~typedb/repos/public-release/packages/?q=format%3Araw+name%3A%5Etypedb-console-mac&sort=-version[Downloads repository] page.
 . Extract the archive into a new directory:
 +
-[,bash,subs=attributes+]
+[,bash]
 ----
 sudo mkdir /opt/typedb-console
-unzip ~/Downloads/typedb-console-mac-x86_64.zip -d /opt/typedb-console
+unzip ~/Downloads/<filename>.zip -d /opt/typedb-console
 ----
++
+Where `<filename>` is the name of the archive.
 . Add a symlink to the TypeDB Console executable in the `/usr/local/bin` directory:
 +
-[,bash,subs=attributes+]
+[,bash]
 ----
-ln -s /opt/typedb-console/typedb-console-mac-x86_64/typedb /usr/local/bin/typedb
+ln -s /opt/typedb-console/<filename>/typedb /usr/local/bin/typedb
 ----
 --
 
@@ -71,17 +73,18 @@ For other versions, see the
 https://cloudsmith.io/~typedb/repos/public-release/packages/?q=format%3Araw+name%3A%5Etypedb-console-linux&sort=-version[Downloads repository] page.
 . Extract the archive into a new directory:
 +
-[,bash,subs=attributes+]
+[,bash]
 ----
 mkdir /opt/typedb-console
-tar -xzf ~/Downloads/typedb-console-linux-x86_64.tar.gz -C /opt/typedb-console
+tar -xzf ~/Downloads/<filename>.tar.gz -C /opt/typedb-console
 ----
-
++
+Where `<filename>` is the name of the archive.
 . Add a symlink to the TypeDB executable in the `/usr/local/bin` directory:
 +
 [,bash,subs=attributes+]
 ----
-ln -s /opt/typedb-console/typedb-console-linux-x86_64/typedb /usr/local/bin/typedb
+ln -s /opt/typedb-console/<filename>/typedb /usr/local/bin/typedb
 ----
 --
 
@@ -95,17 +98,18 @@ https://cloudsmith.io/~typedb/repos/public-release/packages/?q=format%3Araw+name
 
 . Extract the archive into a new directory:
 +
-[,shell,subs=attributes+]
+[,shell]
 ----
 mkdir "C:\Program Files\TypeDB Console"
-tar xvf "C:\Users\username\Downloads\typedb-console-windows-x86_64.zip" -C "C:\Program Files\TypeDB Console"
+tar xvf "C:\Users\username\Downloads\<filename>.zip" -C "C:\Program Files\TypeDB Console"
 ----
-
++
+Where `<filename>` is the name of the archive.
 . Update the `PATH` environment variable:
 +
-[,shell,subs=attributes+]
+[,shell]
 ----
-setx /M PATH "%path%;C:\Program Files\TypeDB Console\typedb-console-windows-x86_64"
+setx /M PATH "%path%;C:\Program Files\TypeDB Console\<filename>"
 ----
 
 Restart the terminal window for the changes to environment variables to take effect.

--- a/home-src/modules/ROOT/pages/install/studio.adoc
+++ b/home-src/modules/ROOT/pages/install/studio.adoc
@@ -62,17 +62,18 @@ For other versions, see the
 https://cloudsmith.io/~typedb/repos/public-release/packages/?q=name%3A%5Etypedb-studio&sort=-version[Downloads repository] page.
 . Extract the archive with TypeDB Studio into a new directory, for example:
 +
-[,bash,subs=attributes+]
+[,bash]
 ----
 mkdir /opt/typedb-studio
-tar -xzf ~/Downloads/typedb-studio-linux-x86_64-{latest-version}.tar.gz -C /opt/typedb-studio
+tar -xzf ~/Downloads/<filename>.tar.gz -C /opt/typedb-studio
 ----
-
++
+Where `<filename>` is the name of the archive.
 . Add a symlink to the TypeDB Studio executable in the `/usr/local/bin` directory, for example:
 +
-[,bash,subs=attributes+]
+[,bash]
 ----
-ln -s /opt/typedb-studio/typedb-studio-linux-x86_64-{latest-version}/typedb-studio /usr/local/bin/typedb-studio
+ln -s /opt/typedb-studio/<filename>/typedb-studio /usr/local/bin/typedb-studio
 ----
 --
 

--- a/home-src/modules/ROOT/partials/linux.adoc
+++ b/home-src/modules/ROOT/partials/linux.adoc
@@ -49,17 +49,18 @@ https://www.oracle.com/java/technologies/downloads/#java11[Oracle JDK,window=_bl
 
 . Extract the archive with TypeDB into a new directory:
 +
-[,bash,subs=attributes+]
+[,bash]
 ----
 mkdir /opt/typedb
-tar -xzf ~/Downloads/typedb-all-linux-{latest-version}.tar.gz -C /opt/typedb
+tar -xzf ~/Downloads/<filename>.tar.gz -C /opt/typedb
 ----
-
++
+Where `<filename>` is the name of the archive.
 . Add a symlink to the TypeDB executable in the `/usr/local/bin` directory:
 +
-[,bash,subs=attributes+]
+[,bash]
 ----
-ln -s /opt/typedb/typedb-all-linux-{latest-version}/typedb /usr/local/bin/typedb
+ln -s /opt/typedb/<filename>/typedb /usr/local/bin/typedb
 ----
 
 // end::manual-install[]

--- a/home-src/modules/ROOT/partials/macos.adoc
+++ b/home-src/modules/ROOT/partials/macos.adoc
@@ -26,17 +26,18 @@ https://en.wikipedia.org/wiki/Rosetta_(software)[Rosetta].
 
 . Extract the archive with TypeDB into a new directory:
 +
-[,bash,subs=attributes+]
+[,bash]
 ----
 sudo mkdir /opt/typedb
-unzip ~/Downloads/typedb-all-mac-{latest-version}.zip -d /opt/typedb
+unzip ~/Downloads/<filename>.zip -d /opt/typedb
 ----
-
++
+Where `<filename>` is the name of the archive.
 . Add a symlink to the TypeDB executable in the `/usr/local/bin` directory:
 +
-[,bash,subs=attributes+]
+[,bash]
 ----
-ln -s /opt/typedb/typedb-all-mac-{latest-version}/typedb /usr/local/bin/typedb
+ln -s /opt/typedb/<filename>/typedb /usr/local/bin/typedb
 ----
 
 // end::manual-install[]

--- a/home-src/modules/ROOT/partials/win.adoc
+++ b/home-src/modules/ROOT/partials/win.adoc
@@ -5,17 +5,18 @@
 
 . Extract the archive with TypeDB into a new directory:
 +
-[,shell,subs=attributes+]
+[,shell]
 ----
 mkdir "C:\Program Files\TypeDB"
-tar xvf "C:\Users\username\Downloads\typedb-all-windows-{latest-version}.zip" -C "C:\Program Files\TypeDB"
+tar xvf "C:\Users\username\Downloads\<filename>.zip" -C "C:\Program Files\TypeDB"
 ----
-
++
+Where `<filename>` is the name of the archive.
 . Update the `PATH` environment variable:
 +
-[,shell,subs=attributes+]
+[,shell]
 ----
-setx /M PATH "%path%;C:\Program Files\TypeDB\typedb-all-windows-{latest-version}"
+setx /M PATH "%path%;C:\Program Files\TypeDB\<filename>"
 ----
 
 Restart the terminal window for the changes to environment variables to take effect.


### PR DESCRIPTION
## What is the goal of this PR?

Fix the issue from the #816.

## What are the changes implemented in this PR?

In installation guides, replace the version placeholder in code snippets in the filenames with the `filename` placeholder.
