### PR TITLE
Improve syntax highlighting for bash commands

### DIFF
--- a/drivers-src/modules/ROOT/pages/cpp/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/cpp/overview.adoc
@@ -128,9 +128,9 @@ dyld[72868]: Library not loaded: bazel-out/darwin-opt/bin/cpp/libtypedb-driver-c
 
 Use the following command to set the path for your TypeDB C++ driver library to the `lib` directory inside your project:
 
-[,bash]
+[source,console]
 ----
-export DYLD_LIBRARY_PATH=./lib
+$ export DYLD_LIBRARY_PATH=./lib
 ----
 
 == Learn more

--- a/drivers-src/modules/ROOT/pages/nodejs/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/nodejs/overview.adoc
@@ -36,17 +36,17 @@ See the
 
 To install TypeDB Node.js driver:
 
-[,bash]
+[source,console]
 ----
-npm install typedb-driver
+$ npm install typedb-driver
 ----
 
 .See the command for older versions (<2.24.0)
 [%collapsible]
 ====
-[,bash]
+[source,console]
 ----
-npm install typedb-client
+$ npm install typedb-client
 ----
 ====
 

--- a/drivers-src/modules/ROOT/pages/python/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/python/overview.adoc
@@ -38,17 +38,17 @@ For Linux: the minimum version of `glibc` is `2.25.0`.
 
 To install TypeDB Python driver:
 
-[,bash]
+[source,console]
 ----
-pip install typedb-driver
+$ pip install typedb-driver
 ----
 
 .See the command for older versions (<2.24.0)
 [%collapsible]
 ====
-[,bash]
+[source,console]
 ----
-pip install typedb-client
+$ pip install typedb-client
 ----
 ====
 

--- a/drivers-src/modules/ROOT/pages/python/tutorial.adoc
+++ b/drivers-src/modules/ROOT/pages/python/tutorial.adoc
@@ -24,9 +24,9 @@ For the driver installation instructions, see the xref:drivers::python/overview.
 
 Use `pip` for the Python driver installation:
 
-[,bash]
+[source,console]
 ----
-pip install typedb-driver
+$ pip install typedb-driver
 ----
 
 //#todo Consider adding virtualenv step-by-step guide

--- a/drivers-src/modules/ROOT/pages/rust/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/rust/overview.adoc
@@ -43,18 +43,18 @@ To install TypeDB Rust driver, select `sync` or `async` and follow the instructi
 async::
 +
 --
-[,bash]
+[source,console]
 ----
-cargo add typedb-driver
+$ cargo add typedb-driver
 ----
 --
 
 sync::
 +
 --
-[,bash]
+[source,console]
 ----
-cargo add typedb-driver -F sync
+$ cargo add typedb-driver -F sync
 ----
 --
 ====

--- a/drivers-src/modules/ROOT/pages/rust/tutorial.adoc
+++ b/drivers-src/modules/ROOT/pages/rust/tutorial.adoc
@@ -25,9 +25,9 @@ For the driver installation instructions, see the xref:drivers::rust/overview.ad
 The Sample application below is synchronous for simplicity,
 so make sure to add `sync` feature either in the `Cargo.toml` or via the following command:
 
-[,bash]
+[source,console]
 ----
-cargo add typedb-driver -F sync
+$ cargo add typedb-driver -F sync
 ----
 
 //#todo Consider adding virtualenv step-by-step guide

--- a/drivers-src/modules/ROOT/partials/tutorials/iam-data.tql
+++ b/drivers-src/modules/ROOT/partials/tutorials/iam-data.tql
@@ -1,0 +1,120 @@
+#
+# Copyright (C) 2023 Vaticle
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Subjects
+insert $p isa person, has full-name "Masako Holley", has email "masako.holley@typedb.com";  # No access
+insert $p isa person, has full-name "Pearle Goodman", has email "pearle.goodman@typedb.com";  # Sales manager
+insert $p isa person, has full-name "Kevin Morrison", has email "kevin.morrison@typedb.com";  # Full access
+
+# Objects
+insert $f isa file, has path "iopvu.java", has size-kb 55;
+insert $f isa file, has path "zlckt.ts", has size-kb 143;
+insert $f isa file, has path "psukg.java", has size-kb 171;
+insert $f isa file, has path "axidw.java", has size-kb 212;
+insert $f isa file, has path "lzfkn.java", has size-kb 70;
+insert $f isa file, has path "budget_2022-05-01.xlsx", has size-kb 758;
+insert $f isa file, has path "zewhb.java";
+insert $f isa file, has path "budget_2021-08-01.xlsx", has size-kb 1705;
+insert $f isa file, has path "LICENSE";
+insert $f isa file, has path "README.md";
+
+# Operations
+insert $o isa operation, has name "modify_file";
+insert $o isa operation, has name "view_file";
+
+# Potential access types
+match $ob isa file, has path "iopvu.java"; $op isa operation, has name "modify_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "zlckt.ts"; $op isa operation, has name "modify_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "psukg.java"; $op isa operation, has name "modify_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "axidw.java"; $op isa operation, has name "modify_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "lzfkn.java"; $op isa operation, has name "modify_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "budget_2022-05-01.xlsx"; $op isa operation, has name "modify_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "zewhb.java"; $op isa operation, has name "modify_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "budget_2021-08-01.xlsx"; $op isa operation, has name "modify_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "LICENSE"; $op isa operation, has name "modify_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "README.md"; $op isa operation, has name "modify_file"; insert $a (object: $ob, action: $op) isa access;
+
+match $ob isa file, has path "iopvu.java"; $op isa operation, has name "view_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "zlckt.ts"; $op isa operation, has name "view_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "psukg.java"; $op isa operation, has name "view_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "axidw.java"; $op isa operation, has name "view_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "lzfkn.java"; $op isa operation, has name "view_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "budget_2022-05-01.xlsx"; $op isa operation, has name "view_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "zewhb.java"; $op isa operation, has name "view_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "budget_2021-08-01.xlsx"; $op isa operation, has name "view_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "LICENSE"; $op isa operation, has name "view_file"; insert $a (object: $ob, action: $op) isa access;
+match $ob isa file, has path "README.md"; $op isa operation, has name "view_file"; insert $a (object: $ob, action: $op) isa access;
+
+# Permissions
+match $s isa subject, has full-name "Kevin Morrison"; $o isa object, has path "iopvu.java";
+      $a isa action, has name "modify_file"; $ac (object: $o, action: $a) isa access;
+insert $p (subject: $s, access: $ac) isa permission;
+
+match $s isa subject, has full-name "Kevin Morrison"; $o isa object, has path "zlckt.ts";
+      $a isa action, has name "modify_file"; $ac (object: $o, action: $a) isa access;
+insert $p (subject: $s, access: $ac) isa permission;
+
+match $s isa subject, has full-name "Kevin Morrison"; $o isa object, has path "psukg.java";
+      $a isa action, has name "modify_file"; $ac (object: $o, action: $a) isa access;
+insert $p (subject: $s, access: $ac) isa permission;
+
+match $s isa subject, has full-name "Kevin Morrison"; $o isa object, has path "axidw.java";
+      $a isa action, has name "modify_file"; $ac (object: $o, action: $a) isa access;
+insert $p (subject: $s, access: $ac) isa permission;
+
+match $s isa subject, has full-name "Kevin Morrison"; $o isa object, has path "lzfkn.java";
+      $a isa action, has name "modify_file"; $ac (object: $o, action: $a) isa access;
+insert $p (subject: $s, access: $ac) isa permission;
+
+match $s isa subject, has full-name "Kevin Morrison"; $o isa object, has path "budget_2022-05-01.xlsx";
+      $a isa action, has name "modify_file"; $ac (object: $o, action: $a) isa access;
+insert $p (subject: $s, access: $ac) isa permission;
+
+match $s isa subject, has full-name "Kevin Morrison"; $o isa object, has path "zewhb.java";
+      $a isa action, has name "modify_file"; $ac (object: $o, action: $a) isa access;
+insert $p (subject: $s, access: $ac) isa permission;
+
+match $s isa subject, has full-name "Kevin Morrison"; $o isa object, has path "budget_2021-08-01.xlsx";
+      $a isa action, has name "modify_file"; $ac (object: $o, action: $a) isa access;
+insert $p (subject: $s, access: $ac) isa permission;
+
+match $s isa subject, has full-name "Kevin Morrison"; $o isa object, has path "LICENSE";
+      $a isa action, has name "modify_file"; $ac (object: $o, action: $a) isa access;
+insert $p (subject: $s, access: $ac) isa permission;
+
+match $s isa subject, has full-name "Kevin Morrison"; $o isa object, has path "README.md";
+      $a isa action, has name "modify_file"; $ac (object: $o, action: $a) isa access;
+insert $p (subject: $s, access: $ac) isa permission;
+
+match $s isa subject, has full-name "Pearle Goodman"; $o isa object, has path "budget_2022-05-01.xlsx";
+      $a isa action, has name "modify_file"; $ac (object: $o, action: $a) isa access;
+insert $p (subject: $s, access: $ac) isa permission;
+
+match $s isa subject, has full-name "Pearle Goodman"; $o isa object, has path "zewhb.java";
+      $a isa action, has name "view_file"; $ac (object: $o, action: $a) isa access;
+insert $p (subject: $s, access: $ac) isa permission;
+
+match $s isa subject, has full-name "Pearle Goodman"; $o isa object, has path "budget_2021-08-01.xlsx";
+      $a isa action, has name "modify_file"; $ac (object: $o, action: $a) isa access;
+insert $p (subject: $s, access: $ac) isa permission;
+
+match $s isa subject, has full-name "Pearle Goodman"; $o isa object, has path "LICENSE";
+      $a isa action, has name "modify_file"; $ac (object: $o, action: $a) isa access;
+insert $p (subject: $s, access: $ac) isa permission;
+
+match $s isa subject, has full-name "Pearle Goodman"; $o isa object, has path "README.md";
+      $a isa action, has name "modify_file"; $ac (object: $o, action: $a) isa access;
+insert $p (subject: $s, access: $ac) isa permission;

