### PR TITLE
Updated all occurrences of "Vaticle" to "TypeDB" where possible

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Report a bug here, or visit discuss.vaticle.com for troubleshooting discussions
+about: Report a bug here, or visit forum.typedb.com for troubleshooting discussions
 title: ''
 labels: bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Request a feature here, or visit discuss.vaticle.com for ideas and questions
+about: Request a feature here, or visit forum.typedb.com for ideas and questions
 title: ''
 labels: feature
 assignees: ''

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vaticle Documentation
+# TypeDB Documentation
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/e8d3d72a-dcb6-4e31-bfc5-deb4e665d083/deploy-status)](https://app.netlify.com/sites/typedb-docs/deploys)
 [![Discord](https://img.shields.io/discord/665254494820368395?color=7389D8&label=chat&logo=discord&logoColor=ffffff)](https://typedb.com/discord)
@@ -6,7 +6,7 @@
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-typedb-796de3.svg)](https://stackoverflow.com/questions/tagged/typedb)
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-typeql-3dce8c.svg)](https://stackoverflow.com/questions/tagged/typeql)
 
-This repository contains all content that powers the Vaticle Documentation Portal, accessible at [https://typedb.com/docs](https://typedb.com/docs).
+This repository contains all content that powers the TypeDB Documentation Portal, accessible at [https://typedb.com/docs](https://typedb.com/docs).
 
 ---
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2024 TypeDB
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/academy-src/modules/ROOT/attachments/bookstore-data.tql
+++ b/academy-src/modules/ROOT/attachments/bookstore-data.tql
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024 Vaticle
+# Copyright (C) 2024 TypeDB
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/academy-src/modules/ROOT/attachments/bookstore-schema.tql
+++ b/academy-src/modules/ROOT/attachments/bookstore-schema.tql
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024 Vaticle
+# Copyright (C) 2024 TypeDB
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/academy-src/modules/ROOT/attachments/python-sample-app.py
+++ b/academy-src/modules/ROOT/attachments/python-sample-app.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024 Vaticle
+# Copyright (C) 2024 TypeDB
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/academy-src/modules/ROOT/attachments/type-theoretic-schema.tql
+++ b/academy-src/modules/ROOT/attachments/type-theoretic-schema.tql
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024 Vaticle
+# Copyright (C) 2024 TypeDB
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/academy-src/modules/ROOT/pages/3-reading-data/3.4-fetching-schema-types.adoc
+++ b/academy-src/modules/ROOT/pages/3-reading-data/3.4-fetching-schema-types.adoc
@@ -202,7 +202,7 @@ https://typedb.com/fundamentals/type-theory[_Everything has a type, and so every
 ____
 
 // This section is omitted due to the difficulty of retrieving exact roles.
-// See: https://github.com/vaticle/typedb/issues/6986#issuecomment-1948116205
+// See: https://github.com/typedb/typedb/issues/6986#issuecomment-1948116205
 // == Variablizing roles
 //
 // The ability to variablize types in queries arises from TypeQL's core philosophy:

--- a/dependencies/maven/BUILD
+++ b/dependencies/maven/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2024 TypeDB
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/dependencies/vaticle/BUILD
+++ b/dependencies/vaticle/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2024 TypeDB
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2024 TypeDB
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/drivers-src/modules/ROOT/pages/c/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/c/overview.adoc
@@ -3,11 +3,11 @@
 :keywords: typedb, client, driver, c
 :pageTitle: TypeDB C driver
 
-The C language driver was developed by Vaticle to enable TypeDB support for C language software and developers.
+The C language driver was developed by the TypeDB team to enable TypeDB support for C language software and developers.
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb-driver/tree/development/c[GitHub,window=_blank]
+.link:https://github.com/typedb/typedb-driver/tree/development/c[GitHub,window=_blank]
 [.clickable]
 ****
 The GitHub repository with the driver's source code and release notes.

--- a/drivers-src/modules/ROOT/pages/c/tutorial.adoc
+++ b/drivers-src/modules/ROOT/pages/c/tutorial.adoc
@@ -11,7 +11,7 @@ In this tutorial, we'll build a sample application with the C driver capable of 
 * Send different types of queries.
 
 Follow the steps below or see the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/c/tutorial.c[full source code,window=_blank].
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/c/tutorial.c[full source code,window=_blank].
 
 == Environment setup
 
@@ -137,7 +137,7 @@ include::drivers::partial$tutorials/c/tutorial.c[tag=db-schema-setup]
 ----
 
 The schema for the sample application is stored in the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql,window=_blank]
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql,window=_blank]
 file.
 
 .See the full schema
@@ -164,7 +164,7 @@ include::drivers::partial$tutorials/c/tutorial.c[tag=db-dataset-setup]
 ----
 
 We read the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[iam-data-single-query.tql,window=_blank]
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[iam-data-single-query.tql,window=_blank]
 file, send its contents as a single query, and then commit the changes.
 
 .See the full Insert query
@@ -323,7 +323,7 @@ include::drivers::partial$tutorials/c/tutorial.c[tag=error_handling]
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/c/tutorial.c[Source code,window=_blank]
+.link:https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/c/tutorial.c[Source code,window=_blank]
 [.clickable]
 ****
 The full source code of this sample application.

--- a/drivers-src/modules/ROOT/pages/cpp/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/cpp/overview.adoc
@@ -3,11 +3,11 @@
 :keywords: typedb, client, driver, c++, cpp, clang
 :pageTitle: TypeDB C++ driver
 
-The C\++ driver was developed by Vaticle to enable TypeDB support for C++ software and developers.
+The C\++ driver was developed by the TypeDB team to enable TypeDB support for C++ software and developers.
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb-driver/tree/development/cpp[GitHub,window=_blank]
+.link:https://github.com/typedb/typedb-driver/tree/development/cpp[GitHub,window=_blank]
 [.clickable]
 ****
 The GitHub repository with the driver's source code and release notes.
@@ -33,7 +33,7 @@ For Linux: the minimum version of `glibc` is `2.25.0`.
 
 To install TypeDB C++ driver:
 
-. https://github.com/vaticle/typedb-driver/releases[Download] the latest release for you architecture (`x86_64`/`arm64`)
+. https://github.com/typedb/typedb-driver/releases[Download] the latest release for you architecture (`x86_64`/`arm64`)
 and OS (Linux/macOS/Win).
 . Place the `.dylib` file in the `lib` directory inside your project folder
 and all the header files in the `include` directory.

--- a/drivers-src/modules/ROOT/pages/cpp/tutorial.adoc
+++ b/drivers-src/modules/ROOT/pages/cpp/tutorial.adoc
@@ -11,7 +11,7 @@ In this tutorial, we'll build a sample application with the C++ driver capable o
 * Send different types of queries.
 
 Follow the steps below or see the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/cpp/main.cpp[full source code,window=_blank].
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/cpp/main.cpp[full source code,window=_blank].
 
 == Environment setup
 
@@ -137,7 +137,7 @@ include::drivers::partial$tutorials/cpp/main.cpp[tag=db-schema-setup]
 ----
 
 The schema for the sample application is stored in the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql,window=_blank]
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql,window=_blank]
 file.
 
 .See the full schema
@@ -164,7 +164,7 @@ include::drivers::partial$tutorials/cpp/main.cpp[tag=db-dataset-setup]
 ----
 
 We read the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[iam-data-single-query.tql,window=_blank]
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[iam-data-single-query.tql,window=_blank]
 file, send its contents as a single query, and then commit the changes.
 
 .See the full Insert query
@@ -319,7 +319,7 @@ include::drivers::partial$tutorials/cpp/main.cpp[tag=delete]
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/cpp/main.cpp[Source code,window=_blank]
+.link:https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/cpp/main.cpp[Source code,window=_blank]
 [.clickable]
 ****
 The full source code of this sample application.

--- a/drivers-src/modules/ROOT/pages/csharp/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/csharp/overview.adoc
@@ -3,11 +3,11 @@
 :keywords: typedb, client, driver, c#, cpp, clang
 :pageTitle: TypeDB C# driver
 
-The C# driver was developed by Vaticle to enable TypeDB support for C# software and developers.
+The C# driver was developed by the TypeDB team to enable TypeDB support for C# software and developers.
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb-driver/tree/development/csharp[GitHub,window=_blank]
+.link:https://github.com/typedb/typedb-driver/tree/development/csharp[GitHub,window=_blank]
 [.clickable]
 ****
 The GitHub repository with the driver's source code and release notes.

--- a/drivers-src/modules/ROOT/pages/csharp/tutorial.adoc
+++ b/drivers-src/modules/ROOT/pages/csharp/tutorial.adoc
@@ -11,7 +11,7 @@ In this tutorial, we'll build a sample application with the C# driver capable of
 * Send different types of queries.
 
 Follow the steps below or see the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/csharp/tutorial.cs[full source code,window=_blank].
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/csharp/tutorial.cs[full source code,window=_blank].
 
 == Environment setup
 
@@ -137,7 +137,7 @@ include::drivers::partial$tutorials/csharp/tutorial.cs[tag=db-schema-setup]
 ----
 
 The schema for the sample application is stored in the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql,window=_blank]
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql,window=_blank]
 file.
 
 .See the full schema
