### PR TITLE
Referenced TypeDB 3.0 roadmap in relevant admonitions

### DIFF
--- a/learn-src/modules/ROOT/pages/11-manipulating-stateful-objects/11.2-programmatic-retrieval.adoc
+++ b/learn-src/modules/ROOT/pages/11-manipulating-stateful-objects/11.2-programmatic-retrieval.adoc
@@ -171,7 +171,7 @@ def cast_thing(thing: Thing) -> Entity | Relation:
 
 [WARNING]
 ====
-The `Thing` class is deprecated and will be removed in TypeDB 3.0.
+The `Thing` class is deprecated and will be removed in TypeDB 3.0. For more information, see the https://typedb.com/blog/typedb-3-roadmap[TypeDB 3.0 roadmap].
 ====
 
 The methods in the above table can also take types or roles as optional arguments on which to filter the data instances returned, as in the following example. This time, we only retrieve the contributions a book plays the `work` role in, rather than all relations.

--- a/learn-src/modules/ROOT/pages/12-advanced-modeling/12.2-using-type-theoretic-relations.adoc
+++ b/learn-src/modules/ROOT/pages/12-advanced-modeling/12.2-using-type-theoretic-relations.adoc
@@ -231,7 +231,7 @@ For this reason, it is even more important to choose interface names carefully w
 
 [NOTE]
 ====
-TypeDB 3.0 will include user-defined *functions* that allow for https://en.wikipedia.org/wiki/Ad_hoc_polymorphism[ad hoc polymorphism]. This will enable a new class of powerful polymorphic queries that do not depend on inheritance hierarchies or interface implementations. By making use of ad hoc polymorphism in TypeDB 3.0, interface names could be chosen freely and the desired polymorphic behaviour could still be implemented!
+TypeDB 3.0 will include user-defined *functions* that allow for https://en.wikipedia.org/wiki/Ad_hoc_polymorphism[ad hoc polymorphism]. This will enable a new class of powerful polymorphic queries that do not depend on inheritance hierarchies or interface implementations. By making use of ad hoc polymorphism in TypeDB 3.0, interface names could be chosen freely and the desired polymorphic behaviour could still be implemented! To learn more about this and other powerful new features, see the https://typedb.com/blog/typedb-3-roadmap[TypeDB 3.0 roadmap].
 ====
 
 

--- a/learn-src/modules/ROOT/pages/12-advanced-modeling/12.4-using-interface-contracts.adoc
+++ b/learn-src/modules/ROOT/pages/12-advanced-modeling/12.4-using-interface-contracts.adoc
@@ -163,7 +163,7 @@ music-score sub publication,
 
 [NOTE]
 ====
-TypeDB 2.x does not support the use of schema validation to enforce role contracts in the same way as for ownership contracts. This feature will be released in TypeDB 3.0.
+TypeDB 2.x does not support the use of schema validation to enforce role contracts in the same way as for ownership contracts. This feature will be released in TypeDB 3.0. To learn more about this and other powerful new features, see the https://typedb.com/blog/typedb-3-roadmap[TypeDB 3.0 roadmap].
 ====
 
 Below is a complete implementation of the bookstore schema using the type-theoretic framework of the PERA model, and including the new publication types `serial` and `music-score` and the `isn` interface contract.

--- a/learn-src/modules/ROOT/pages/3-reading-data/3.4-fetching-schema-types.adoc
+++ b/learn-src/modules/ROOT/pages/3-reading-data/3.4-fetching-schema-types.adoc
@@ -335,7 +335,7 @@ In addition to `company` (which is the direct supertype of `publisher`) and `pub
 
 [WARNING]
 ====
-The `thing` type is deprecated and will be removed in TypeDB 3.0.
+The `thing` type is deprecated and will be removed in TypeDB 3.0. For more information, see the https://typedb.com/blog/typedb-3-roadmap[TypeDB 3.0 roadmap].
 ====
 
 If we would like to retrieve only _direct_ subtypes or supertypes of a type, we can instead use the `sub!` keyword, similar to the `isa!` keyword!

--- a/learn-src/modules/ROOT/pages/4-writing-data/4.3-deleting-data.adoc
+++ b/learn-src/modules/ROOT/pages/4-writing-data/4.3-deleting-data.adoc
@@ -130,7 +130,7 @@ When deleting an entity, it's important to also delete any relations it plays a 
 
 [IMPORTANT]
 ====
-TypeDB 2.x does not support SQL-style cascading deletes. When a roleplayer in a relation is deleted, the relation must also be deleted manually. TypeDB 3.0 will include functionalities for relations to be automatically deleted when any roleplayer is deleted.
+TypeDB 2.x does not support SQL-style cascading deletes. When a roleplayer in a relation is deleted, the relation must also be deleted manually. TypeDB 3.0 will include functionalities for relations to be automatically deleted when any roleplayer is deleted. To learn more about this and other powerful new features, see the https://typedb.com/blog/typedb-3-roadmap[TypeDB 3.0 roadmap].
 ====
 
 [NOTE]

--- a/learn-src/modules/ROOT/pages/5-defining-schemas/5.1-defining-individual-types.adoc
+++ b/learn-src/modules/ROOT/pages/5-defining-schemas/5.1-defining-individual-types.adoc
@@ -73,7 +73,7 @@ In this case, `rating` and `order-line` are binary relation types, while `publis
 
 [NOTE]
 ====
