### PR TITLE
Renamed course overview and summary pages.

### DIFF
--- a/home-src/modules/ROOT/pages/quickstart.adoc
+++ b/home-src/modules/ROOT/pages/quickstart.adoc
@@ -372,7 +372,7 @@ Repeat the <<_query_examples>> from TypeDB Studio in TypeDB Console.
 After completing this guide, we recommend the following order of topics to continue exploring TypeDB:
 
 . Explore more interesting queries with the xref:home::25-queries.adoc[] page.
-. Learn more about TypeQL schemas, patterns, and queries in our xref:learn::course-overview.adoc[TypeDB Learning course].
+. Learn more about TypeQL schemas, patterns, and queries in our xref:learn::overview.adoc[TypeDB Learning course].
 . Go straight to practice with our xref:manual::overview.adoc[TypeDB manual]:
 * xref:manual::connecting/overview.adoc[]
 * xref:manual::defining/overview.adoc[]

--- a/learn-src/antora.yml
+++ b/learn-src/antora.yml
@@ -3,4 +3,4 @@ title: Learn
 version: 2.x
 nav:
 - modules/ROOT/nav.adoc
-start_page: learn::course-overview.adoc
+start_page: learn::overview.adoc

--- a/learn-src/modules/ROOT/pages/overview.adoc
+++ b/learn-src/modules/ROOT/pages/overview.adoc
@@ -1,4 +1,5 @@
 = The TypeDB learning course
+:page-aliases: learn::course-overview.adoc
 
 == Introduction
 

--- a/learn-src/modules/ROOT/pages/summary.adoc
+++ b/learn-src/modules/ROOT/pages/summary.adoc
@@ -1,4 +1,5 @@
 = The TypeDB learning course
+:page-aliases: learn::course-summary.adoc
 
 == Summary
 

--- a/learn-src/modules/ROOT/partials/learn-nav.adoc
+++ b/learn-src/modules/ROOT/partials/learn-nav.adoc
@@ -1,6 +1,6 @@
 .Learn
 
-* xref:learn::course-overview.adoc[Course overview]
+* xref:learn::overview.adoc[Overview]
 
 * xref:learn::1-why-typedb/1-why-typedb.adoc[Why TypeDB]
 
@@ -68,4 +68,4 @@
 ** xref:learn::11-manipulating-stateful-objects/11.1-retrieving-objects.adoc[Retrieving objects]
 ** xref:learn::11-manipulating-stateful-objects/11.2-operating-on-objects.adoc[Operating on objects]
 
-* xref:learn::course-summary.adoc[Course summary]
+* xref:learn::summary.adoc[Summary]


### PR DESCRIPTION
## What is the goal of this PR?

To rename the course overview and summary pages for a more consistent style across the docs.

## What are the changes implemented in this PR?

- Renamed course overview and summary pages.
- Added aliases for old page names.