### PR TITLE
Add links to "Behavior" sections

### DIFF
--- a/manual-src/modules/ROOT/pages/writing/insert.adoc
+++ b/manual-src/modules/ROOT/pages/writing/insert.adoc
@@ -9,7 +9,7 @@ In this guide, you'll see how to insert data in a database using Studio, Console
 An Insert query is used to insert data into a TypeDB database.
 An `insert` clause is executed once per every result matched by the `match` clause of the same query.
 If the `match` clause is omitted, then the `insert` clause is executed exactly once. 
-For a detailed explanation of the query see the xref:typeql::queries/delete.adoc[] page.
+For a detailed explanation of the query see the xref:typeql::queries/insert.adoc[] page.
 
 [#_how_to_send_an_insert_query]
 == Sending Insert queries

--- a/typeql-src/modules/ROOT/pages/statements/abstract.adoc
+++ b/typeql-src/modules/ROOT/pages/statements/abstract.adoc
@@ -16,7 +16,7 @@ The `abstract` keyword doesn't use any object, so after the keyword always follo
 
 == Behavior
 
-TypeQL statements with the `abstract` keyword are used in Define queries to define (declare) that the type is abstract.
+TypeQL statements with the `abstract` keyword are used in xref:typeql::queries/define.adoc[] to define (declare) that the type is abstract.
 
 An abstract type can't be used to insert a data instance
 but can be used to create a subtype or to query (for its subtypes).

--- a/typeql-src/modules/ROOT/pages/statements/key.adoc
+++ b/typeql-src/modules/ROOT/pages/statements/key.adoc
@@ -18,7 +18,7 @@ The syntax of a `@key` statement includes:
 
 == Behavior
 
-TypeQL statements with the `@key` keyword can be used only in Define queries.
+TypeQL statements with the `@key` keyword can be used only in xref:typeql::queries/define.adoc[].
 
 The `@key` keyword adds a xref:typeql::statements/unique.adoc[unique annotation] constraint,
 as well as a cardinality constraint of exactly one.

--- a/typeql-src/modules/ROOT/pages/statements/owns.adoc
+++ b/typeql-src/modules/ROOT/pages/statements/owns.adoc
@@ -24,7 +24,7 @@ An optional <<_usage_with_override,override>> can be added at the end.
 
 == Behavior
 
-TypeQL statements with the `owns` keyword can be used only in Define and Undefine queries.
+TypeQL statements with the `owns` keyword can be used only in xref:typeql::queries/define.adoc[] and xref:typeql::queries/undefine.adoc[].
 
 The `owns` keyword adds an ability for the subject type to own attributes of
 the object attribute type to the schema.

--- a/typeql-src/modules/ROOT/pages/statements/plays.adoc
+++ b/typeql-src/modules/ROOT/pages/statements/plays.adoc
@@ -20,7 +20,7 @@ An optional <<_usage_with_override,override>> can be added at the end.
 
 == Behavior
 
-TypeQL statements with the `plays` keyword can be used only in Define and Undefine queries.
+TypeQL statements with the `plays` keyword can be used only in xref:typeql::queries/define.adoc[] and xref:typeql::queries/undefine.adoc[].
 
 The `plays` keyword adds an ability to play a role to a schema.
 

--- a/typeql-src/modules/ROOT/pages/statements/regex.adoc
+++ b/typeql-src/modules/ROOT/pages/statements/regex.adoc
@@ -19,7 +19,7 @@ The syntax of a `regex` statement includes:
 
 == Behavior
 
-TypeQL statements with the `regex` keyword can be used only in Define queries.
+TypeQL statements with the `regex` keyword can be used only in xref:typeql::queries/define.adoc[].
 
 The `regex` keyword adds a constraint on values of attributes of a given attribute type
 to be valid strings according to the object regular expression.

--- a/typeql-src/modules/ROOT/pages/statements/relates.adoc
+++ b/typeql-src/modules/ROOT/pages/statements/relates.adoc
@@ -20,7 +20,7 @@ An optional <<_usage_with_override,override>> can be added at the end.
 
 == Behavior
 
-TypeQL statements with the `relates` keyword can be used only in Define and Undefine queries.
+TypeQL statements with the `relates` keyword can be used only in xref:typeql::queries/define.adoc[] and xref:typeql::queries/undefine.adoc[].
 
 The `relates` keyword adds a new role to a relation type.
 

--- a/typeql-src/modules/ROOT/pages/statements/rule.adoc
+++ b/typeql-src/modules/ROOT/pages/statements/rule.adoc
@@ -22,7 +22,7 @@ rule <rule-label>: when {
 
 == Behavior
 
-TypeQL statements with the `rule` keyword can be used only in Define queries.
+TypeQL statements with the `rule` keyword can be used only in xref:typeql::queries/define.adoc[].
 To undefine a rule, use the `rule` keyword, followed by the rule's label, and a semicolon.
 
 The `rule` keyword adds a new rule to a schema, or updates an existing rule with the same label.

--- a/typeql-src/modules/ROOT/pages/statements/unique.adoc
+++ b/typeql-src/modules/ROOT/pages/statements/unique.adoc
@@ -18,7 +18,7 @@ The syntax of a `@unique` statement includes:
 
 == Behavior
 
-TypeQL statements with the `@unique` keyword can be used only in Define queries.
+TypeQL statements with the `@unique` keyword can be used only in xref:typeql::queries/define.adoc[].
 
 The `@unique` keyword adds a uniqueness constraint for all attributes of the attribute type
 owned by data instances of the subject type.

--- a/typeql-src/modules/ROOT/pages/statements/value.adoc
+++ b/typeql-src/modules/ROOT/pages/statements/value.adoc
@@ -18,7 +18,7 @@ The syntax of a `value` statement includes:
 
 == Behavior
 
-TypeQL statements with the `value` keyword can be used only in Define queries.
+TypeQL statements with the `value` keyword can be used only in xref:typeql::queries/define.adoc[].
 
 The `value` keyword adds a constraint on values of attributes of a given attribute type
 to be of the selected value type only.


### PR DESCRIPTION
Hi

While browsing the documentation of TypeDB, I noticed that various queries such as `Define` or `Undefine` were not linked.
This PR adds them.

Thanks