@@ -164,7 +164,7 @@ include::drivers::partial$tutorials/csharp/tutorial.cs[tag=db-dataset-setup]
 ----
 
 We read the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[iam-data-single-query.tql,window=_blank]
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[iam-data-single-query.tql,window=_blank]
 file, send its contents as a single query, and then commit the changes.
 
 .See the full Insert query
@@ -313,7 +313,7 @@ include::drivers::partial$tutorials/csharp/tutorial.cs[tag=delete]
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/csharp/tutorial.cs[Source code,window=_blank]
+.link:https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/csharp/tutorial.cs[Source code,window=_blank]
 [.clickable]
 ****
 The full source code of this sample application.

--- a/drivers-src/modules/ROOT/pages/java/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/java/overview.adoc
@@ -4,11 +4,11 @@
 :keywords: typedb, driver, java
 :pageTitle: TypeDB Java driver
 
-The Java driver was developed by Vaticle to enable TypeDB support for Java software and developers.
+The Java driver was developed by the TypeDB team to enable TypeDB support for Java software and developers.
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb-driver/tree/development/java[GitHub,window=_blank]
+.link:https://github.com/typedb/typedb-driver/tree/development/java[GitHub,window=_blank]
 [.clickable]
 ****
 The GitHub repository with the driver's source code and release notes.

--- a/drivers-src/modules/ROOT/pages/java/tutorial.adoc
+++ b/drivers-src/modules/ROOT/pages/java/tutorial.adoc
@@ -11,7 +11,7 @@ In this tutorial, we'll build a sample application with the Java driver capable 
 * Send different types of queries.
 
 Follow the steps below or see the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/java/src/main/java/org/example2/Main.java[full source code,window=_blank].
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/java/src/main/java/org/example2/Main.java[full source code,window=_blank].
 
 == Environment setup
 
@@ -138,7 +138,7 @@ include::drivers::partial$tutorials/java/src/main/java/org/example2/Main.java[ta
 ----
 
 The schema for the sample application is stored in the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql,window=_blank]
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql,window=_blank]
 file.
 
 .See the full schema
@@ -165,7 +165,7 @@ include::drivers::partial$tutorials/java/src/main/java/org/example2/Main.java[ta
 ----
 
 We read the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[iam-data-single-query.tql,window=_blank]
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[iam-data-single-query.tql,window=_blank]
 file, send its contents as a single query, and then commit the changes.
 
 .See the full Insert query
@@ -316,7 +316,7 @@ include::drivers::partial$tutorials/java/src/main/java/org/example2/Main.java[ta
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/java/src/main.rs[Source code,window=_blank]
+.link:https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/java/src/main.rs[Source code,window=_blank]
 [.clickable]
 ****
 The full source code of this sample application.

--- a/drivers-src/modules/ROOT/pages/nodejs/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/nodejs/overview.adoc
@@ -4,17 +4,17 @@
 :keywords: typedb, driver, node.js
 :pageTitle: TypeDB Node.js driver
 
-The Node.js driver was developed by Vaticle to enable TypeDB support for Node.js software and developers.
+The Node.js driver was developed by the TypeDB team to enable TypeDB support for Node.js software and developers.
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb-driver/tree/development/nodejs[GitHub,window=_blank]
+.link:https://github.com/typedb/typedb-driver/tree/development/nodejs[GitHub,window=_blank]
 [.clickable]
 ****
 The GitHub repository with the driver's source code and release notes.
 ****
 
-//.link:https://github.com/vaticle/typedb-driver/releases[Releases,window=_blank]
+//.link:https://github.com/typedb/typedb-driver/releases[Releases,window=_blank]
 //[.clickable]
 //****
 

--- a/drivers-src/modules/ROOT/pages/nodejs/tutorial.adoc
+++ b/drivers-src/modules/ROOT/pages/nodejs/tutorial.adoc
@@ -12,7 +12,7 @@ In this tutorial, we'll build a sample application with the Node.js driver capab
 * Send different types of queries.
 
 Follow the steps below or see the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/nodejs/sample.js[full source code,window=_blank].
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/nodejs/sample.js[full source code,window=_blank].
 
 == Environment setup
 
@@ -138,7 +138,7 @@ include::drivers::partial$tutorials/nodejs/sample.js[tag=db-schema-setup]
 ----
 
 The schema for the sample application is stored in the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql,window=_blank]
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql,window=_blank]
 file.
 
 .See the full schema
@@ -165,7 +165,7 @@ include::drivers::partial$tutorials/nodejs/sample.js[tag=db-dataset-setup]
 ----
 
 We read the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[iam-data-single-query.tql,window=_blank]
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[iam-data-single-query.tql,window=_blank]
 file, send its contents as a single query, and then commit the changes.
 
 .See the full TypeQL Insert query
@@ -318,7 +318,7 @@ include::drivers::partial$tutorials/nodejs/sample.js[tag=delete]
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/nodejs/sample.js[Source code,window=_blank]
+.link:https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/nodejs/sample.js[Source code,window=_blank]
 [.clickable]
 ****
 The full source code of this sample application.

--- a/drivers-src/modules/ROOT/pages/other-languages.adoc
+++ b/drivers-src/modules/ROOT/pages/other-languages.adoc
@@ -4,7 +4,7 @@
 :longTailKeywords: typedb client, typedb community client, typedb julia client, typedb haskell client
 :pageTitle: Community TypeDB Clients
 
-Community client drivers are not maintained by Vaticle. They are built and maintained fully by the community.
+Community client drivers are not maintained by the TypeDB team. They are built and maintained fully by the community.
 
 == TypeDB Clients developed by the community
 

--- a/drivers-src/modules/ROOT/pages/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/overview.adoc
@@ -9,7 +9,7 @@ Welcome to the TypeDB driver documentation!
 == Introduction
 
 TypeDB accepts client connections via gRPC based
-https://github.com/vaticle/typedb-protocol[TypeDB driver RPC,window=_blank] protocol.
+https://github.com/typedb/typedb-protocol[TypeDB driver RPC,window=_blank] protocol.
 
 To build an application capable of connecting to TypeDB, we can use one of the
 existing libraries implementing it, called TypeDB drivers, or we can implement it ourselves as a new driver.

--- a/drivers-src/modules/ROOT/pages/python/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/python/overview.adoc
@@ -4,17 +4,17 @@
 :keywords: typedb, client, driver, python
 :pageTitle: TypeDB Python driver
 
-The Python driver was developed by Vaticle to enable TypeDB support for Python software and developers.
+The Python driver was developed by the TypeDB team to enable TypeDB support for Python software and developers.
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb-driver/tree/development/python[GitHub,window=_blank]
+.link:https://github.com/typedb/typedb-driver/tree/development/python[GitHub,window=_blank]
 [.clickable]
 ****
 The GitHub repository with the driver's source code and release notes.
 ****
 
-//.link:https://github.com/vaticle/typedb-driver/releases[Releases,window=_blank]
+//.link:https://github.com/typedb/typedb-driver/releases[Releases,window=_blank]
 //[.clickable]
 //****
 

--- a/drivers-src/modules/ROOT/pages/python/tutorial.adoc
+++ b/drivers-src/modules/ROOT/pages/python/tutorial.adoc
@@ -12,7 +12,7 @@ In this tutorial, we'll build a sample application with the Python driver capabl
 * Send different types of queries.
 
 Follow the steps below or see the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/python/sample.py[full source code,window=_blank].
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/python/sample.py[full source code,window=_blank].
 
 == Environment setup
 
@@ -148,7 +148,7 @@ include::drivers::partial$tutorials/python/sample.py[tag=db-schema-setup]
 ----
 
 The schema for the sample application is stored in the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql,window=_blank]
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql,window=_blank]
 file.
 
 .See the full schema
@@ -175,7 +175,7 @@ include::drivers::partial$tutorials/python/sample.py[tag=db-dataset-setup]
 ----
 
 We read the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[iam-data-single-query.tql,window=_blank]
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[iam-data-single-query.tql,window=_blank]
 file, send its contents as a single query, and then commit the changes.
 
 .See the full Insert query
@@ -334,7 +334,7 @@ include::drivers::partial$tutorials/python/sample.py[tag=delete]
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/python/sample.py[Source code,window=_blank]
+.link:https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/python/sample.py[Source code,window=_blank]
 [.clickable]
 ****
 The full source code of this sample application.

--- a/drivers-src/modules/ROOT/pages/rust/overview.adoc
+++ b/drivers-src/modules/ROOT/pages/rust/overview.adoc
@@ -4,17 +4,17 @@
 :keywords: typedb, client, driver, rust
 :pageTitle: TypeDB Rust driver
 
-The Rust driver was developed by Vaticle to enable TypeDB support for Rust software and developers.
+The Rust driver was developed by the TypeDB team to enable TypeDB support for Rust software and developers.
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb-driver/tree/development/rust[GitHub,window=_blank]
+.link:https://github.com/typedb/typedb-driver/tree/development/rust[GitHub,window=_blank]
 [.clickable]
 ****
 The GitHub repository with the driver's source code and release notes.
 ****
 