-TypeDB 2.x does not include syntax for specifying the cardinality of roles. When instantiating a relation, all roles can be played any number of times. Syntax for restricting role cardinalities will be included in TypeDB 3.0.
+TypeDB 2.x does not include syntax for specifying the cardinality of roles. When instantiating a relation, all roles can be played any number of times. Syntax for restricting role cardinalities will be included in TypeDB 3.0. To learn more about this and other powerful new features, see the https://typedb.com/blog/typedb-3-roadmap[TypeDB 3.0 roadmap].
 ====
 
 .Exercise

--- a/learn-src/modules/ROOT/pages/5-defining-schemas/5.2-defining-type-hierarchies.adoc
+++ b/learn-src/modules/ROOT/pages/5-defining-schemas/5.2-defining-type-hierarchies.adoc
@@ -245,5 +245,5 @@ Value types of attribute types are inherited by their subtypes. In this case, `i
 
 [NOTE]
 ====
-In TypeDB 2.x, all attribute types in a hierarchy must have the same value type, as specified in the definition of the supertype. In TypeDB 3.0, it will be possible to create abstract attribute types that do not have a value type, and to assign different value types to their subtypes.
+In TypeDB 2.x, all attribute types in a hierarchy must have the same value type, as specified in the definition of the supertype. In TypeDB 3.0, it will be possible to create abstract attribute types that do not have a value type, and to assign different value types to their subtypes. To learn more about this and other powerful new features, see the https://typedb.com/blog/typedb-3-roadmap[TypeDB 3.0 roadmap].
 ====

--- a/learn-src/modules/ROOT/pages/5-defining-schemas/5.3-defining-constraints.adoc
+++ b/learn-src/modules/ROOT/pages/5-defining-schemas/5.3-defining-constraints.adoc
@@ -18,7 +18,7 @@ Regex constraints apply directly to attributes, regardless of the owning type. I
 
 [NOTE]
 ====
-The `regex` constraint is the only attribute value constraint in TypeDB 2.x. TypeDB 3.0 will feature other value constraints, such as ranges for numeric values and enums.
+The `regex` constraint is the only attribute value constraint in TypeDB 2.x. TypeDB 3.0 will feature other value constraints, such as ranges for numeric values and enums. To learn more about this and other powerful new features, see the https://typedb.com/blog/typedb-3-roadmap[TypeDB 3.0 roadmap].
 ====
 
 == Constraining attribute ownerships

--- a/learn-src/modules/ROOT/pages/6-building-applications/6.2-managing-users-and-databases.adoc
+++ b/learn-src/modules/ROOT/pages/6-building-applications/6.2-managing-users-and-databases.adoc
@@ -77,7 +77,7 @@ with TypeDB.core_driver(ADDRESS) as driver:
 // Add after switch to Cloud
 // [NOTE]
 // ====
-// In TypeDB 3.0, database management controls will only be available to admins.
+// In TypeDB 3.0, database management controls will only be available to admins. To learn more about this and other powerful new features, see the https://typedb.com/blog/typedb-3-roadmap[TypeDB 3.0 roadmap].
 // ====
 
 .Exercise
@@ -324,7 +324,7 @@ def print_database_details(driver: TypeDBDriver) -> None:
 // // Add after switch to Cloud
 // // [NOTE]
 // // ====
-// // In TypeDB 3.0, database management controls will only be available to admins.
+// // In TypeDB 3.0, database management controls will only be available to admins. To learn more about this and other powerful new features, see the https://typedb.com/blog/typedb-3-roadmap[TypeDB 3.0 roadmap].
 // // ====
 //
 // .Exercise

--- a/learn-src/modules/ROOT/pages/7-understanding-query-patterns/7.1-patterns-as-constraints.adoc
+++ b/learn-src/modules/ROOT/pages/7-understanding-query-patterns/7.1-patterns-as-constraints.adoc
@@ -93,7 +93,7 @@ Every pattern is equivalent to a list of *constraints* that must be *simultaneou
 
 [NOTE]
 ====
-In TypeDB 2.x, the `match` clause of all queries uses all-or-nothing pattern matching, meaning that every constraint must be satisfied simultaneously. Syntax for optional pattern elements will be introduced in TypeDB 3.0, which will allow some constraints to be matched only if possible.
+In TypeDB 2.x, the `match` clause of all queries uses all-or-nothing pattern matching, meaning that every constraint must be satisfied simultaneously. Syntax for optional pattern elements will be introduced in TypeDB 3.0, which will allow some constraints to be matched only if possible. To learn more about this and other powerful new features, see the https://typedb.com/blog/typedb-3-roadmap[TypeDB 3.0 roadmap].
 ====
 
 The types of `$book`, `$user`, and `$review` are not explicitly specified in the pattern, but we have previously seen how TypeDB is able to infer their types regardless. This is done by solving the pattern as a *constraint satisfaction* problem.

--- a/learn-src/modules/ROOT/pages/7-understanding-query-patterns/7.5-value-expressions.adoc
+++ b/learn-src/modules/ROOT/pages/7-understanding-query-patterns/7.5-value-expressions.adoc
@@ -86,7 +86,7 @@ We will explore the different value operations, along with the value types they 
 
 [NOTE]
 ====
-In TypeDB 2.x, the only supported operations are on longs and doubles. Datetime, string, and boolean operations will be available in TypeDB 3.0.
+In TypeDB 2.x, the only supported operations are on longs and doubles. Datetime, string, and boolean operations will be available in TypeDB 3.0. To learn more about this and other powerful new features, see the https://typedb.com/blog/typedb-3-roadmap[TypeDB 3.0 roadmap].
 ====
 
 == Arithmetic operations

--- a/learn-src/modules/ROOT/pages/9-modeling-schemas/9.1-the-pera-model.adoc
+++ b/learn-src/modules/ROOT/pages/9-modeling-schemas/9.1-the-pera-model.adoc
@@ -37,7 +37,7 @@ This difference also affects permitted *interface implementations* in the PERA m
 
 [WARNING]
 ====
-In TypeDB 2.x, attribute types can implement interfaces (own other attribute types and play roles in relation types) in the same way object types can, contrary to the PERA model. This behaviour is deprecated and will be removed in TypeDB 3.0. In some niche cases, usage of this feature can result in information loss due to attribute idempotency, so it is strongly advised against.
+In TypeDB 2.x, attribute types can implement interfaces (own other attribute types and play roles in relation types) in the same way object types can, contrary to the PERA model. This behaviour is deprecated and will be removed in TypeDB 3.0. In some niche cases, usage of this feature can result in information loss due to attribute idempotency, so it is strongly advised against. For more information, see the https://typedb.com/blog/typedb-3-roadmap[TypeDB 3.0 roadmap].
 ====
 
 === Polymorphic features

--- a/manual-src/modules/ROOT/pages/bulk-loading/preventing-duplication.adoc
+++ b/manual-src/modules/ROOT/pages/bulk-loading/preventing-duplication.adoc
@@ -49,7 +49,7 @@ We can adopt one of three strategies to prevent duplications of this kind from h
 
 [NOTE]
 ====
-TypeDB 3.0 will introduce a "put" operation, which can be used to insert data only if it doesn't already exist. This will allow the above example data to be inserted in a single highly performant query, with each entity or relation being inserted only if it doesn't exist already. Find out more about this and other powerful new features in the https://typedb.com/blog/typedb-3-roadmap[TypeDB 3.0 roadmap].
+TypeDB 3.0 will introduce a "put" operation, which can be used to insert data only if it doesn't already exist. This will allow the above example data to be inserted in a single highly performant query, with each entity or relation being inserted only if it doesn't exist already. To learn more about this and other powerful new features, see the https://typedb.com/blog/typedb-3-roadmap[TypeDB 3.0 roadmap].
 ====
 
 == Pre-processing data

--- a/typeql-src/modules/ROOT/partials/thing-warning-with-example.adoc
+++ b/typeql-src/modules/ROOT/partials/thing-warning-with-example.adoc
@@ -1,6 +1,6 @@
 [WARNING]
 ====
-The `thing` internal type will be deprecated in one of the upcoming versions and deleted in TypeDB version `3.0`.
+The `thing` internal type will be deprecated in one of the upcoming versions and deleted in TypeDB version `3.0`. For more information, see the https://typedb.com/blog/typedb-3-roadmap[TypeDB 3.0 roadmap].
 
 Consider using `entity`, `attribute`, or `relation` built-in types instead.
 

--- a/typeql-src/modules/ROOT/partials/thing-warning.adoc
+++ b/typeql-src/modules/ROOT/partials/thing-warning.adoc
@@ -1,4 +1,4 @@
 [WARNING]
 ====
-The `thing` built-in type is deprecated and will be deleted in TypeDB version `3.0`.
+The `thing` built-in type is deprecated and will be deleted in TypeDB version `3.0`. For more information, see the https://typedb.com/blog/typedb-3-roadmap[TypeDB 3.0 roadmap].
 ====


### PR DESCRIPTION
## What is the goal of this PR?

To reference the TypeDB 3.0 roadmap in all admonitions where future 3.0 features are mentioned, or where deprecated 2.x features are mentioned.

## What are the changes implemented in this PR?

- Added references to the roadmap in all relevant admonitions.