### PR TITLE
Typo fixes in example queries

### DIFF
--- a/learn-src/modules/ROOT/pages/5-defining-schemas/5.2-defining-type-hierarchies.adoc
+++ b/learn-src/modules/ROOT/pages/5-defining-schemas/5.2-defining-type-hierarchies.adoc
@@ -169,7 +169,7 @@ Write a query to define the following new roleplayers:
 [,typeql]
 ----
 define
-book plays contrubution:work;
+book plays contribution:work;
 contributor plays contribution:contributor;
 contributor plays authoring:author;
 contributor plays editing:editor;
@@ -187,7 +187,7 @@ match
 (work: $book, contributor: $contributor) isa contribution;
 fetch
 $book: title;
-$contributor: $name;
+$contributor: name;
 ----
 
 .Exercise
@@ -204,7 +204,7 @@ match
 (work: $book, author: $contributor) isa authoring;
 fetch
 $book: title;
-$contributor: $name;
+$contributor: name;
 ----
 =====
 


### PR DESCRIPTION
## What is the goal of this PR?

This PR updates the lesson documentation to ensure provided TypeQL queries are correct, ensuring end-users can follow along more easily. The previous version contained three queries that resulted in syntax issues, whereas the new version corrects these queries.

## What are the changes implemented in this PR?

Correct typo in one query and fix two additional queries that use a variable instead of an attribute name