-//.link:https://github.com/vaticle/typedb-driver/releases[Releases,window=_blank]
+//.link:https://github.com/typedb/typedb-driver/releases[Releases,window=_blank]
 //[.clickable]
 //****
 

--- a/drivers-src/modules/ROOT/pages/rust/tutorial.adoc
+++ b/drivers-src/modules/ROOT/pages/rust/tutorial.adoc
@@ -12,7 +12,7 @@ In this tutorial, we'll build a sample application with the Rust driver capable 
 * Send different types of queries.
 
 Follow the steps below or see the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/rust/src/main.rs[full source code,window=_blank].
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/rust/src/main.rs[full source code,window=_blank].
 
 == Environment setup
 
@@ -147,7 +147,7 @@ include::drivers::partial$tutorials/rust/src/main.rs[tag=db-schema-setup]
 ----
 
 The schema for the sample application is stored in the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql,window=_blank]
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql,window=_blank]
 file.
 
 .See the full schema
@@ -174,7 +174,7 @@ include::drivers::partial$tutorials/rust/src/main.rs[tag=db-dataset-setup]
 ----
 
 We read the
-https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[iam-data-single-query.tql,window=_blank]
+https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[iam-data-single-query.tql,window=_blank]
 file, send its contents as a single query, and then commit the changes.
 
 .See the full Insert query
@@ -325,7 +325,7 @@ include::drivers::partial$tutorials/rust/src/main.rs[tag=delete]
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/rust/src/main.rs[Source code,window=_blank]
+.link:https://github.com/typedb/typedb-docs/tree/master/drivers-src/modules/ROOT/partials/tutorials/rust/src/main.rs[Source code,window=_blank]
 [.clickable]
 ****
 The full source code of this sample application.

--- a/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql
+++ b/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2023 Vaticle
+# Copyright (C) 2024 TypeDB
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/drivers-src/modules/ROOT/partials/tutorials/iam-data.tql
+++ b/drivers-src/modules/ROOT/partials/tutorials/iam-data.tql
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2023 Vaticle
+# Copyright (C) 2024 TypeDB
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql
+++ b/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2023 Vaticle
+# Copyright (C) 2024 TypeDB
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/drivers-src/modules/resources/pages/downloads.adoc
+++ b/drivers-src/modules/resources/pages/downloads.adoc
@@ -4,7 +4,7 @@
 :summary: Download any version of TypeDB Client here.
 :page-aliases: clients::resources/downloads
 :tabs-sync-option:
-:repo: https://github.com/vaticle/typedb-studio/releases/
+:repo: https://github.com/typedb/typedb-studio/releases/
 
 // tag::clients-download[]
 == TypeDB Console
@@ -14,7 +14,7 @@ TypeDB Console is distributed with both TypeDB Core and TypeDB Cloud.
 [NOTE]
 ====
 There is also a *server-only* version available for download from the
-https://github.com/vaticle/typedb/releases[GitHub,window=_blank]. It has `server` keyword instead of `all` in its name.
+https://github.com/typedb/typedb/releases[GitHub,window=_blank]. It has `server` keyword instead of `all` in its name.
 ====
 
 ////
@@ -65,7 +65,7 @@ To download TypeDB Rust driver, you can use any of the following options:
 
 For more information on the driver versions, check the
 xref:drivers:ROOT:rust/overview.adoc#_version_compatibility[version compatibility] table and
-https://github.com/vaticle/typedb-driver/releases[release notes,window=_blank].
+https://github.com/typedb/typedb-driver/releases[release notes,window=_blank].
 --
 
 Python::
@@ -81,7 +81,7 @@ To download TypeDB Python driver, you can use any of the following options:
 
 For more information on the driver versions, check the
 xref:drivers:ROOT:python/overview.adoc#_version_compatibility[version compatibility] table and
-https://github.com/vaticle/typedb-driver/releases[release notes,window=_blank].
+https://github.com/typedb/typedb-driver/releases[release notes,window=_blank].
 --
 
 Java::
@@ -96,7 +96,7 @@ Alternatively, you can download TypeDB Java driver by the following link:
 
 For more information on the driver versions, check the
 xref:drivers:ROOT:java/overview.adoc#_version_compatibility[version compatibility] table and
-https://github.com/vaticle/typedb-driver/releases[release notes,window=_blank].
+https://github.com/typedb/typedb-driver/releases[release notes,window=_blank].
 --
 
 Node.js::
@@ -111,7 +111,7 @@ To download TypeDB Node.js driver, you can use the following command:
 
 For more information on the driver versions, check the
 xref:drivers:ROOT:nodejs/overview.adoc#_version_compatibility[version compatibility] table and
-https://github.com/vaticle/typedb-driver/releases[release notes,window=_blank].
+https://github.com/typedb/typedb-driver/releases[release notes,window=_blank].
 --
 ====
 

--- a/drivers-src/modules/resources/partials/.all-versions-generator.py
+++ b/drivers-src/modules/resources/partials/.all-versions-generator.py
@@ -1,6 +1,6 @@
 import requests
 
-repo = "https://api.github.com/repos/vaticle/typedb-studio/releases"
+repo = "https://api.github.com/repos/typedb/typedb-studio/releases"
 filename_all = "all-versions.adoc"
 filename_latest = "latest-version.adoc"
 errors = []

--- a/drivers-src/modules/resources/partials/all-versions.adoc
+++ b/drivers-src/modules/resources/partials/all-versions.adoc
@@ -1,5 +1,5 @@
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.26.6[2.26.6]
+| https://github.com/typedb/typedb-studio/releases/tag/2.26.6[2.26.6]
 | https://repo.typedb.com/public/public-release/raw/names/typedb-studio-windows-x86_64/versions/2.26.6/typedb-studio-windows-x86_64-2.26.6.exe[x86_x64]
 // Check: manual
 | https://repo.typedb.com/public/public-release/raw/names/typedb-studio-linux-x86_64/versions/2.26.6/typedb-studio-linux-x86_64-2.26.6.tar.gz[x86_x64] / https://repo.typedb.com/public/public-release/raw/names/typedb-studio-linux-arm64/versions/2.26.6/typedb-studio-linux-arm64-2.26.6.tar.gz[arm64]