--- a/home-src/modules/ROOT/pages/install/cloud-self-hosted.adoc
+++ b/home-src/modules/ROOT/pages/install/cloud-self-hosted.adoc
@@ -44,41 +44,41 @@ Make sure to use `docker login` first, to get correct authentication.
 
 To pull the TypeDB Cloud Docker image, run:
 
-[,bash]
+[source,console]
 ----
-docker pull vaticle/typedb-cloud:latest
+$ docker pull vaticle/typedb-cloud:latest
 ----
 
 Use `docker run` to create a new container with the downloaded image.
 By default, a TypeDB Cloud server is expected to be running on port `1729`.
 To ensure that data is preserved even when the container is killed or restarted, use a Docker volume:
 
-[,bash]
+[source,console]
 ----
-docker run --name typedb -d -v $(pwd)/db/:/opt/ -p 1729:1729 vaticle/typedb-cloud:latest
+$ docker run --name typedb -d -v $(pwd)/db/:/opt/ -p 1729:1729 vaticle/typedb-cloud:latest
 ----
 
 ==== Start and Stop TypeDB Cloud in Docker
 
 To start the Docker container:
 
-[,bash]
+[source,console]
 ----
-docker start typedb
+$ docker start typedb
 ----
 
 To check the containers running:
 
-[,bash]
+[source,console]
 ----
-docker ps
+$ docker ps
 ----
 
 To stop the Docker container:
 
-[,bash]
+[source,console]
 ----
