### PR TITLE
Update Core install guide with Run subsections

### DIFF
--- a/home-src/modules/ROOT/pages/install/core.adoc
+++ b/home-src/modules/ROOT/pages/install/core.adoc
@@ -1,9 +1,11 @@
 = TypeDB Core installation guide
 :tabs-sync-option:
+:experimental:
 // Goal – Install TypeDB Core
 
-This page is an installation guide for TypeDB Core.
-TypeDB Core can be installed in multiple ways: using <<_docker,Docker>>, via <<_package,package manager>>, or by
+TypeDB Core can be installed in multiple ways:
+using <<_docker,Docker>> image,
+via <<_package,package manager>>, or by
 <<_manual,manual installation>>.
 
 For self-hosted TypeDB Cloud installation and setup,
@@ -13,6 +15,16 @@ see the xref:home::install/cloud-self-hosted.adoc[Self-hosted deployment] page.
 == Docker
 
 include::home::partial$docker.adoc[tag=install]
+
+=== Run
+
+include::home::partial$docker.adoc[tags=run]
+
+include::home::partial$docker.adoc[tags=run-info]
+
+include::home::partial$docker.adoc[tag=stop]
+
+include::home::partial$docker.adoc[tag=start]
 
 [#_package]
 == Package manager
@@ -38,7 +50,19 @@ No package manager option is available for Windows. See the <<_manual>> section 
 --
 ====
 
-//To learn how to run TypeDB Core, see the xref:home::quickstart.adoc[] guide.
+=== Run
+
+// tag::core-run[]
+To start a local TypeDB Core server:
+
+[,bash]
+----
+typedb server
+----
+// end::core-run[]
+// tag::core-stop[]
+To stop a local TypeDB server, close the terminal where it runs or press kbd:[Ctrl+C].
+// end::core-stop[]
 
 [#_manual]
 == Manual install
@@ -75,45 +99,11 @@ include::home::partial$win.adoc[tag=manual-install]
 --
 ====
 
-////
-[#_run_typedb_core]
-== Run TypeDB Core
+=== Run
 
-=== Start
-
-// tag::core-run[]
-To start a local TypeDB Core server:
-
-[,bash]
-----
-typedb server
-----
-
-To run TypeDB Core in a new Docker container:
-
-[,bash]
-----
-docker run --name typedb -d -v typedb-data:/opt/ -p 1729:1729 --platform linux/amd64 vaticle/typedb:latest
-----
-// end::core-run[]
-
-[NOTE]
-====
-To learn how to use TypeDB, see the xref:home::quickstart.adoc[] guide,
-xref:home::25-queries.adoc[] page, and the xref:learn::course-overview.adoc[Learn] category.
-====
-
-=== Stop
-
-To stop a local TypeDB server, close the terminal with it or press kbd:[Ctrl+C].
-
-For a Docker container:
-
-include::home::partial$docker.adoc[tag=stop]
-////
+include::home::install/core.adoc[tags="core-run,core-stop"]
 
 == Learn more
-
 
 [cols-2]
 --

--- a/home-src/modules/ROOT/pages/quickstart.adoc
+++ b/home-src/modules/ROOT/pages/quickstart.adoc
@@ -35,6 +35,8 @@ Core::
 TypeDB Core needs to be xref:home::install/core.adoc[installed] first.
 
 include::home::install/core.adoc[tag=core-run]
+
+include::home::partial$docker.adoc[tags=run]
 --
 ====
 

--- a/home-src/modules/ROOT/partials/docker.adoc
+++ b/home-src/modules/ROOT/partials/docker.adoc
@@ -20,26 +20,36 @@ To check the list of available versions, see the xref:manual:resources:releases.
 
 // end::install[]
 
-// tag::start[]
-To run a Docker container:
+// tag::run[]
+To create and run a new Docker container with TypeDB Core server:
+
 [,bash]
 ----
-docker run --name typedb -d -v typedb-data:/opt/typedb-all-linux/server/data/ -p 1729:1729 --platform linux/amd64 vaticle/typedb:latest
+docker run --name typedb -d -v typedb-data:/opt/ -p 1729:1729 --platform linux/amd64 vaticle/typedb:latest
 ----
-
-The following parameters should be noted:
-
-* `typedb` -- the name of the container,
-* `typedb-data` -- the name of the volume to persist data.
+// end::run[]
+// tag::run-info[]
+Where `typedb` -- the name of the container; `typedb-data` -- the name of the volume to persist data.
 
 The `--platform linux/amd64` parameter is required to run the TypeDB container on macOS with the `arm64`
 architecture.
 //Support for `linux/arm64` will be released in a future version of TypeDB.
-// end::start[]
+// end::run-info[]
 
 // tag::stop[]
+To stop a running Docker container:
+
 [,bash]
 ----
 docker stop typedb
 ----
 // end::stop[]
+
+// tag::start[]
+To start an existing Docker container again:
+
+[,bash]
+----
+docker start typedb
+----
+// end::start[]

--- a/home-src/modules/ROOT/partials/linux.adoc
+++ b/home-src/modules/ROOT/partials/linux.adoc
@@ -66,16 +66,16 @@ ln -s /opt/typedb/<filename>/typedb /usr/local/bin/typedb
 // end::manual-install[]
 
 // tag::start[]
+To run TypeDB Core installed locally:
 
 [,shell]
 ----
 typedb server
 ----
-
 // end::start[]
 
 // tag::stop[]
 
-Close the terminal or press kbd:[Ctrl+C].
+To stop TypeDB Core server, close the terminal or press kbd:[Ctrl+C].
 
 // end::stop[]


### PR DESCRIPTION
## What is the goal of this PR?

Add Run instructions back to the TypeDB Core install guide.

## What are the changes implemented in this PR?

Update run instructions and insert h3 "Run" sections into every h2 block.