@@ -7,130 +7,130 @@
 | https://repo.typedb.com/public/public-release/raw/names/typedb-studio-mac-x86_64/versions/2.26.6/typedb-studio-mac-x86_64-2.26.6.dmg[x86_64] / https://cloudsmith.io/~typedb/repos/public-release/packages/detail/raw/typedb-studio-mac-arm64/2.26.6/[arm64]
 // Check: manual
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.26.0[2.26.0]
-| https://github.com/vaticle/typedb-studio/releases/download/2.26.0/typedb-studio-windows-x86_64-2.26.0.exe[Download]
+| https://github.com/typedb/typedb-studio/releases/tag/2.26.0[2.26.0]
+| https://github.com/typedb/typedb-studio/releases/download/2.26.0/typedb-studio-windows-x86_64-2.26.0.exe[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.26.0/typedb-studio-linux-x86_64-2.26.0.tar.gz[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.26.0/typedb-studio-linux-x86_64-2.26.0.tar.gz[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.26.0/typedb-studio-mac-x86_64-2.26.0.dmg[Download]
-// Check: PASSED
-
-| https://github.com/vaticle/typedb-studio/releases/tag/2.25.11[2.25.11]
-| https://github.com/vaticle/typedb-studio/releases/download/2.25.11/typedb-studio-windows-x86_64-2.25.11.exe[Download]
-// Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.25.11/typedb-studio-linux-x86_64-2.25.11.tar.gz[Download]
-// Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.25.11/typedb-studio-mac-x86_64-2.25.11.dmg[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.26.0/typedb-studio-mac-x86_64-2.26.0.dmg[Download]
 // Check: PASSED
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.25.10[2.25.10]
-| https://github.com/vaticle/typedb-studio/releases/download/2.25.10/typedb-studio-windows-x86_64-2.25.10.exe[Download]
+| https://github.com/typedb/typedb-studio/releases/tag/2.25.11[2.25.11]
+| https://github.com/typedb/typedb-studio/releases/download/2.25.11/typedb-studio-windows-x86_64-2.25.11.exe[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.25.10/typedb-studio-linux-x86_64-2.25.10.tar.gz[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.25.11/typedb-studio-linux-x86_64-2.25.11.tar.gz[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.25.10/typedb-studio-mac-x86_64-2.25.10.dmg[Download]
-// Check: PASSED
-
-| https://github.com/vaticle/typedb-studio/releases/tag/2.25.9[2.25.9]
-| https://github.com/vaticle/typedb-studio/releases/download/2.25.9/typedb-studio-windows-x86_64-2.25.9.exe[Download]
-// Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.25.9/typedb-studio-linux-x86_64-2.25.9.tar.gz[Download]
-// Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.25.9/typedb-studio-mac-x86_64-2.25.9.dmg[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.25.11/typedb-studio-mac-x86_64-2.25.11.dmg[Download]
 // Check: PASSED
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.25.8[2.25.8]
-| https://github.com/vaticle/typedb-studio/releases/download/2.25.8/typedb-studio-windows-x86_64-2.25.8.exe[Download]
+| https://github.com/typedb/typedb-studio/releases/tag/2.25.10[2.25.10]
+| https://github.com/typedb/typedb-studio/releases/download/2.25.10/typedb-studio-windows-x86_64-2.25.10.exe[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.25.8/typedb-studio-linux-x86_64-2.25.8.tar.gz[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.25.10/typedb-studio-linux-x86_64-2.25.10.tar.gz[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.25.8/typedb-studio-mac-x86_64-2.25.8.dmg[Download]
-// Check: PASSED
-
-| https://github.com/vaticle/typedb-studio/releases/tag/2.25.0[2.25.0]
-| https://github.com/vaticle/typedb-studio/releases/download/2.25.0/typedb-studio-windows-x86_64-2.25.0.exe[Download]
-// Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.25.0/typedb-studio-linux-x86_64-2.25.0.tar.gz[Download]
-// Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.25.0/typedb-studio-mac-x86_64-2.25.0.dmg[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.25.10/typedb-studio-mac-x86_64-2.25.10.dmg[Download]
 // Check: PASSED
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.24.15[2.24.15]
-| https://github.com/vaticle/typedb-studio/releases/download/2.24.15/typedb-studio-windows-x86_64-2.24.15.exe[Download]
+| https://github.com/typedb/typedb-studio/releases/tag/2.25.9[2.25.9]
+| https://github.com/typedb/typedb-studio/releases/download/2.25.9/typedb-studio-windows-x86_64-2.25.9.exe[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.24.15/typedb-studio-linux-x86_64-2.24.15.tar.gz[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.25.9/typedb-studio-linux-x86_64-2.25.9.tar.gz[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.24.15/typedb-studio-mac-x86_64-2.24.15.dmg[Download]
-// Check: PASSED
-
-| https://github.com/vaticle/typedb-studio/releases/tag/2.24.14[2.24.14]
-| https://github.com/vaticle/typedb-studio/releases/download/2.24.14/typedb-studio-windows-x86_64-2.24.14.exe[Download]
-// Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.24.14/typedb-studio-linux-x86_64-2.24.14.tar.gz[Download]
-// Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.24.14/typedb-studio-mac-x86_64-2.24.14.dmg[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.25.9/typedb-studio-mac-x86_64-2.25.9.dmg[Download]
 // Check: PASSED
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.21.2[2.21.2]
-| https://github.com/vaticle/typedb-studio/releases/download/2.21.2/typedb-studio-windows-2.21.2.exe[Download]
+| https://github.com/typedb/typedb-studio/releases/tag/2.25.8[2.25.8]
+| https://github.com/typedb/typedb-studio/releases/download/2.25.8/typedb-studio-windows-x86_64-2.25.8.exe[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.21.2/typedb-studio-linux-2.21.2.tar.gz[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.25.8/typedb-studio-linux-x86_64-2.25.8.tar.gz[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.21.2/typedb-studio-mac-2.21.2.dmg[Download]
-// Check: PASSED
-
-| https://github.com/vaticle/typedb-studio/releases/tag/2.21.1[2.21.1]
-| https://github.com/vaticle/typedb-studio/releases/download/2.21.1/typedb-studio-windows-2.21.1.exe[Download]
-// Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.21.1/typedb-studio-linux-2.21.1.tar.gz[Download]
-// Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.21.1/typedb-studio-mac-2.21.1.dmg[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.25.8/typedb-studio-mac-x86_64-2.25.8.dmg[Download]
 // Check: PASSED
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.21.0[2.21.0]
-| https://github.com/vaticle/typedb-studio/releases/download/2.21.0/typedb-studio-windows-2.21.0.exe[Download]
+| https://github.com/typedb/typedb-studio/releases/tag/2.25.0[2.25.0]
+| https://github.com/typedb/typedb-studio/releases/download/2.25.0/typedb-studio-windows-x86_64-2.25.0.exe[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.21.0/typedb-studio-linux-2.21.0.tar.gz[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.25.0/typedb-studio-linux-x86_64-2.25.0.tar.gz[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.21.0/typedb-studio-mac-2.21.0.dmg[Download]
-// Check: PASSED
-
-| https://github.com/vaticle/typedb-studio/releases/tag/2.18.0[2.18.0]
-| https://github.com/vaticle/typedb-studio/releases/download/2.18.0/typedb-studio-windows-2.18.0.exe[Download]
-// Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.18.0/typedb-studio-linux-2.18.0.tar.gz[Download]
-// Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.18.0/typedb-studio-mac-2.18.0.dmg[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.25.0/typedb-studio-mac-x86_64-2.25.0.dmg[Download]
 // Check: PASSED
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.17.0[2.17.0]
-| https://github.com/vaticle/typedb-studio/releases/download/2.17.0/typedb-studio-windows-2.17.0.exe[Download]
+| https://github.com/typedb/typedb-studio/releases/tag/2.24.15[2.24.15]
+| https://github.com/typedb/typedb-studio/releases/download/2.24.15/typedb-studio-windows-x86_64-2.24.15.exe[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.17.0/typedb-studio-linux-2.17.0.tar.gz[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.24.15/typedb-studio-linux-x86_64-2.24.15.tar.gz[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.17.0/typedb-studio-mac-2.17.0.dmg[Download]
-// Check: PASSED
-
-| https://github.com/vaticle/typedb-studio/releases/tag/2.14.2[2.14.2]
-| https://github.com/vaticle/typedb-studio/releases/download/2.14.2/typedb-studio-windows-2.14.2.exe[Download]
-// Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.14.2/typedb-studio-linux-2.14.2.tar.gz[Download]
-// Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.14.2/typedb-studio-mac-2.14.2.dmg[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.24.15/typedb-studio-mac-x86_64-2.24.15.dmg[Download]
 // Check: PASSED
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.14.1[2.14.1]
-| https://github.com/vaticle/typedb-studio/releases/download/2.14.1/typedb-studio-windows-2.14.1.exe[Download]
+| https://github.com/typedb/typedb-studio/releases/tag/2.24.14[2.24.14]
+| https://github.com/typedb/typedb-studio/releases/download/2.24.14/typedb-studio-windows-x86_64-2.24.14.exe[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.14.1/typedb-studio-linux-2.14.1.tar.gz[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.24.14/typedb-studio-linux-x86_64-2.24.14.tar.gz[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.14.1/typedb-studio-mac-2.14.1.dmg[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.24.14/typedb-studio-mac-x86_64-2.24.14.dmg[Download]
 // Check: PASSED
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.11.0[2.11.0]
-| https://github.com/vaticle/typedb-studio/releases/download/2.11.0/typedb-studio-windows-2.11.0.exe[Download]
+| https://github.com/typedb/typedb-studio/releases/tag/2.21.2[2.21.2]
+| https://github.com/typedb/typedb-studio/releases/download/2.21.2/typedb-studio-windows-2.21.2.exe[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.11.0/typedb-studio-linux-2.11.0.tar.gz[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.21.2/typedb-studio-linux-2.21.2.tar.gz[Download]
 // Check: PASSED
-| https://github.com/vaticle/typedb-studio/releases/download/2.11.0/typedb-studio-mac-2.11.0.dmg[Download]
+| https://github.com/typedb/typedb-studio/releases/download/2.21.2/typedb-studio-mac-2.21.2.dmg[Download]
+// Check: PASSED
+
+| https://github.com/typedb/typedb-studio/releases/tag/2.21.1[2.21.1]
+| https://github.com/typedb/typedb-studio/releases/download/2.21.1/typedb-studio-windows-2.21.1.exe[Download]
+// Check: PASSED
+| https://github.com/typedb/typedb-studio/releases/download/2.21.1/typedb-studio-linux-2.21.1.tar.gz[Download]
+// Check: PASSED
+| https://github.com/typedb/typedb-studio/releases/download/2.21.1/typedb-studio-mac-2.21.1.dmg[Download]
+// Check: PASSED
+
+| https://github.com/typedb/typedb-studio/releases/tag/2.21.0[2.21.0]
+| https://github.com/typedb/typedb-studio/releases/download/2.21.0/typedb-studio-windows-2.21.0.exe[Download]
+// Check: PASSED
+| https://github.com/typedb/typedb-studio/releases/download/2.21.0/typedb-studio-linux-2.21.0.tar.gz[Download]
+// Check: PASSED
+| https://github.com/typedb/typedb-studio/releases/download/2.21.0/typedb-studio-mac-2.21.0.dmg[Download]
+// Check: PASSED
+
+| https://github.com/typedb/typedb-studio/releases/tag/2.18.0[2.18.0]
+| https://github.com/typedb/typedb-studio/releases/download/2.18.0/typedb-studio-windows-2.18.0.exe[Download]
+// Check: PASSED
+| https://github.com/typedb/typedb-studio/releases/download/2.18.0/typedb-studio-linux-2.18.0.tar.gz[Download]
+// Check: PASSED
+| https://github.com/typedb/typedb-studio/releases/download/2.18.0/typedb-studio-mac-2.18.0.dmg[Download]
+// Check: PASSED
+
+| https://github.com/typedb/typedb-studio/releases/tag/2.17.0[2.17.0]
+| https://github.com/typedb/typedb-studio/releases/download/2.17.0/typedb-studio-windows-2.17.0.exe[Download]
+// Check: PASSED
+| https://github.com/typedb/typedb-studio/releases/download/2.17.0/typedb-studio-linux-2.17.0.tar.gz[Download]
+// Check: PASSED
+| https://github.com/typedb/typedb-studio/releases/download/2.17.0/typedb-studio-mac-2.17.0.dmg[Download]
+// Check: PASSED
+
+| https://github.com/typedb/typedb-studio/releases/tag/2.14.2[2.14.2]
+| https://github.com/typedb/typedb-studio/releases/download/2.14.2/typedb-studio-windows-2.14.2.exe[Download]
+// Check: PASSED
+| https://github.com/typedb/typedb-studio/releases/download/2.14.2/typedb-studio-linux-2.14.2.tar.gz[Download]
+// Check: PASSED
+| https://github.com/typedb/typedb-studio/releases/download/2.14.2/typedb-studio-mac-2.14.2.dmg[Download]
+// Check: PASSED
+
+| https://github.com/typedb/typedb-studio/releases/tag/2.14.1[2.14.1]
+| https://github.com/typedb/typedb-studio/releases/download/2.14.1/typedb-studio-windows-2.14.1.exe[Download]
+// Check: PASSED
+| https://github.com/typedb/typedb-studio/releases/download/2.14.1/typedb-studio-linux-2.14.1.tar.gz[Download]
+// Check: PASSED
+| https://github.com/typedb/typedb-studio/releases/download/2.14.1/typedb-studio-mac-2.14.1.dmg[Download]
+// Check: PASSED
+
+| https://github.com/typedb/typedb-studio/releases/tag/2.11.0[2.11.0]
+| https://github.com/typedb/typedb-studio/releases/download/2.11.0/typedb-studio-windows-2.11.0.exe[Download]
+// Check: PASSED
+| https://github.com/typedb/typedb-studio/releases/download/2.11.0/typedb-studio-linux-2.11.0.tar.gz[Download]
+// Check: PASSED
+| https://github.com/typedb/typedb-studio/releases/download/2.11.0/typedb-studio-mac-2.11.0.dmg[Download]
 // Check: PASSED

