### PR TITLE
Add inference toggle instructions for the inference page

### DIFF
--- a/manual-src/modules/ROOT/pages/reading/infer.adoc
+++ b/manual-src/modules/ROOT/pages/reading/infer.adoc
@@ -48,6 +48,7 @@ Then use the steps below:
 
 . Use a drop-down list in the top toolbar to select a database.
 . Switch to `data` session and `read` transaction types.
+. Enable the inference transaction option, by toggling on the `infer` button.
 . Open a new tab and insert or type in an Insert query, for example:
 +
 .TypeQL Fetch query
@@ -65,11 +66,12 @@ btn:[Run Query] button.
 Console::
 +
 --
-. Open a `data` session and `read` transaction to the selected database (e.g., `sample_db`):
+. Open a `data` session and `read` transaction to the selected database (e.g., `sample_db`)
+with the `infer` transaction option enabled:
 +
 [,bash]
 ----
-transaction sample_db data read
+transaction sample_db data read --infer true
 ----
 . Send the Fetch query:
 +


### PR DESCRIPTION
## What is the goal of this PR?

Fix the inference manual by re-introducing the toggling on of the inference option for Studio and Console.

## What are the changes implemented in this PR?

Add a step to toggle on the infer button for Studio.
Add the `--infer true` for the transaction command for Console.
