### PR TITLE
Update docker run instructions to docker create & docker start instead

### DIFF
--- a/home-src/modules/ROOT/pages/install/cloud-self-hosted.adoc
+++ b/home-src/modules/ROOT/pages/install/cloud-self-hosted.adoc
@@ -49,13 +49,13 @@ To pull the TypeDB Cloud Docker image, run:
 $ docker pull vaticle/typedb-cloud:latest
 ----
 
-Use `docker run` to create a new container with the downloaded image.
+Use `docker create` to create a new container with the downloaded image.
 By default, a TypeDB Cloud server is expected to be running on port `1729`.
 To ensure that data is preserved even when the container is killed or restarted, use Docker volumes:
 
 [source,console]
 ----
-$ docker run --name typedb -d -p 1729:1729 \
+$ docker create --name typedb -p 1729:1729 \
     -v $(pwd)/db/data:/opt/typedb-cloud-all-linux-x86_64/server/data \
     -v $(pwd)/db/replication:/opt/typedb-cloud-all-linux-x86_64/server/replication \
     -v $(pwd)/db/user:/opt/typedb-cloud-all-linux-x86_64/server/user \
@@ -64,7 +64,7 @@ $ docker run --name typedb -d -p 1729:1729 \
 
 ==== Start and Stop TypeDB Cloud in Docker
 
-To start the Docker container:
+To start the Docker container, or restart a stopped container:
 
 [source,console]
 ----

--- a/home-src/modules/ROOT/pages/install/cloud-self-hosted.adoc
+++ b/home-src/modules/ROOT/pages/install/cloud-self-hosted.adoc
@@ -51,11 +51,15 @@ $ docker pull vaticle/typedb-cloud:latest
 
 Use `docker run` to create a new container with the downloaded image.
 By default, a TypeDB Cloud server is expected to be running on port `1729`.
-To ensure that data is preserved even when the container is killed or restarted, use a Docker volume:
+To ensure that data is preserved even when the container is killed or restarted, use Docker volumes:
 
 [source,console]
 ----
-$ docker run --name typedb -d -v $(pwd)/db/:/opt/ -p 1729:1729 vaticle/typedb-cloud:latest
+$ docker run --name typedb -d -p 1729:1729 \
+    -v $(pwd)/db/data:/opt/typedb-cloud-all-linux-x86_64/server/data \
+    -v $(pwd)/db/replication:/opt/typedb-cloud-all-linux-x86_64/server/replication \
+    -v $(pwd)/db/user:/opt/typedb-cloud-all-linux-x86_64/server/user \
+    vaticle/typedb-cloud:latest
 ----
 
 ==== Start and Stop TypeDB Cloud in Docker

--- a/home-src/modules/ROOT/partials/docker.adoc
+++ b/home-src/modules/ROOT/partials/docker.adoc
@@ -22,11 +22,12 @@ see the link:https://github.com/vaticle/typedb/releases[Releases,window=_blank] 
 // end::install[]
 
 // tag::run[]
-To create and run a new Docker container with TypeDB Core server:
+To create a new Docker container with TypeDB Core server:
 
 [source,console]
 ----
-$ docker run --name typedb -d -v typedb-data:/opt/ -p 1729:1729 --platform linux/amd64 vaticle/typedb:latest
+$ docker volume create typedb-data
+$ docker create --name typedb -d -v typedb-data:/opt/typedb-all-linux-x86_64/server/data -p 1729:1729 --platform linux/amd64 vaticle/typedb:latest
 ----
 // end::run[]
 // tag::run-info[]
@@ -37,6 +38,15 @@ architecture.
 //Support for `linux/arm64` will be released in a future version of TypeDB.
 // end::run-info[]
 
+// tag::start[]
+To start the created Docker container, or restart a stopped container:
+
+[source,console]
+----
+$ docker start typedb
+----
+// end::start[]
+
 // tag::stop[]
 To stop a running Docker container:
 
@@ -46,11 +56,3 @@ $ docker stop typedb
 ----
 // end::stop[]
 
-// tag::start[]
-To start an existing Docker container again:
-
-[source,console]
-----
-$ docker start typedb
-----
-// end::start[]

--- a/home-src/modules/ROOT/partials/docker.adoc
+++ b/home-src/modules/ROOT/partials/docker.adoc
@@ -27,7 +27,7 @@ To create a new Docker container with TypeDB Core server:
 [source,console]
 ----
 $ docker volume create typedb-data
-$ docker create --name typedb -d -v typedb-data:/opt/typedb-all-linux-x86_64/server/data -p 1729:1729 --platform linux/amd64 vaticle/typedb:latest
+$ docker create --name typedb -v typedb-data:/opt/typedb-all-linux-x86_64/server/data -p 1729:1729 --platform linux/amd64 vaticle/typedb:latest
 ----
 // end::run[]
 // tag::run-info[]


### PR DESCRIPTION
## What is the goal of this PR?
Update instructions for using the TypeDB core & cloud docker images to be more explicit about mounting volumes.

## What are the changes implemented in this PR?
* Update TypeDB core docker command to create a named docker volume & mount `server/data` on it.
* Update TypeDB Cloud docker command to create a volume each for data, replication and user.