--- a/drivers-src/modules/resources/partials/latest-version.adoc
+++ b/drivers-src/modules/resources/partials/latest-version.adoc
@@ -1,5 +1,5 @@
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.26.6[2.26.6]
+| https://github.com/typedb/typedb-studio/releases/tag/2.26.6[2.26.6]
 | https://repo.typedb.com/public/public-release/raw/names/typedb-studio-windows-x86_64/versions/2.26.6/typedb-studio-windows-x86_64-2.26.6.exe[x86_x64]
 // Check: manual
 | https://repo.typedb.com/public/public-release/raw/names/typedb-studio-linux-x86_64/versions/2.26.6/typedb-studio-linux-x86_64-2.26.6.tar.gz[x86_x64] / https://repo.typedb.com/public/public-release/raw/names/typedb-studio-linux-arm64/versions/2.26.6/typedb-studio-linux-arm64-2.26.6.tar.gz[arm64]

--- a/home-src/modules/ROOT/pages/install/cloud-self-hosted.adoc
+++ b/home-src/modules/ROOT/pages/install/cloud-self-hosted.adoc
@@ -23,7 +23,7 @@ https://www.oracle.com/java/technologies/downloads/#java11[Oracle Java]).
 
 TypeDB Cloud is distributed and installed separately from TypeDB Core.
 
-Request access to the TypeDB Cloud distributive repositories from Vaticle.
+Request access to the TypeDB Cloud distributive repositories from the TypeDB team.
 You can do that via technical support, using the contact details from your contract, or through our
 https://typedb.com/discord[Discord,window=_blank] server.
 
@@ -94,7 +94,7 @@ Download the https://cloudsmith.io/~typedb/repos/private-release/packages/?q=clo
 unzip it in a location on your machine that is easily accessible via terminal.
 
 If TypeDB doesn't have a distribution you need, please open an issue
-https://github.com/vaticle/typedb/issues[on GitHub].
+https://github.com/typedb/typedb/issues[on GitHub].
 
 ==== Start and Stop TypeDB Cloud manually
 

--- a/home-src/modules/ROOT/pages/install/console.adoc
+++ b/home-src/modules/ROOT/pages/install/console.adoc
@@ -4,7 +4,7 @@ TypeDB Console is the built-in CLI client for TypeDB. Both TypeDB Core and TypeD
 
 [cols-3]
 --
-.link:https://github.com/vaticle/typedb-console[GitHub,window=_blank]
+.link:https://github.com/typedb/typedb-console[GitHub,window=_blank]
 [.clickable]
 ****
 See source code and release notes.

--- a/home-src/modules/ROOT/pages/install/studio.adoc
+++ b/home-src/modules/ROOT/pages/install/studio.adoc
@@ -4,7 +4,7 @@ TypeDB Studio is a standalone IDE for TypeDB. If you are unsure of the version y
 
 [cols-3]
 --
-.link:https://github.com/vaticle/typedb-studio[GitHub,window=_blank]
+.link:https://github.com/typedb/typedb-studio[GitHub,window=_blank]
 [.clickable]
 ****
 See source code and release notes.
@@ -35,8 +35,8 @@ To install TypeDB Studio via Homebrew:
 
 [source,console]
 ----
-brew tap vaticle/tap
-brew install --cask vaticle/tap/typedb-studio
+brew tap typedb/tap
+brew install --cask typedb/tap/typedb-studio
 ----
 --
 
@@ -49,8 +49,8 @@ Linux::
 ----
 sudo apt install software-properties-common apt-transport-https gpg
 gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 17507562824cfdcc
-gpg --export 17507562824cfdcc | sudo tee /etc/apt/trusted.gpg.d/vaticle.gpg > /dev/null
-echo "deb https://repo.typedb.com/public/public-release/deb/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/vaticle.list > /dev/null
+gpg --export 17507562824cfdcc | sudo tee /etc/apt/trusted.gpg.d/typedb.gpg > /dev/null
+echo "deb https://repo.typedb.com/public/public-release/deb/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/typedb.list > /dev/null
 sudo apt update
 ----
 . Install TypeDB Studio:

--- a/home-src/modules/ROOT/partials/docker.adoc
+++ b/home-src/modules/ROOT/partials/docker.adoc
@@ -2,8 +2,8 @@
 
 Get the docker image from the https://hub.docker.com/r/vaticle/typedb/tags[Docker hub,window=_blank]
 or
-https://github.com/vaticle/typedb-driver/blob/development/rust/README.md#build-from-source[build,window=_blank]
-it from https://github.com/vaticle/typedb/tags[source code,window=_blank] with Bazel.
+https://github.com/typedb/typedb-driver/blob/development/rust/README.md#build-from-source[build,window=_blank]
+it from https://github.com/typedb/typedb/tags[source code,window=_blank] with Bazel.
 
 // end::manual-install[]
 
@@ -17,7 +17,7 @@ docker pull vaticle/typedb:latest
 
 You can replace `latest` with a version number to get a specific version of TypeDB Core.
 To check the list of available versions,
-see the link:https://github.com/vaticle/typedb/releases[Releases,window=_blank] page.
+see the link:https://github.com/typedb/typedb/releases[Releases,window=_blank] page.
 
 // end::install[]
 

--- a/home-src/modules/ROOT/partials/linux.adoc
+++ b/home-src/modules/ROOT/partials/linux.adoc
@@ -6,8 +6,8 @@
 ----
 sudo apt install software-properties-common apt-transport-https gpg
 gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 17507562824cfdcc
-gpg --export 17507562824cfdcc | sudo tee /etc/apt/trusted.gpg.d/vaticle.gpg > /dev/null
-echo "deb https://repo.typedb.com/public/public-release/deb/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/vaticle.list > /dev/null
+gpg --export 17507562824cfdcc | sudo tee /etc/apt/trusted.gpg.d/typedb.gpg > /dev/null
+echo "deb https://repo.typedb.com/public/public-release/deb/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/typedb.list > /dev/null
 sudo apt update
 ----
 . Ensure Java 11+ is installed:

--- a/home-src/modules/ROOT/partials/macos.adoc
+++ b/home-src/modules/ROOT/partials/macos.adoc
@@ -3,8 +3,8 @@ To install TypeDB via Homebrew:
 
 [source,console]
 ----
-brew tap vaticle/tap
-brew install vaticle/tap/typedb
+brew tap typedb/tap
+brew install typedb/tap/typedb
 ----
 // end::install-homebrew[]
 

--- a/home-src/modules/ROOT/partials/win.adoc
+++ b/home-src/modules/ROOT/partials/win.adoc
@@ -39,7 +39,7 @@ https://developers.google.com/optimization/install/java/binary_windows#microsoft
 [,shell]
 ----
 Exception in thread "main" java.lang.UnsatisfiedLinkError:
-C:\Users\Vaticle\AppData\Local\Temp\ortools-java\win32-x86-64\jniortools.dll: Can't find dependent libraries
+C:\Users\TypeDB\AppData\Local\Temp\ortools-java\win32-x86-64\jniortools.dll: Can't find dependent libraries
 ----
 // end::start[]
 