-docker stop typedb
+$ docker stop typedb
 ----
 
 [#_manual_download_and_installation]
@@ -99,9 +99,9 @@ To start TypeDB Cloud manually:
 1. Navigate into the directory with unpacked files of TypeDB Cloud.
 2. Run:
 +
-[,bash]
+[source,console]
 ----
-./typedb server
+$ ./typedb server
 ----
 
 Now TypeDB Cloud should show a welcome screen with its version, address, and bootup time.
@@ -117,16 +117,16 @@ xref:drivers:ROOT:overview.adoc[TypeDB Client].
 
 You can use xref:manual:ROOT:console.adoc[TypeDB Console] from your TypeDB Cloud directory:
 
-[,bash]
+[source,console]
 ----
-./typedb console --cloud 127.0.0.1:1729 --username admin --password
+$ ./typedb console --cloud 127.0.0.1:1729 --username admin --password
 ----
 
 To run TypeDB Console from a Docker container, run:
 
-[,bash]
+[source,console]
 ----
-docker exec -ti typedb-cloud bash -c '/opt/typedb-cloud-all-linux-x86_64/typedb console --cloud 127.0.0.1:1729 --username admin --password'
+$ docker exec -ti typedb-cloud bash -c '/opt/typedb-cloud-all-linux-x86_64/typedb console --cloud 127.0.0.1:1729 --username admin --password'
 ----
 
 [#_deploying_manually]
@@ -172,9 +172,9 @@ The first machine with the IP address of `10.0.0.1`.
 
 To run TypeDB server #1:
 
-[,bash]
+[source,console]
 ----
-./typedb server \
+$ ./typedb server \
     --server.address=10.0.0.1:1729 \
     --server.internal-address.zeromq=10.0.0.1:1730 \
     --server.internal-address.grpc=10.0.0.1:1731 \
@@ -196,9 +196,9 @@ The first machine with the IP address of `10.0.0.2`.
 
 To run TypeDB server #2:
 
-[,bash]
+[source,console]
 ----
-./typedb server \
+$ ./typedb server \
     --server.address=10.0.0.2:1729 \
     --server.internal-address.zeromq=10.0.0.2:1730 \
     --server.internal-address.grpc=10.0.0.2:1731 \
@@ -220,9 +220,9 @@ The first machine with the IP address of `10.0.0.3`.
 
 To run TypeDB server #3:
 
-[,bash]
+[source,console]
 ----
-./typedb server \
+$ ./typedb server \
     --server.address=10.0.0.3:1729 \
     --server.internal-address.zeromq=10.0.0.3:1730 \
     --server.internal-address.grpc=10.0.0.3:1731 \
@@ -250,9 +250,9 @@ TypeDB Cloud also supports using different IP addresses for client and server co
 The relevant external hostname should be passed as arguments using the `--server.address` and
 `--server.peers` flags as below.
 
-[,bash]
+[source,console]
 ----
-./typedb server \
+$ ./typedb server \
     --server.address=external-host-1:1729 \
     --server.internal-address.zeromq=10.0.0.1:1730 \
     --server.internal-address.grpc=10.0.0.1:1731 \

--- a/home-src/modules/ROOT/pages/install/console.adoc
+++ b/home-src/modules/ROOT/pages/install/console.adoc
@@ -48,18 +48,18 @@ For other versions, see the
 https://cloudsmith.io/~typedb/repos/public-release/packages/?q=format%3Araw+name%3A%5Etypedb-console-mac&sort=-version[Downloads repository] page.
 . Extract the archive into a new directory:
 +
-[,bash]
+[source,console]
 ----
-sudo mkdir /opt/typedb-console
-unzip ~/Downloads/<filename>.zip -d /opt/typedb-console
+$ sudo mkdir /opt/typedb-console
+$ unzip ~/Downloads/<filename>.zip -d /opt/typedb-console
 ----
 +
 Where `<filename>` is the name of the archive.
 . Add a symlink to the TypeDB Console executable in the `/usr/local/bin` directory:
 +
-[,bash]
+[source,console]
 ----
-ln -s /opt/typedb-console/<filename>/typedb /usr/local/bin/typedb
+$ ln -s /opt/typedb-console/<filename>/typedb /usr/local/bin/typedb
 ----
 --
 
@@ -73,18 +73,18 @@ For other versions, see the
 https://cloudsmith.io/~typedb/repos/public-release/packages/?q=format%3Araw+name%3A%5Etypedb-console-linux&sort=-version[Downloads repository] page.
 . Extract the archive into a new directory:
 +
-[,bash]
+[source,console]
 ----
-mkdir /opt/typedb-console
-tar -xzf ~/Downloads/<filename>.tar.gz -C /opt/typedb-console
+$ mkdir /opt/typedb-console
+$ tar -xzf ~/Downloads/<filename>.tar.gz -C /opt/typedb-console
 ----
 +
 Where `<filename>` is the name of the archive.
 . Add a symlink to the TypeDB executable in the `/usr/local/bin` directory:
 +
-[,bash,subs=attributes+]
+[source,console]
 ----
-ln -s /opt/typedb-console/<filename>/typedb /usr/local/bin/typedb
+$ ln -s /opt/typedb-console/<filename>/typedb /usr/local/bin/typedb
 ----
 --
 
@@ -98,18 +98,18 @@ https://cloudsmith.io/~typedb/repos/public-release/packages/?q=format%3Araw+name
 
 . Extract the archive into a new directory:
 +
-[,shell]
+[source,console]
 ----
-mkdir "C:\Program Files\TypeDB Console"
-tar xvf "C:\Users\username\Downloads\<filename>.zip" -C "C:\Program Files\TypeDB Console"
+$ mkdir "C:\Program Files\TypeDB Console"
+$ tar xvf "C:\Users\username\Downloads\<filename>.zip" -C "C:\Program Files\TypeDB Console"
 ----
 +
 Where `<filename>` is the name of the archive.
 . Update the `PATH` environment variable:
 +
-[,shell]
+[source,console]
 ----
-setx /M PATH "%path%;C:\Program Files\TypeDB Console\<filename>"
+$ setx /M PATH "%path%;C:\Program Files\TypeDB Console\<filename>"
 ----
 
 Restart the terminal window for the changes to environment variables to take effect.
@@ -120,9 +120,9 @@ Restart the terminal window for the changes to environment variables to take eff
 
 To run TypeDB Console:
 
-[,bash]
+[source,console]
 ----
-typedb console
+$ typedb console
 ----
 
 For more information on how to use TypeDB Console, see the xref:manual::console.adoc[] page.

--- a/home-src/modules/ROOT/pages/install/core.adoc
+++ b/home-src/modules/ROOT/pages/install/core.adoc
@@ -55,9 +55,9 @@ No package manager option is available for Windows. See the <<_manual>> section 
 // tag::core-run[]
 To start a local TypeDB Core server:
 
-[,bash]
+[source,console]
 ----
-typedb server
+$ typedb server
 ----
 // end::core-run[]
 // tag::core-stop[]

--- a/home-src/modules/ROOT/pages/install/studio.adoc
+++ b/home-src/modules/ROOT/pages/install/studio.adoc
@@ -45,10 +45,10 @@ https://cloudsmith.io/~typedb/repos/public-release/packages/?q=name%3A%5Etypedb-
 
 Alternatively, you can use Brew to install TypeDB Studio:
 
-[,bash]
+[source,console]
 ----
-brew tap vaticle/tap
-brew install --cask vaticle/tap/typedb-studio
+$ brew tap vaticle/tap
+$ brew install --cask vaticle/tap/typedb-studio
 ----
 --
 
@@ -62,18 +62,18 @@ For other versions, see the
 https://cloudsmith.io/~typedb/repos/public-release/packages/?q=name%3A%5Etypedb-studio&sort=-version[Downloads repository] page.
 . Extract the archive with TypeDB Studio into a new directory, for example:
 +
-[,bash]
+[source,console]
 ----
-mkdir /opt/typedb-studio
-tar -xzf ~/Downloads/<filename>.tar.gz -C /opt/typedb-studio
+$ mkdir /opt/typedb-studio
+$ tar -xzf ~/Downloads/<filename>.tar.gz -C /opt/typedb-studio
 ----
 +
 Where `<filename>` is the name of the archive.
 . Add a symlink to the TypeDB Studio executable in the `/usr/local/bin` directory, for example:
 +
-[,bash]
+[source,console]
 ----
-ln -s /opt/typedb-studio/<filename>/typedb-studio /usr/local/bin/typedb-studio
+$ ln -s /opt/typedb-studio/<filename>/typedb-studio /usr/local/bin/typedb-studio
 ----
 --
 

--- a/home-src/modules/ROOT/pages/quickstart.adoc
+++ b/home-src/modules/ROOT/pages/quickstart.adoc
@@ -280,9 +280,9 @@ Cloud::
 +
 --
 .TypeDB Cloud connection
-[,bash]
+[source,console]
 ----
-typedb console --cloud=<server-address> --username=<username> --password --tls-enabled=true
+$ typedb console --cloud=<server-address> --username=<username> --password --tls-enabled=true
 ----
 
 You will be prompted for a password.
@@ -294,9 +294,9 @@ Core::
 +
 --
 .TypeDB Core connection
-[,bash]
+[source,console]
 ----
-typedb console
+$ typedb console
 ----
 
 By default, TypeDB Console connects to your local TypeDB Core installation with the `localhost:1729` address.

--- a/home-src/modules/ROOT/partials/docker.adoc
+++ b/home-src/modules/ROOT/partials/docker.adoc
@@ -10,9 +10,9 @@ it from https://github.com/vaticle/typedb/tags[source code,window=_blank] with B
 // tag::install[]
 To pull the latest TypeDB Docker image:
 
-[,bash]
+[source,console]
 ----
-docker pull vaticle/typedb:latest
+$ docker pull vaticle/typedb:latest
 ----
 
 You can replace `latest` with a version number to get a specific version of TypeDB Core.
@@ -23,9 +23,9 @@ To check the list of available versions, see the xref:manual:resources:releases.
 // tag::run[]
 To create and run a new Docker container with TypeDB Core server:
 
-[,bash]
+[source,console]
 ----
-docker run --name typedb -d -v typedb-data:/opt/ -p 1729:1729 --platform linux/amd64 vaticle/typedb:latest
+$ docker run --name typedb -d -v typedb-data:/opt/ -p 1729:1729 --platform linux/amd64 vaticle/typedb:latest
 ----
 // end::run[]
 // tag::run-info[]
@@ -39,17 +39,17 @@ architecture.
 // tag::stop[]
 To stop a running Docker container:
 
-[,bash]
+[source,console]
 ----
-docker stop typedb
+$ docker stop typedb
 ----
 // end::stop[]
 
 // tag::start[]
 To start an existing Docker container again:
 
-[,bash]
+[source,console]
 ----
-docker start typedb
+$ docker start typedb
 ----
 // end::start[]

--- a/home-src/modules/ROOT/partials/linux.adoc
+++ b/home-src/modules/ROOT/partials/linux.adoc
@@ -2,36 +2,36 @@
 
 . Add the TypeDB repository:
 +
-[,bash]
+[source,console]
 ----
-sudo apt install software-properties-common apt-transport-https gpg
-gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 17507562824cfdcc
-gpg --export 17507562824cfdcc | sudo tee /etc/apt/trusted.gpg.d/vaticle.gpg > /dev/null
-echo "deb https://repo.typedb.com/public/public-release/deb/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/vaticle.list > /dev/null
-sudo apt update
+$ sudo apt install software-properties-common apt-transport-https gpg
+$ gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 17507562824cfdcc
+$ gpg --export 17507562824cfdcc | sudo tee /etc/apt/trusted.gpg.d/vaticle.gpg > /dev/null
+$ echo "deb https://repo.typedb.com/public/public-release/deb/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/vaticle.list > /dev/null
+$ sudo apt update
 ----
 . Ensure Java 11+ is installed:
 +
-[,bash]
+[source,console]
 ----
-sudo apt install default-jre
+$ sudo apt install default-jre
 ----
 +
 TypeDB supports https://jdk.java.net[OpenJDK,window=_blank] and
 https://www.oracle.com/java/technologies/downloads/#java11[Oracle JDK,window=_blank].
 . Install `typedb`:
 +
-[,bash]
+[source,console]
 ----
-sudo apt install typedb
+$ sudo apt install typedb
 ----
 +
 If you had an older version (≤`2.25.5`) of TypeDB installed, it might be needed to uninstall older packages to avoid
 conflicts:
 +
-[,bash]
+[source,console]
 ----
-sudo apt remove typedb-server typedb-bin typedb-console
+$ sudo apt remove typedb-server typedb-bin typedb-console
 ----
 ////
 The `typedb-server` and `typedb-console` packages are updated more often than `typedb-bin`, so their
@@ -49,18 +49,18 @@ https://www.oracle.com/java/technologies/downloads/#java11[Oracle JDK,window=_bl
 
 . Extract the archive with TypeDB into a new directory:
 +
-[,bash]
+[source,console]
 ----
-mkdir /opt/typedb
-tar -xzf ~/Downloads/<filename>.tar.gz -C /opt/typedb
+$ mkdir /opt/typedb
+$ tar -xzf ~/Downloads/<filename>.tar.gz -C /opt/typedb
 ----
 +
 Where `<filename>` is the name of the archive.
 . Add a symlink to the TypeDB executable in the `/usr/local/bin` directory:
 +
-[,bash]
+[source,console]
 ----
-ln -s /opt/typedb/<filename>/typedb /usr/local/bin/typedb
+$ ln -s /opt/typedb/<filename>/typedb /usr/local/bin/typedb
 ----
 
 // end::manual-install[]
@@ -68,9 +68,9 @@ ln -s /opt/typedb/<filename>/typedb /usr/local/bin/typedb
 // tag::start[]
 To run TypeDB Core installed locally:
 
-[,shell]
+[source,console]
 ----
-typedb server
+$ typedb server
 ----
 // end::start[]
 

--- a/home-src/modules/ROOT/partials/macos.adoc
+++ b/home-src/modules/ROOT/partials/macos.adoc
@@ -1,10 +1,10 @@
 // tag::install-homebrew[]
 To install TypeDB via `brew`:
 
-[,bash]
+[source,console]
 ----
-brew tap vaticle/tap
-brew install vaticle/tap/typedb
+$ brew tap vaticle/tap
+$ brew install vaticle/tap/typedb
 ----
 // end::install-homebrew[]
 
@@ -15,9 +15,9 @@ https://www.oracle.com/java/technologies/downloads/#java11[Oracle JDK,window=_bl
 +
 To check the Java SDK version:
 +
-[,bash]
+[source,console]
 ----
-/usr/libexec/java_home -V
+$ /usr/libexec/java_home -V
 ----
 +
 TypeDB runs natively on both `arm64` and `x86_64` architectures.
@@ -26,27 +26,27 @@ https://en.wikipedia.org/wiki/Rosetta_(software)[Rosetta].
 
 . Extract the archive with TypeDB into a new directory:
 +
-[,bash]
+[source,console]
 ----
-sudo mkdir /opt/typedb
-unzip ~/Downloads/<filename>.zip -d /opt/typedb
+$ sudo mkdir /opt/typedb
+$ unzip ~/Downloads/<filename>.zip -d /opt/typedb
 ----
 +
 Where `<filename>` is the name of the archive.
 . Add a symlink to the TypeDB executable in the `/usr/local/bin` directory:
 +
-[,bash]
+[source,console]
 ----
-ln -s /opt/typedb/<filename>/typedb /usr/local/bin/typedb
+$ ln -s /opt/typedb/<filename>/typedb /usr/local/bin/typedb
 ----
 
 // end::manual-install[]
 
 // tag::start[]
 
-[,bash]
+[source,console]
 ----
-typedb server
+$ typedb server
 ----
 
 // end::start[]

--- a/home-src/modules/ROOT/partials/win.adoc
+++ b/home-src/modules/ROOT/partials/win.adoc
@@ -5,18 +5,18 @@
 
 . Extract the archive with TypeDB into a new directory:
 +
-[,shell]
+[source,console]
 ----
-mkdir "C:\Program Files\TypeDB"
-tar xvf "C:\Users\username\Downloads\<filename>.zip" -C "C:\Program Files\TypeDB"
+$ mkdir "C:\Program Files\TypeDB"
+$ tar xvf "C:\Users\username\Downloads\<filename>.zip" -C "C:\Program Files\TypeDB"
 ----
 +
 Where `<filename>` is the name of the archive.
 . Update the `PATH` environment variable:
 +
-[,shell]
+[source,console]
 ----
-setx /M PATH "%path%;C:\Program Files\TypeDB\<filename>"
+$ setx /M PATH "%path%;C:\Program Files\TypeDB\<filename>"
 ----
 
 Restart the terminal window for the changes to environment variables to take effect.

--- a/home-src/modules/ROOT/partials/win.adoc
+++ b/home-src/modules/ROOT/partials/win.adoc
@@ -25,9 +25,9 @@ Restart the terminal window for the changes to environment variables to take eff
 
 // tag::start[]
 
-[,shell]
+[source,console]
 ----
-typedb server
+$ typedb server
 ----
 
 Or use a `typedb.bat server` command directly from the directory with TypeDB files to start a TypeDB server

--- a/learn-src/modules/ROOT/pages/2-environment-setup/2.1-sample-deployment.adoc
+++ b/learn-src/modules/ROOT/pages/2-environment-setup/2.1-sample-deployment.adoc
@@ -7,15 +7,15 @@ Throughout this course, we will be using a sample database for an online booksto
 . Install and run https://docs.docker.com/get-docker/[Docker].
 . Pull the Docker image for the sample database:
 +
-[,bash]
+[source,console]
 ----
-docker image pull vaticle/typedb-sample-data:1.0.0
+$ docker image pull vaticle/typedb-sample-data:1.0.0
 ----
 . Start the Docker image:
 +
-[,bash]
+[source,console]
 ----
-docker run -p 1730:1729 vaticle/typedb-sample-data:1.0.0
+$ docker run -p 1730:1729 vaticle/typedb-sample-data:1.0.0
 ----
 
 The server can be connected to using port `1730`.

--- a/learn-src/modules/ROOT/pages/6-building-applications/6.1-driver-setup.adoc
+++ b/learn-src/modules/ROOT/pages/6-building-applications/6.1-driver-setup.adoc
@@ -4,9 +4,9 @@
 
 Ensure you have the latest stable version of https://www.python.org/downloads/[Python installed], and run the following command to install the official TypeDB Python driver package:
 
-[,bash]
+[source,console]
 ----
-pip install typedb-driver
+$ pip install typedb-driver
 ----
 
 == Imports

--- a/manual-src/modules/ROOT/pages/configuring/arguments.adoc
+++ b/manual-src/modules/ROOT/pages/configuring/arguments.adoc
@@ -14,18 +14,18 @@ server:
 If we want to use port `1730` instead of `1729`, we can either update the configuration file or override it from the
 command line using the following command:
 
-[,bash]
+[source,console]
 ----
-typedb server --server.address 0.0.0.0:1730
+$ typedb server --server.address 0.0.0.0:1730
 ----
 
 Use the same approach to set a completely new section of the configuration that isn't presented in the file yet.
 For example, to define a new logger subsection to print out all query plans,
 we could do the following to set the package `com.vaticle.typedb.core.traversal` to output on a more verbose level:
 
-[,bash]
+[source,console]
 ----
-typedb server  \
+$ typedb server  \
   --server.address 0.0.0.0:1730  \
   --log.logger.traversal.filter com.vaticle.typedb.core.traversal  \
   --log.logger.traversal.level debug \
@@ -55,9 +55,9 @@ Any value from the config file can be overridden by a command line argument.
 
 For all available commands via the command line use the `--help` argument to get a reference:
 
-[,bash]
+[source,console]
 ----
-typedb server --help
+$ typedb server --help
 ----
 
 This will list out how to use specific command line arguments as well as options derived from the configuration file.

--- a/manual-src/modules/ROOT/pages/configuring/export.adoc
+++ b/manual-src/modules/ROOT/pages/configuring/export.adoc
@@ -52,9 +52,9 @@ This and the following commands should be addressed to the *new server*, that wi
 
 For the export to work make sure the TypeDB server with *the database to export* is working.
 
-[,bash]
+[source,console]
 ----
-typedb server export --database=<database> --port=<server rpc port> --data=<data_filename>.typedb --schema=<schema_filename>.tql
+$ typedb server export --database=<database> --port=<server rpc port> --data=<data_filename>.typedb --schema=<schema_filename>.tql
 ----
 
 Where:
@@ -74,9 +74,9 @@ Use positional arguments instead. For example, `typedb server export <database> 
 
 For the import to work make sure the target TypeDB server (where the database will be *migrated to*) is working.
 
-[,bash]
+[source,console]
 ----
-typedb server import --database=<database> --port=<server rpc port> --data=<data_filename>.typedb --schema=<schema_filename>.tql
+$ typedb server import --database=<database> --port=<server rpc port> --data=<data_filename>.typedb --schema=<schema_filename>.tql
 ----
 
 Where:

--- a/manual-src/modules/ROOT/pages/configuring/overview.adoc
+++ b/manual-src/modules/ROOT/pages/configuring/overview.adoc
@@ -91,9 +91,9 @@ an additional 2 GB of memory for each database).
 To support large data volumes, it is important to check the open file limit the operating system imposes. Some Unix
 distributions default to `1024` open file descriptors. This can be checked with the following command:
 
-[,bash]
+[source,console]
 ----
-ulimit -n
+$ ulimit -n
 ----
 
 We recommend this is increased to at least `50 000`.

--- a/manual-src/modules/ROOT/pages/configuring/users.adoc
+++ b/manual-src/modules/ROOT/pages/configuring/users.adoc
@@ -12,9 +12,9 @@ You can use TypeDB Console or TypeDB driver API for user management.
 
 Assuming TypeDB Console is xref:home::install/console.adoc[installed], to connect to TypeDB Cloud:
 
-[,bash]
+[source,console]
 ----
-typedb console --cloud=<server-address> --username=<username> --password --tls-enabled=true
+$ typedb console --cloud=<server-address> --username=<username> --password --tls-enabled=true
 ----
 
 For more information on how to use TypeDB Console, see the xref:manual::console.adoc[] page.

--- a/manual-src/modules/ROOT/pages/console.adoc
+++ b/manual-src/modules/ROOT/pages/console.adoc
@@ -206,7 +206,6 @@ typedb console --command=<command1> --command=<command2>
 ----
 
 [#_command_argument_example]
-=== Example
 
 The following example achieves the same results as the <<_interactive_mode_example,one in the interactive mode>>
 via the command line arguments.
@@ -255,25 +254,27 @@ then invoke Console with the `--script` argument, specifying a path to the scrip
 typedb console --script=<script-file-path>
 ----
 
-Each line in the script is interpreted as one command, so multiline queries are not available in this mode.
-For example, see the <<_script_example>> section below.
+[NOTE]
+====
+Each line in the script file is interpreted as one command, so multiline queries are not available in this mode.
+You can overcome this limitation, by using calling a TypeQL query from a file with the `source` keyword.
+For example, see the <<_load_a_query_from_a_file>> section below.
+====
 
 [#_script_example]
-=== Example
-
 Prepare the following script and save it to a local file:
 
 .script.txt
 ----
 database create test
 transaction test schema write
-    define person sub entity;
+    define person sub entity, owns name; name sub attribute, value string;
     commit
 transaction test data write
-    insert $x isa person;
+    insert $x isa person, has name "Bob";
     commit
 transaction test data read
-    match $x isa person; get;
+    match $x isa person, has name $f; fetch $f;
     close
 database delete test
 ----
@@ -287,32 +288,68 @@ typedb console --script=PATH/script.txt
 
 Where `PATH/script.txt` is the path to the file and the filename.
 
-You will see the following output:
+You will see the following or similar output:
 
 .Output
 ----
 + database create test
 Database 'test' created
 + transaction test schema write
-++ define person sub entity;
+++ define person sub entity, owns name; name sub attribute, value string;
 Concepts have been defined
+
 ++ commit
 Transaction changes committed
 + transaction test data write
-++ insert $x isa person;
-{ $x iid 0x966e80017fffffffffffffff isa person; }
-answers: 1, duration: 87 ms
+++ insert $x isa person, has name "Bob";
+{
+    $_0 Bob isa name;
+    $x iid 0x826e80017fffffffffffffff isa person;
+}
+
+answers: 1, total duration: 15 ms
+
 ++ commit
 Transaction changes committed
 + transaction test data read
-++ match $x isa person; get;
-{ $x iid 0x966e80018000000000000000 isa person; }
-answers: 1, duration: 25 ms
+++ match $x isa person, has name $f; fetch $f;
+{ "f": { "value": "Bob", "type": { "label": "name", "root": "attribute", "value_type": "string" } } }
+
+answers: 1, total duration: 10 ms
+
 ++ close
-Transaction closed without committing changes
+Transaction closed
 + database delete test
 Database 'test' deleted
 ----
+
+[#_load_a_query_from_a_file]
+=== Load a query from a file
+
+It's quite often, that you have your query nicely prepared in a separate file.
+Instead of copying it to the script and removing all line breaks, you can link the file with your query by using
+the `source` command:
+
+.Loading a TypeQL query from a file
+----
+database create iam_sample_db
+transaction iam_sample_db schema write
+    source iam-schema.tql
+    commit
+transaction iam_sample_db data write
+    source iam-data.tql
+    commit
+transaction iam_sample_db data read
+    match $p isa person; fetch $p as person: attribute;
+    close
+database delete iam_sample_db
+----
+
+You can use the
+https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql,window=_blank]
+and
+https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-data.tql[iam-data.tql,window=_blank]
+files for the above example.
 
 == Troubleshooting
 

--- a/manual-src/modules/ROOT/pages/console.adoc
+++ b/manual-src/modules/ROOT/pages/console.adoc
@@ -58,9 +58,9 @@ Cloud::
 --
 // tag::connect_cloud_console[]
 .Connect to TypeDB Cloud
-[,bash]
+[source,console]
 ----
-typedb console --cloud=<server-address> --username=<username> --password --tls-enabled=true
+$ typedb console --cloud=<server-address> --username=<username> --password --tls-enabled=true
 ----
 
 You will be prompted for a password.
@@ -80,9 +80,9 @@ Core::
 --
 // tag::connect_core_console[]
 .Connect to TypeDB Core
-[,bash]
+[source,console]
 ----
-typedb console --core=<server-address>
+$ typedb console --core=<server-address>
 ----
 
 The `--core` argument is used to set the TypeDB Core server IP address and port to connect to,
@@ -158,8 +158,9 @@ The asterisk (`*`) is used to notify that the current transaction has uncommitte
 
 . Run Console in the interactive mode and <<_connect_to_typedb,connect>> it to TypeDB:
 +
+[source,console]
 ----
-typedb console
+$ typedb console
 ----
 
 . Now, run the following command to create a database:
@@ -174,8 +175,8 @@ Use it to send the Define query, and commit changes:
 +
 ----
 transaction sample_db schema write
-sample_db::schema::write> define person sub entity;
-sample_db::schema::write*> commit
+define person sub entity;
+commit
 ----
 +
 The <<_transaction_level,Transaction level>> of REPL is announced by the CLI prompt change to include database name,
@@ -188,8 +189,8 @@ as a single push of the btn:[Enter] is recognized as a line break in the query.
 +
 ----
 transaction sample_db data write
-sample_db::data::write> insert $p isa person;
-sample_db::data::write*> commit
+insert $p isa person;
+commit
 ----
 
 The above example creates a database with the name `sample_db`,
@@ -201,8 +202,9 @@ then inserts a single instance of the type into the database.
 You can run Console commands using the `--command` argument:
 
 [,bash]
+[source,console]
 ----
-typedb console --command=<command1> --command=<command2>
+$ typedb console --command=<command1> --command=<command2>
 ----
 
 [#_command_argument_example]
@@ -212,8 +214,9 @@ via the command line arguments.
 Run the following command in a terminal to start TypeDB and execute queries:
 
 [,bash]
+[source,console]
 ----
-typedb console --command="database create sample_db" \
+$ typedb console --command="database create sample_db" \
 --command="database list" \
 --command="transaction sample_db schema write" \
 --command="define person sub entity;" \
@@ -249,9 +252,9 @@ Transaction changes committed
 You can create a script file that contains the list of commands to run,
 then invoke Console with the `--script` argument, specifying a path to the script file:
 
-[,bash]
+[source,console]
 ----
-typedb console --script=<script-file-path>
+$ typedb console --script=<script-file-path>
 ----
 
 [NOTE]
@@ -279,16 +282,16 @@ transaction test data read
 database delete test
 ----
 
-Use the following command to execute the script:
+Execute the script with TypeDB Console:
 
 .Run script.txt
+[source,console]
 ----
-typedb console --script=PATH/script.txt
+$ typedb console --script=PATH/script.txt
 ----
 
 Where `PATH/script.txt` is the path to the file and the filename.
-
-You will see the following or similar output:
+The result should look similar to the following:
 
 .Output
 ----
@@ -373,9 +376,9 @@ Linux::
 Use `locale -a` to list all installed locales, and use `export` to set the environment.
 For example, to use `en_US.UTF-8` run:
 
-[,bash]
+[source,console]
 ----
-bash export LANG=en_US.UTF-8 && export LC_ALL=en_US.UTF-8
+$ bash export LANG=en_US.UTF-8 && export LC_ALL=en_US.UTF-8
 ----
 --
 
@@ -385,9 +388,9 @@ macOS::
 Use `locale -a` to list all installed locales, and use `export` to set the environment.
 For example, to use `en_US.UTF-8` run:
 
-[,bash]
+[source,console]
 ----
-bash export LANG=en_US.UTF-8 && export LC_ALL=en_US.UTF-8
+$ bash export LANG=en_US.UTF-8 && export LC_ALL=en_US.UTF-8
 ----
 --
 

--- a/manual-src/modules/ROOT/partials/kubernetes.adoc
+++ b/manual-src/modules/ROOT/partials/kubernetes.adoc
@@ -11,9 +11,9 @@
 
 First, create a secret to access TypeDB Cloud image on Docker Hub:
 
-[,bash]
+[source,console]
 ----
-kubectl create secret docker-registry private-docker-hub --docker-server=https://index.docker.io/v2/ \
+$ kubectl create secret docker-registry private-docker-hub --docker-server=https://index.docker.io/v2/ \
 --docker-username=USERNAME --docker-password='PASSWORD' --docker-email=EMAIL
 ----
 
@@ -22,9 +22,9 @@ https://hub.docker.com/settings/security?generateToken=true[access token,window=
 
 Next, add the Vaticle Helm repo:
 
-[,bash]
+[source,console]
 ----
-helm repo add vaticle https://repo.vaticle.com/repository/helm/
+$ helm repo add vaticle https://repo.vaticle.com/repository/helm/
 ----
 
 == Encryption setup (optional)
@@ -39,9 +39,9 @@ https://www.cloudflare.com/[CloudFlare] or https://letsencrypt.org/[letsencrypt.
 Alternatively, it is also possible to generate it manually with a tool we provide with TypeDB Cloud
 in the `tool` directory:
 
-[,bash]
+[source,console]
 ----
-java -jar encryption-gen.jar --ca-common-name=<x500-common-name> --hostname=<external-hostname>,<internal-hostname>
+$ java -jar encryption-gen.jar --ca-common-name=<x500-common-name> --hostname=<external-hostname>,<internal-hostname>
 ----
 
 _Please note that an external certificate is always bound to URL address, not IP address._
@@ -63,17 +63,17 @@ The path to each file is configured in the `encryption` section of the TypeDB Cl
 Once the external and internal certificates are all generated, we can upload it to Kubernetes Secrets.
 Navigate into the directory with cluster certificates and run:
 
-[,bash]
+[source,console]
 ----
-kubectl create secret generic ext-grpc \
+$ kubectl create secret generic ext-grpc \
   --from-file ext-grpc-certificate.pem \
   --from-file ext-grpc-private-key.pem \
   --from-file ext-grpc-root-ca.pem
-kubectl create secret generic int-grpc \
+$ kubectl create secret generic int-grpc \
     --from-file int-grpc-certificate.pem \
     --from-file int-grpc-private-key.pem \
     --from-file int-grpc-root-ca.pem
-kubectl create secret generic int-zmq \
+$ kubectl create secret generic int-zmq \
   --from-file int-zmq-private-key \
   --from-file int-zmq-public-key
 ----
@@ -100,9 +100,9 @@ Without encryption::
 --
 Deploy:
 
-[,bash]
+[source,console]
 ----
-helm install typedb-cloud vaticle/typedb-cloud --set "exposed=false,encrypted=false"
+$ helm install typedb-cloud vaticle/typedb-cloud --set "exposed=false,encrypted=false"
 ----
 --
 
@@ -112,9 +112,9 @@ With encryption::
 
 To enable in-flight encryption for your private cluster, make sure the `encrypted` flag is set to `true`:
 
-[,bash]
+[source,console]
 ----
-helm install typedb-cloud vaticle/typedb-cloud --set "exposed=false,encrypted=true" \
+$ helm install typedb-cloud vaticle/typedb-cloud --set "exposed=false,encrypted=true" \
 --set servers=3,cpu=1,storage.persistent=false,storage.size=1Gi,exposed=true,domain=localhost-ext --set encryption.enable=true --set encryption.enable=true,encryption.externalGRPC.secretName=ext-grpc,encryption.externalGRPC.content.privateKeyName=ext-grpc-private-key.pem,encryption.externalGRPC.content.certificateName=ext-grpc-certificate.pem,encryption.externalGRPC.content.rootCAName=ext-grpc-root-ca.pem \
 --set encryption.internalGRPC.secretName=int-grpc,encryption.internalGRPC.content.privateKeyName=int-grpc-private-key.pem,encryption.internalGRPC.content.certificateName=int-grpc-certificate.pem,encryption.internalGRPC.content.rootCAName=int-grpc-root-ca.pem \
 --set encryption.internalZMQ.secretName=int-zmq,encryption.internalZMQ.content.privateKeyName=int-zmq-private-key,encryption.internalZMQ.content.publicKeyName=int-zmq-public-key
@@ -149,18 +149,18 @@ Without encryption::
 --
 Deploy:
 
-[,bash]
+[source,console]
 ----
-helm install typedb-cloud vaticle/typedb-cloud --set "exposed=true"
+$ helm install typedb-cloud vaticle/typedb-cloud --set "exposed=true"
 ----
 
 Once the deployment has been completed,
 the servers can be accessible via public IPs/hostnames assigned to the Kubernetes `LoadBalancer` services.
 The addresses can be obtained with this command:
 
-[,bash]
+[source,console]
 ----
-kubectl get svc -l external-ip-for=typedb-cloud \
+$ kubectl get svc -l external-ip-for=typedb-cloud \
 -o='custom-columns=NAME:.metadata.name,IP OR HOSTNAME:.status.loadBalancer.ingress[0].*'
 ----
 --
@@ -187,9 +187,9 @@ Once the domain name and external certificate have been configured accordingly,
 we can proceed to perform the deployment.
 Ensure that the `encrypted` flag is set to `true` and the `domain` flag set accordingly.
 
-[,bash]
+[source,console]
 ----
-helm install typedb-cloud vaticle/typedb-cloud --set "exposed=true,encrypted=true,domain=<domain-name>" \
+$ helm install typedb-cloud vaticle/typedb-cloud --set "exposed=true,encrypted=true,domain=<domain-name>" \
 --set servers=3,cpu=1,storage.persistent=false,storage.size=1Gi,exposed=true,domain=localhost-ext --set encryption.enable=true --set encryption.enable=true,encryption.externalGRPC.secretName=ext-grpc,encryption.externalGRPC.content.privateKeyName=ext-grpc-private-key.pem,encryption.externalGRPC.content.certificateName=ext-grpc-certificate.pem,encryption.externalGRPC.content.rootCAName=ext-grpc-root-ca.pem \
 --set encryption.internalGRPC.secretName=int-grpc,encryption.internalGRPC.content.privateKeyName=int-grpc-private-key.pem,encryption.internalGRPC.content.certificateName=int-grpc-certificate.pem,encryption.internalGRPC.content.rootCAName=int-grpc-root-ca.pem \
 --set encryption.internalZMQ.secretName=int-zmq,encryption.internalZMQ.content.privateKeyName=int-zmq-private-key,encryption.internalZMQ.content.publicKeyName=int-zmq-public-key
@@ -232,33 +232,33 @@ Ensure to have https://minikube.sigs.k8s.io/[Minikube] installed and running.
 
 Deploy, adjusting the parameters for CPU and storage to run on a local machine:
 
-[,bash]
+[source,console]
 ----
-helm install typedb-cloud vaticle/typedb-cloud --set image.pullPolicy=Always,servers=3,singlePodPerNode=false,cpu=1,storage.persistent=false,storage.size=1Gi,exposed=true,javaopts=-Xmx4G --set encryption.enable=false
+$ helm install typedb-cloud vaticle/typedb-cloud --set image.pullPolicy=Always,servers=3,singlePodPerNode=false,cpu=1,storage.persistent=false,storage.size=1Gi,exposed=true,javaopts=-Xmx4G --set encryption.enable=false
 ----
 
 ////
-[,bash]
+[source,console]
 ----
-helm install vaticle/typedb-cloud --generate-name \
+$ helm install vaticle/typedb-cloud --generate-name \
 --set "cpu=2,replicas=3,singlePodPerNode=false,storage.persistent=true,storage.size=10Gi,exposed=true"
 ----
 ////
 
 Once the deployment has been completed, enable tunneling from another terminal:
 
-[,bash]
+[source,console]
 ----
-minikube tunnel
+$ minikube tunnel
 ----
 
 == K8s cluster status check
 
 To check the status of a cluster:
 
-[,bash]
+[source,console]
 ----
-kubectl describe sts typedb-cloud
+$ kubectl describe sts typedb-cloud
 ----
 
 It should show `Pods Status` field as `Running` for all the nodes after a few minutes
@@ -266,27 +266,27 @@ after deploying a TypeDB Cloud cluster.
 
 You can connect to a pod:
 
-[,bash]
+[source,console]
 ----
-kubectl exec --stdin --tty typedb-cloud-0 -- /bin/bash
+$ kubectl exec --stdin --tty typedb-cloud-0 -- /bin/bash
 ----
 
 == K8s cluster removal
 
 To stop and remove a K8s cluster from Kubernetes, use the `helm uninstall` with the helm release name:
 
-[,bash]
+[source,console]
 ----
-helm uninstall typedb-cloud
+$ helm uninstall typedb-cloud
 ----
 
 == K8s troubleshooting
 
 To see pod details for the `typedb-cloud-0` pod:
 
-[,bash]
+[source,console]
 ----
-kubectl describe pod typedb-cloud-0
+$ kubectl describe pod typedb-cloud-0
 ----
 
 The following are the common error scenarios and how to troubleshoot them.
@@ -309,9 +309,9 @@ executing `kubectl get secret/private-docker-hub`. Correct state looks like this
 This might mean pods requested more resources than available.
 To check if that's the case, run on a stuck pod (e.g. `typedb-cloud-0`):
 
-[,bash]
+[source,console]
 ----
-`kubectl describe pod/typedb-cloud-0`
+$ kubectl describe pod/typedb-cloud-0
 ----
 
 Error message similar to
@@ -324,9 +324,9 @@ indicates that `cpu` or `storage.size` <<_helm_configuration_reference,settings>
 This might indicate any misconfiguration of TypeDB Cloud.
 Please check the logs:
 
-[,bash]
+[source,console]
 ----
-kubectl logs pod/typedb-cloud-0
+$ kubectl logs pod/typedb-cloud-0
 ----
 
 [#_helm_configuration_reference]

--- a/typeql-src/modules/ROOT/pages/data/delete.adoc
+++ b/typeql-src/modules/ROOT/pages/data/delete.adoc
@@ -170,9 +170,9 @@ See an <<_deleting_a_role_player,example>> of deleting role players from a relat
 == Examples
 
 Use the IAM
-https://github.com/vaticle/typedb-docs/blob/master/typedb-src/modules/ROOT/attachments/iam-schema.tql[schema,window=_blank]
+https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[schema,window=_blank]
 and
-https://github.com/vaticle/typedb-docs/blob/master/typedb-src/modules/ROOT/attachments/iam-data.tql[sample data,window=_blank]
+https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[sample data,window=_blank]
 for the following examples.
 
 [#_simple_example]

--- a/typeql-src/modules/ROOT/pages/data/examples.adoc
+++ b/typeql-src/modules/ROOT/pages/data/examples.adoc
@@ -25,8 +25,8 @@ toc::[]
 [NOTE]
 ====
 The statements below are designed for the IAM
-https://github.com/vaticle/typedb-docs/blob/master/typedb-src/modules/ROOT/attachments/iam-schema.tql[schema,window=_blank] and
-https://github.com/vaticle/typedb-docs/blob/master/typedb-src/modules/ROOT/attachments/iam-data.tql[dataset,window=_blank],
+https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[schema,window=_blank] and
+https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[dataset,window=_blank],
 but they can return any number of results: zero, one, or multiple.
 ====
 

--- a/typeql-src/modules/ROOT/pages/data/fetch.adoc
+++ b/typeql-src/modules/ROOT/pages/data/fetch.adoc
@@ -285,8 +285,8 @@ to get more deterministic and predictable results.
 
 //mention IAM schema and data
 The following examples use the
-https://github.com/vaticle/typedb-docs/blob/master/typedb-src/modules/ROOT/attachments/iam-schema.tql[IAM schema,window=_blank] and
-https://github.com/vaticle/typedb-docs/blob/master/typedb-src/modules/ROOT/attachments/iam-data.tql[IAM sample data,window=_blank].
+https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[IAM schema,window=_blank] and
+https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[IAM sample data,window=_blank].
 
 [#_fetch_an_attribute]
 === Fetch an attribute
@@ -444,7 +444,7 @@ Hence, the value in "try-subquery" key has no type.
 
 We can use Fetch query to infer new facts.
 For example, we can use the `add-view-permission` rule from the
-https://github.com/vaticle/typedb-docs/blob/master/typedb-src/modules/ROOT/attachments/iam-schema.tql[IAM schema,window=_blank]
+https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[IAM schema,window=_blank]
 to infer `view_file` action access permissions.
 
 .Example of using inference
@@ -458,7 +458,7 @@ fetch $fp;
 ----
 
 Using the
-https://github.com/vaticle/typedb-docs/blob/master/typedb-src/modules/ROOT/attachments/iam-data.tql[IAM sample data,window=_blank]
+https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[IAM sample data,window=_blank]
 the above query shows any results only if inference is
 xref:manual::reading/infer.adoc#_how_to_send_a_query_with_inference[enabled].
 

--- a/typeql-src/modules/ROOT/pages/data/get.adoc
+++ b/typeql-src/modules/ROOT/pages/data/get.adoc
@@ -33,7 +33,7 @@ followed by optional <<_modifiers,modifiers>>.
 
 Get queries are written in TypeQL with the following syntax:
 
-[,bash]
+[,typeql]
 ----
 match <pattern>
 get <variable> [, <variable>];

--- a/typeql-src/modules/ROOT/pages/data/insert.adoc
+++ b/typeql-src/modules/ROOT/pages/data/insert.adoc
@@ -152,9 +152,9 @@ See an <<_multiple_role_players,example>> of inserting role players from a relat
 == Examples
 
 Use the IAM
-https://github.com/vaticle/typedb-docs/blob/master/typedb-src/modules/ROOT/attachments/iam-schema.tql[schema,window=_blank]
+https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[schema,window=_blank]
 and
-https://github.com/vaticle/typedb-docs/blob/master/typedb-src/modules/ROOT/attachments/iam-data.tql[sample data,window=_blank]
+https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[sample data,window=_blank]
 for the following examples.
 
 [#_inserting_data_with_no_matching]

--- a/typeql-src/modules/ROOT/pages/queries/fetch.adoc
+++ b/typeql-src/modules/ROOT/pages/queries/fetch.adoc
@@ -509,7 +509,7 @@ to get more deterministic and predictable results.
 
 We can use Fetch query to infer new facts.
 For example, we can use the `add-view-permission` rule from the
-https://github.com/vaticle/typedb-docs/blob/master/typedb-src/modules/ROOT/attachments/iam-schema.tql[IAM schema,window=_blank]
+https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[IAM schema,window=_blank]
 to infer `view_file` action access permissions.
 
 .Example of using inference
@@ -523,7 +523,7 @@ fetch $fp;
 ----
 
 Using the
-https://github.com/vaticle/typedb-docs/blob/master/typedb-src/modules/ROOT/attachments/iam-data.tql[IAM sample data,window=_blank]
+https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[IAM sample data,window=_blank]
 the above query shows any results only if inference is
 xref:manual::reading/infer.adoc#_how_to_send_a_query_with_inference[enabled].
 

--- a/typeql-src/modules/ROOT/pages/queries/get.adoc
+++ b/typeql-src/modules/ROOT/pages/queries/get.adoc
@@ -18,7 +18,7 @@ followed by optional <<_modifiers,modifiers>>.
 
 Get queries are written in TypeQL with the following syntax:
 
-[,bash]
+[,typeql]
 ----
 match <pattern>
 get <variable> [, <variable>];

--- a/typeql-src/modules/ROOT/pages/schema/rule-definitions.adoc
+++ b/typeql-src/modules/ROOT/pages/schema/rule-definitions.adoc
@@ -233,7 +233,7 @@ Note that all roles, roleplayers, and relation types are variablized, making thi
 
 Let's see an example of a more complex rule from the IAM schema.
 For the full IAM schema, see the
-https://github.com/vaticle/typedb-docs/blob/master/typedb-src/modules/ROOT/attachments/iam-schema.tql[iam-schema.tql]
+https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql]
 file in our documentation repository.
 
 .Complex rule example

--- a/typeql-src/modules/ROOT/pages/schema/undefine.adoc
+++ b/typeql-src/modules/ROOT/pages/schema/undefine.adoc
@@ -62,7 +62,7 @@ Alternatively, we can remove some parts of type definition, like an ownership of
 == Examples
 
 The following examples use a database with the
-https://github.com/vaticle/typedb-docs/blob/master/typedb-src/modules/ROOT/attachments/iam-schema.tql[IAM schema]
+https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[IAM schema]
 for Undefine queries.
 
 === Undefine a type
@@ -79,7 +79,7 @@ user-role sub user-group;
 ----
 
 The above example undefines four types from the
-https://github.com/vaticle/typedb-docs/blob/master/typedb-src/modules/ROOT/attachments/iam-schema.tql[IAM schema].
+https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[IAM schema].
 
 Note that `operation-set` is not a direct subtype of the `entity` root type.
 


### PR DESCRIPTION
## What is the goal of this PR?

Improve readability of bash (CLI) commands.
Improve TypeDB Console `source` command documentation.

## What are the changes implemented in this PR?

Replace `[,bash]` for `[source,console]` and add `$` at the beginning of the command line.
Add an example of the `source` command usage in the TypeDB Console.
Minor improvements to the TypeDB Console page.
