### PR TITLE
Typo fix in example query

### DIFF
--- a/learn-src/modules/ROOT/pages/5-defining-schemas/5.1-defining-individual-types.adoc
+++ b/learn-src/modules/ROOT/pages/5-defining-schemas/5.1-defining-individual-types.adoc
@@ -234,7 +234,7 @@ Write a query to define seven new ownerships:
 define
 address owns street;
 publication owns year;
-review owns owns score;
+review owns score;
 promotion owns code,
     owns start-timestamp,
     owns end-timestamp;


### PR DESCRIPTION
remove duplicate `owns` keyword causing syntax error

## What is the goal of this PR?

This PR corrects a sample solution for defining ownerships in lesson 5.1. The previous solution incorrectly repeated the keyword `owns`, causing invalid syntax when executed. The updated solution remedies this error and is a functioning TypeQL query.

## What are the changes implemented in this PR?

This is a lesson documentation update only.