--- a/manual-src/modules/ROOT/pages/connecting/connection.adoc
+++ b/manual-src/modules/ROOT/pages/connecting/connection.adoc
@@ -13,7 +13,7 @@ This guide covers connecting to
 
 ////
 TypeDB accepts connections via gRPC based
-https://github.com/vaticle/typedb-protocol[TypeDB RPC protocol,window=_blank].
+https://github.com/typedb/typedb-protocol[TypeDB RPC protocol,window=_blank].
 It is implemented by TypeDB drivers and TypeDB clients.
 
 All released clients and drivers support connection to both TypeDB Cloud and TypeDB Core.

--- a/manual-src/modules/ROOT/pages/connecting/overview.adoc
+++ b/manual-src/modules/ROOT/pages/connecting/overview.adoc
@@ -7,7 +7,7 @@
 
 ////
 TypeDB accepts connections via gRPC based
-https://github.com/vaticle/typedb-protocol[TypeDB RPC protocol,window=_blank].
+https://github.com/typedb/typedb-protocol[TypeDB RPC protocol,window=_blank].
 It is implemented by TypeDB drivers and TypeDB clients.
 ////
 

--- a/manual-src/modules/ROOT/pages/console.adoc
+++ b/manual-src/modules/ROOT/pages/console.adoc
@@ -22,7 +22,7 @@ For a standalone installation, see the xref:home:ROOT:install/console.adoc[Insta
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb-console[GitHub,window=_blank]
+.link:https://github.com/typedb/typedb-console[GitHub,window=_blank]
 [.clickable]
 ****
 The GitHub repository with the source code and release notes.
@@ -92,7 +92,7 @@ As a result, you get a welcome message from TypeDB Console followed by a command
 
 ----
 Welcome to TypeDB Console. You are now in TypeDB Wonderland!
-Copyright (C) 2022 Vaticle
+Copyright (C) 2024 TypeDB
 
 >
 ----
@@ -359,10 +359,10 @@ For example, let's use the following script file to:
 
 * Create the `iam_sample_db` database
 * Load the IAM schema form the
-https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql,window=_blank]
+https://github.com/typedb/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[iam-schema.tql,window=_blank]
 file in a schema session
 * Load sample data from the
-https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-data.tql[iam-data.tql,window=_blank]
+https://github.com/typedb/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-data.tql[iam-data.tql,window=_blank]
 file in a data session
 * Run a Fetch query
 * Delete the database to reset the environment
@@ -750,37 +750,37 @@ transaction sample_db data read --infer true
 |===
 | TypeDB Console | Protocol encoding version | TypeDB Core | TypeDB Cloud
 
-| https://github.com/vaticle/typedb-console/releases/tag/2.28.0[2.28.0]
+| https://github.com/typedb/typedb-console/releases/tag/2.28.0[2.28.0]
 | 3
 | 2.28.0
 | 2.28.0
 
-| https://github.com/vaticle/typedb-console/releases/tag/2.27.0[2.27.0]
+| https://github.com/typedb/typedb-console/releases/tag/2.27.0[2.27.0]
 | 3
 | 2.27.0
 | 2.27.0
 
-| https://github.com/vaticle/typedb-console/releases/tag/2.26.6[2.26.6]
+| https://github.com/typedb/typedb-console/releases/tag/2.26.6[2.26.6]
 | 3
 | 2.26.6
 | 2.26.6
 
-| https://github.com/vaticle/typedb-console/releases/tag/2.25.7[2.25.7]
+| https://github.com/typedb/typedb-console/releases/tag/2.25.7[2.25.7]
 | 3
 | 2.25.7
 | 2.25.7
 
-| https://github.com/vaticle/typedb-console/releases/tag/2.24.15[2.24.15]
+| https://github.com/typedb/typedb-console/releases/tag/2.24.15[2.24.15]
 | 2
 | 2.24.17
 | 2.24.17
 
-| https://github.com/vaticle/typedb-console/releases/tag/2.18.0[2.18.0]
+| https://github.com/typedb/typedb-console/releases/tag/2.18.0[2.18.0]
 | 1
 | 2.18.0 to 2.23.0
 | 2.18.0 to 2.23.0
 
-| https://github.com/vaticle/typedb-console/releases/tag/2.17.0[2.17.0]
+| https://github.com/typedb/typedb-console/releases/tag/2.17.0[2.17.0]
 | N/A
 | 2.17.0
 | 2.17.0

--- a/manual-src/modules/ROOT/pages/error-codes/driver.adoc
+++ b/manual-src/modules/ROOT/pages/error-codes/driver.adoc
@@ -6,7 +6,7 @@ include::manual:resources:partial$error-messages/adoc/java-driver.java.adoc[]
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb-driver/blob/development/java/common/exception/ErrorMessage.java[Source code,window=_blank]
+.link:https://github.com/typedb/typedb-driver/blob/development/java/common/exception/ErrorMessage.java[Source code,window=_blank]
 [.clickable]
 ****
 ErrorMessage.java source code stored at GitHub.

--- a/manual-src/modules/ROOT/pages/error-codes/server.adoc
+++ b/manual-src/modules/ROOT/pages/error-codes/server.adoc
@@ -6,7 +6,7 @@ include::manual:resources:partial$error-messages/adoc/server.java.adoc[]
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb/blob/development/common/exception/ErrorMessage.java[Source code,window=_blank]
+.link:https://github.com/typedb/typedb/blob/development/common/exception/ErrorMessage.java[Source code,window=_blank]
 [.clickable]
 ****
 ErrorMessage.java source code stored at GitHub.

--- a/manual-src/modules/ROOT/pages/error-codes/typeql.adoc
+++ b/manual-src/modules/ROOT/pages/error-codes/typeql.adoc
@@ -6,7 +6,7 @@ include::manual:resources:partial$error-messages/adoc/typeql.java.adoc[]
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typeql/blob/development/java/common/exception/ErrorMessage.java[Source code,window=_blank]
+.link:https://github.com/typedb/typeql/blob/development/java/common/exception/ErrorMessage.java[Source code,window=_blank]
 [.clickable]
 ****
 ErrorMessage.java source code stored at GitHub.

--- a/manual-src/modules/ROOT/pages/studio.adoc
+++ b/manual-src/modules/ROOT/pages/studio.adoc
@@ -21,7 +21,7 @@ and query results visualizer.
 
 [cols-2]
 --
-.link:https://github.com/vaticle/typedb-studio/[GitHub,window=_blank]
+.link:https://github.com/typedb/typedb-studio/[GitHub,window=_blank]
 [.clickable]
 ****
 The GitHub repository with the source code and release notes.
@@ -433,27 +433,27 @@ Default value: *On*.
 | TypeDB Studio +
 (release notes) | Protocol encoding version | TypeDB Core | TypeDB Cloud
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.28.4[2.28.4]
+| https://github.com/typedb/typedb-studio/releases/tag/2.28.4[2.28.4]
 | 3
 | 2.28.3
 | 2.28.3
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.27.0[2.27.0]
+| https://github.com/typedb/typedb-studio/releases/tag/2.27.0[2.27.0]
 | 3
 | 2.27.0
 | 2.27.0
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.26.6[2.26.6]
+| https://github.com/typedb/typedb-studio/releases/tag/2.26.6[2.26.6]
 | 3
 | 2.26.6
 | 2.26.6
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.25.11[2.25.11]
+| https://github.com/typedb/typedb-studio/releases/tag/2.25.11[2.25.11]
 | 3
 | 2.25.7
 | 2.25.7
 
-| https://github.com/vaticle/typedb-studio/releases/tag/2.24.15[2.24.15]
+| https://github.com/typedb/typedb-studio/releases/tag/2.24.15[2.24.15]
 | 2
 | 2.24.17
 | 2.24.17

--- a/manual-src/modules/ROOT/partials/c-manual-code.c
+++ b/manual-src/modules/ROOT/partials/c-manual-code.c
@@ -149,7 +149,7 @@ int main() {
             goto cleanup;
         }
         char query[512];
