### PR TITLE
Remove enum tag in python driver docs.

### DIFF
--- a/drivers-src/modules/ROOT/partials/tutorials/python/sample.py
+++ b/drivers-src/modules/ROOT/partials/tutorials/python/sample.py
@@ -6,12 +6,13 @@ from enum import Enum
 
 
 # tag::constants[]
+DB_NAME = "sample_app_db"
+SERVER_ADDR = "127.0.0.1:1729"
+
 class Edition(Enum):
     Cloud = 1
     Core = 2
 
-DB_NAME = "sample_app_db"
-SERVER_ADDR = "127.0.0.1:1729"
 TYPEDB_EDITION = Edition.Core
 CLOUD_USERNAME = "admin"
 CLOUD_PASSWORD = "password"

--- a/drivers-src/modules/ROOT/partials/tutorials/python/sample.py
+++ b/drivers-src/modules/ROOT/partials/tutorials/python/sample.py
@@ -5,14 +5,11 @@ from enum import Enum
 # end::import[]
 
 
-# tag::enum[]
+# tag::constants[]
 class Edition(Enum):
     Cloud = 1
     Core = 2
-# end::enum[]
 
-
-# tag::constants[]
 DB_NAME = "sample_app_db"
 SERVER_ADDR = "127.0.0.1:1729"
 TYPEDB_EDITION = Edition.Core


### PR DESCRIPTION
## What is the goal of this PR?

Resolves #883.

## What are the changes implemented in this PR?

Removes the enum tag from `sample.py` and include the `Edition` enum in the constants tag.

This is consistent with the other driver examples (e.g., [Java](https://github.com/vaticle/typedb-docs/blob/4a52a99237ed3269230e3a3579ce7e801f91a584/drivers-src/modules/ROOT/partials/tutorials/java/src/main/java/org/example2/Main.java#L20-L32), [CPP](https://github.com/vaticle/typedb-docs/blob/4a52a99237ed3269230e3a3579ce7e801f91a584/drivers-src/modules/ROOT/partials/tutorials/cpp/main.cpp#L8-L15)).