-        snprintf(query, sizeof(query), "insert $user1 isa user, has name 'Alice', has email 'alice@vaticle.com'; $user2 isa user, has name 'Bob', has email 'bob@vaticle.com'; $friendship (friend:$user1, friend: $user2) isa friendship;");
+        snprintf(query, sizeof(query), "insert $user1 isa user, has name 'Alice', has email 'alice@typedb.com'; $user2 isa user, has name 'Bob', has email 'bob@typedb.com'; $friendship (friend:$user1, friend: $user2) isa friendship;");
         ConceptMapIterator* insertResult = query_insert(tx, query, opts);
         if (FAILED()) {
             handle_error("Query execution failed.");
@@ -172,7 +172,7 @@ int main() {
             goto cleanup;
         }
         char query[512];
-        snprintf(query, sizeof(query), "match $u isa user, has name 'Bob'; insert $new-u isa user, has name 'Charlie', has email 'charlie@vaticle.com'; $f($u,$new-u) isa friendship;");
+        snprintf(query, sizeof(query), "match $u isa user, has name 'Bob'; insert $new-u isa user, has name 'Charlie', has email 'charlie@typedb.com'; $f($u,$new-u) isa friendship;");
         ConceptMapIterator* insertResult = query_insert(tx, query, opts);
         if (FAILED()) {
             handle_error("Query execution failed.");
@@ -223,7 +223,7 @@ int main() {
             goto cleanup;
         }
         char query[512];
-        snprintf(query, sizeof(query), "match $u isa user, has name 'Charlie', has email $e; delete $u has $e; insert $u has email 'charles@vaticle.com';");
+        snprintf(query, sizeof(query), "match $u isa user, has name 'Charlie', has email $e; delete $u has $e; insert $u has email 'charles@typedb.com';");
         ConceptMapIterator* insertResult = query_update(tx, query, opts);
         if (FAILED()) {
             handle_error("Query execution failed.");
@@ -445,7 +445,7 @@ int main() {
         while ((rule = rule_iterator_next(rules)) != NULL) {
             printf("%s\n%s\n%s\n", rule_get_label(rule), rule_get_when(rule), rule_get_then(rule));
         }
-        Rule* newRule = rule_promise_resolve(logic_manager_put_rule(tx, "Employee", "{$u isa user, has email $e; $e contains '@vaticle.com';}", "$u has name 'Employee'"));
+        Rule* newRule = rule_promise_resolve(logic_manager_put_rule(tx, "Employee", "{$u isa user, has email $e; $e contains '@typedb.com';}", "$u has name 'Employee'"));
         Rule* oldRule = rule_promise_resolve(logic_manager_get_rule(tx, "users"));
         printf("%s\n", rule_get_label(oldRule));
         rule_delete(tx, newRule);
@@ -472,7 +472,7 @@ int main() {
         }
         // end::get_rules[]
         // tag::put_rule[]
-        Rule* newRule = rule_promise_resolve(logic_manager_put_rule(tx, "Employee", "{$u isa user, has email $e; $e contains '@vaticle.com';}", "$u has name 'Employee'"));
+        Rule* newRule = rule_promise_resolve(logic_manager_put_rule(tx, "Employee", "{$u isa user, has email $e; $e contains '@typedb.com';}", "$u has name 'Employee'"));
         // end::put_rule[]
         // tag::get_rule[]
         Rule* oldRule = rule_promise_resolve(logic_manager_get_rule(tx, "users"));

--- a/manual-src/modules/ROOT/partials/csharp-manual-code.cs
+++ b/manual-src/modules/ROOT/partials/csharp-manual-code.cs
@@ -88,8 +88,8 @@ class ManualProgram
             using (ITypeDBTransaction tx = session.Transaction(TransactionType.Write)) {
                 string insert_query = @"
                                         insert
-                                        $user1 isa user, has name 'Alice', has email 'alice@vaticle.com';
-                                        $user2 isa user, has name 'Bob', has email 'bob@vaticle.com';
+                                        $user1 isa user, has name 'Alice', has email 'alice@typedb.com';
+                                        $user2 isa user, has name 'Bob', has email 'bob@typedb.com';
                                         $friendship (friend:$user1, friend: $user2) isa friendship;";
                 _ = tx.Query.Insert(insert_query).ToList();
                 tx.Commit();
@@ -103,7 +103,7 @@ class ManualProgram
                                             match
                                             $u isa user, has name 'Bob';
                                             insert
-                                            $new-u isa user, has name 'Charlie', has email 'charlie@vaticle.com';
+                                            $new-u isa user, has name 'Charlie', has email 'charlie@typedb.com';
                                             $f($u,$new-u) isa friendship;";
                 List<IConceptMap> response = tx.Query.Insert(match_insert_query).ToList();
                 if (response.Count == 1) {
@@ -137,7 +137,7 @@ class ManualProgram
                                 delete
                                 $u has $e;
                                 insert
-                                $u has email 'charles@vaticle.com';";
+                                $u has email 'charles@typedb.com';";
                 List<IConceptMap> response = tx.Query.Update(update_query).ToList();
                 if (response.Count == 1) {
                     tx.Commit();
@@ -276,7 +276,7 @@ class ManualProgram
                     Console.WriteLine(rule.When);
                     Console.WriteLine(rule.Then);
                 }
-                IRule newRule = tx.Logic.PutRule("Employee", "{$u isa user, has email $e; $e contains '@vaticle.com';}","$u has name 'Employee'").Resolve()!;
+                IRule newRule = tx.Logic.PutRule("Employee", "{$u isa user, has email $e; $e contains '@typedb.com';}","$u has name 'Employee'").Resolve()!;
                 IRule oldRule = tx.Logic.GetRule("users").Resolve()!;
                 Console.WriteLine(oldRule.Label);
                 newRule.Delete(tx).Resolve();
@@ -295,7 +295,7 @@ class ManualProgram
                 }
                 // end::get_rules[]
                 // tag::put_rule[]
-                IRule newRule = tx.Logic.PutRule("Employee", "{$u isa user, has email $e; $e contains '@vaticle.com';}","$u has name 'Employee'").Resolve()!;
+                IRule newRule = tx.Logic.PutRule("Employee", "{$u isa user, has email $e; $e contains '@typedb.com';}","$u has name 'Employee'").Resolve()!;
                 // end::put_rule[]
                 // tag::get_rule[]
                 IRule oldRule = tx.Logic.GetRule("users").Resolve()!;

--- a/manual-src/modules/ROOT/partials/kubernetes.adoc
+++ b/manual-src/modules/ROOT/partials/kubernetes.adoc
@@ -20,11 +20,11 @@ kubectl create secret docker-registry private-docker-hub --docker-server=https:/
 You can use an
 https://hub.docker.com/settings/security?generateToken=true[access token,window=_blank] instead of password.
 
-Next, add the Vaticle Helm repo:
+Next, add the TypeDB Helm repo:
 
 [source,console]
 ----
-helm repo add vaticle https://repo.typedb.com/repository/helm/
+helm repo add typedb https://repo.typedb.com/repository/helm/
 ----
 
 == Encryption setup (optional)
@@ -102,7 +102,7 @@ Deploy:
 
 [source,console]
 ----
-helm install typedb-cloud vaticle/typedb-cloud --set "exposed=false,encrypted=false"
+helm install typedb-cloud typedb/typedb-cloud --set "exposed=false,encrypted=false"
 ----
 --
 
@@ -114,7 +114,7 @@ To enable in-flight encryption for your private cluster, make sure the `encrypte
 
 [source,console]
 ----
-helm install typedb-cloud vaticle/typedb-cloud --set "exposed=false,encrypted=true" \
+helm install typedb-cloud typedb/typedb-cloud --set "exposed=false,encrypted=true" \
 --set servers=3,cpu=1,storage.persistent=false,storage.size=1Gi,exposed=true,domain=localhost-ext --set encryption.enable=true --set encryption.enable=true,encryption.externalGRPC.secretName=ext-grpc,encryption.externalGRPC.content.privateKeyName=ext-grpc-private-key.pem,encryption.externalGRPC.content.certificateName=ext-grpc-certificate.pem,encryption.externalGRPC.content.rootCAName=ext-grpc-root-ca.pem \
 --set encryption.internalGRPC.secretName=int-grpc,encryption.internalGRPC.content.privateKeyName=int-grpc-private-key.pem,encryption.internalGRPC.content.certificateName=int-grpc-certificate.pem,encryption.internalGRPC.content.rootCAName=int-grpc-root-ca.pem \
 --set encryption.internalZMQ.secretName=int-zmq,encryption.internalZMQ.content.privateKeyName=int-zmq-private-key,encryption.internalZMQ.content.publicKeyName=int-zmq-public-key
@@ -151,7 +151,7 @@ Deploy:
 
 [source,console]
 ----
-helm install typedb-cloud vaticle/typedb-cloud --set "exposed=true"
+helm install typedb-cloud typedb/typedb-cloud --set "exposed=true"
 ----
 
 Once the deployment has been completed,
@@ -189,7 +189,7 @@ Ensure that the `encrypted` flag is set to `true` and the `domain` flag set acco
 
 [source,console]
 ----
-helm install typedb-cloud vaticle/typedb-cloud --set "exposed=true,encrypted=true,domain=<domain-name>" \
+helm install typedb-cloud typedb/typedb-cloud --set "exposed=true,encrypted=true,domain=<domain-name>" \
 --set servers=3,cpu=1,storage.persistent=false,storage.size=1Gi,exposed=true,domain=localhost-ext --set encryption.enable=true --set encryption.enable=true,encryption.externalGRPC.secretName=ext-grpc,encryption.externalGRPC.content.privateKeyName=ext-grpc-private-key.pem,encryption.externalGRPC.content.certificateName=ext-grpc-certificate.pem,encryption.externalGRPC.content.rootCAName=ext-grpc-root-ca.pem \
 --set encryption.internalGRPC.secretName=int-grpc,encryption.internalGRPC.content.privateKeyName=int-grpc-private-key.pem,encryption.internalGRPC.content.certificateName=int-grpc-certificate.pem,encryption.internalGRPC.content.rootCAName=int-grpc-root-ca.pem \
 --set encryption.internalZMQ.secretName=int-zmq,encryption.internalZMQ.content.privateKeyName=int-zmq-private-key,encryption.internalZMQ.content.publicKeyName=int-zmq-public-key
@@ -234,13 +234,13 @@ Deploy, adjusting the parameters for CPU and storage to run on a local machine:
 
 [source,console]
 ----
-helm install typedb-cloud vaticle/typedb-cloud --set image.pullPolicy=Always,servers=3,singlePodPerNode=false,cpu=1,storage.persistent=false,storage.size=1Gi,exposed=true,javaopts=-Xmx4G --set encryption.enable=false
+helm install typedb-cloud typedb/typedb-cloud --set image.pullPolicy=Always,servers=3,singlePodPerNode=false,cpu=1,storage.persistent=false,storage.size=1Gi,exposed=true,javaopts=-Xmx4G --set encryption.enable=false
 ----
 
 ////
 [source,console]
 ----
-helm install vaticle/typedb-cloud --generate-name \
+helm install typedb/typedb-cloud --generate-name \
 --set "cpu=2,replicas=3,singlePodPerNode=false,storage.persistent=true,storage.size=10Gi,exposed=true"
 ----
 ////

--- a/manual-src/modules/resources/partials/.get-latest-from-cloudsmith.py
+++ b/manual-src/modules/resources/partials/.get-latest-from-cloudsmith.py
@@ -49,7 +49,7 @@ def get_release_notes(product):
         case _:
             gh_alias = product
     product_version = get_released_version(product)
-    release_notes_link = f"https://github.com/vaticle/{gh_alias}/releases/tag/{product_version}"
+    release_notes_link = f"https://github.com/typedb/{gh_alias}/releases/tag/{product_version}"
     return product_version, release_notes_link
 
 

--- a/manual-src/modules/resources/partials/error-messages/src/studio.kt
+++ b/manual-src/modules/resources/partials/error-messages/src/studio.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Vaticle
+ * Copyright (C) 2024 TypeDB
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/manual-src/modules/resources/partials/typedb-all-latest-links.adoc
+++ b/manual-src/modules/resources/partials/typedb-all-latest-links.adoc
@@ -1,5 +1,5 @@
 | 
-https://github.com/vaticle/typedb/releases/tag/2.28.0[2.28.0]
+https://github.com/typedb/typedb/releases/tag/2.28.0[2.28.0]
 
 | 
 // tag::mac[]

--- a/manual-src/modules/resources/partials/typedb-console-latest-links.adoc
+++ b/manual-src/modules/resources/partials/typedb-console-latest-links.adoc
@@ -1,5 +1,5 @@
 | 
-https://github.com/vaticle/typedb-console/releases/tag/2.28.0[2.28.0]
+https://github.com/typedb/typedb-console/releases/tag/2.28.0[2.28.0]
 
 | 
 // tag::mac[]

--- a/manual-src/modules/resources/partials/typedb-studio-latest-links.adoc
+++ b/manual-src/modules/resources/partials/typedb-studio-latest-links.adoc
@@ -1,5 +1,5 @@
 | 
-https://github.com/vaticle/typedb-studio/releases/tag/2.28.0[2.28.0]
+https://github.com/typedb/typedb-studio/releases/tag/2.28.0[2.28.0]
 
 | 
 // tag::mac[]

--- a/typeql-src/modules/ROOT/pages/introduction.adoc
+++ b/typeql-src/modules/ROOT/pages/introduction.adoc
@@ -68,7 +68,7 @@ TypeQL is based on the contemporary mathematical field of https://plato.stanford
 
 === Contribution
 
-TypeQL is an open source language project. You can learn more about (and contribute to) TypeQL by visiting our https://github.com/vaticle/typeql[Github repo].
+TypeQL is an open source language project. You can learn more about (and contribute to) TypeQL by visiting our https://github.com/typedb/typeql[Github repo].
 
 == Good to know
 

--- a/typeql-src/modules/ROOT/pages/keywords.adoc
+++ b/typeql-src/modules/ROOT/pages/keywords.adoc
@@ -4,7 +4,7 @@
 :pageTitle: Keywords
 
 The source of truth for the TypeQL keywords and grammar is the *ANTLR v.4* specification file:
-https://github.com/vaticle/typeql/blob/master/grammar/TypeQL.g4[TypeQL.g4,window=_blank].
+https://github.com/typedb/typeql/blob/master/grammar/TypeQL.g4[TypeQL.g4,window=_blank].
 
 [#_clause_keywords]
 == Clauses

--- a/typeql-src/modules/ROOT/pages/queries/fetch.adoc
+++ b/typeql-src/modules/ROOT/pages/queries/fetch.adoc
@@ -169,7 +169,7 @@ with `full-name`, `email`, and `type` keys inside.
 ----
 {
     "p": {
-        "email": [ { "value": "kevin.morrison@vaticle.com", "type": { "label": "email", "root": "attribute", "value_type": "string" } } ],
+        "email": [ { "value": "kevin.morrison@typedb.com", "type": { "label": "email", "root": "attribute", "value_type": "string" } } ],
         "full-name": [ { "value": "Kevin Morrison", "type": { "label": "full-name", "root": "attribute", "value_type": "string" } } ],
         "type": { "label": "person", "root": "entity" }
     }
@@ -421,7 +421,7 @@ The resulting JSON objects have a predictable structure of keys, that was set by
     "permited-files": [  ],
     "user": {
         "User attributes": [
-            { "value": "masako.holley@vaticle.com", "type": { "label": "email", "root": "attribute", "value_type": "string" } },
+            { "value": "masako.holley@typedb.com", "type": { "label": "email", "root": "attribute", "value_type": "string" } },
             { "value": "Masako Holley", "type": { "label": "full-name", "root": "attribute", "value_type": "string" } }
         ],
         "type": { "label": "person", "root": "entity" }
@@ -451,7 +451,7 @@ The resulting JSON objects have a predictable structure of keys, that was set by
     ],
     "user": {
         "User attributes": [
-            { "value": "kevin.morrison@vaticle.com", "type": { "label": "email", "root": "attribute", "value_type": "string" } },
+            { "value": "kevin.morrison@typedb.com", "type": { "label": "email", "root": "attribute", "value_type": "string" } },
             { "value": "Kevin Morrison", "type": { "label": "full-name", "root": "attribute", "value_type": "string" } }
         ],
         "type": { "label": "person", "root": "entity" }
@@ -461,7 +461,7 @@ The resulting JSON objects have a predictable structure of keys, that was set by
     "permited-files": [  ],
     "user": {
         "User attributes": [
-            { "value": "pearle.goodman@vaticle.com", "type": { "label": "email", "root": "attribute", "value_type": "string" } },
+            { "value": "pearle.goodman@typedb.com", "type": { "label": "email", "root": "attribute", "value_type": "string" } },
             { "value": "Pearle Goodman", "type": { "label": "full-name", "root": "attribute", "value_type": "string" } }
         ],
         "type": { "label": "person", "root": "entity" }
@@ -521,7 +521,7 @@ include::typeql::partial$iam-database-links.adoc[]
 
 We can use Fetch query to infer new facts.
 For example, we can use the `add-view-permission` rule from the
-https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[IAM schema,window=_blank]
+https://github.com/typedb/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[IAM schema,window=_blank]
 to infer `view_file` action access permissions.
 
 .Example of using inference
@@ -535,7 +535,7 @@ fetch $fp;
 ----
 
 Using the
-https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[IAM sample data,window=_blank]
+https://github.com/typedb/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[IAM sample data,window=_blank]
 the above query shows any results only if inference is
 xref:manual::reading/infer.adoc#_how_to_send_a_query_with_inference[enabled].
 

--- a/typeql-src/modules/ROOT/pages/statements/is.adoc
+++ b/typeql-src/modules/ROOT/pages/statements/is.adoc
@@ -72,7 +72,7 @@ $e;
 ----
 
 In our IAM database
-link:https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[sample dataset]
+link:https://github.com/typedb/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[sample dataset]
 that query returns no results.
 
 == Learn more

--- a/typeql-src/modules/ROOT/partials/TypeQL.g4
+++ b/typeql-src/modules/ROOT/partials/TypeQL.g4
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Vaticle
+ * Copyright (C) 2024 TypeDB
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/typeql-src/modules/ROOT/partials/iam-database-links.adoc
+++ b/typeql-src/modules/ROOT/partials/iam-database-links.adoc
@@ -1,5 +1,5 @@
 _For this example, use a database with the IAM
-link:https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[schema]
+link:https://github.com/typedb/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-schema.tql[schema]
 and
-link:https://github.com/vaticle/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[sample data]
+link:https://github.com/typedb/typedb-docs/blob/master/drivers-src/modules/ROOT/partials/tutorials/iam-data-single-query.tql[sample data]
 loaded._


### PR DESCRIPTION
## What is the goal of this PR?

To replace all occurrences of "Vaticle" with "TypeDB" following the renaming of the GitHub org wherever possible in user-facing places.

## What are the changes implemented in this PR?

- Replaced in GitHub URIs.
- Replaced in code examples.
- Replaced in text.
- Replaced in arbitrary file names.
- Replaced in copyright statements.
- Not replaced in Docker URIs, as the Docker org has not been renamed.
- Not replaced in Java package names, as the packages have not been renamed.
- Not replaced in Bazel files, as this is not user-facing and has potential to break things.