### PR TITLE
Add update pipeline stage documentation

### DIFF
--- a/drivers/modules/ROOT/pages/java/tutorial.adoc
+++ b/drivers/modules/ROOT/pages/java/tutorial.adoc
@@ -274,25 +274,30 @@ Additionally, let's use a TypeDB function called `all_relatives` that we previou
 include::{page-version}@drivers::partial$tutorials/java/src/main/java/org/example2/Main.java[tag=match-function]
 ----
 
-// TODO: Rewrite this when updates are introduced
 [#_update]
 === Update query
 
 Let's replace a `phone` of one of the `user` s by a new one.
-We can do that by deleting ownership of the old path attribute from the file entity and assigning it with ownership of the new path attribute:
+The fastest way is to use an `update` stage, which replaces the old data with the specified values:
 
 [,java,indent=0]
 ----
 include::{page-version}@drivers::partial$tutorials/java/src/main/java/org/example2/Main.java[tag=update]
 ----
 
-Here, you can notice how both `delete` and `insert` pipeline stages reuse the same variable from the first `match` stage. Executing both write stages in a single transaction isolates these changes from other transactions: there won't be any point of time for other TypeDB users where they won't see a `user` s `phone`. Moreover,
-if any other transaction makes a conflicting change before we commit this transaction, then our transaction fails upon a commit.
+We could also do that by deleting ownership of the old path attribute from the file entity and assigning it with ownership of the new path attribute manually by writing consecutive `delete` and `insert` pipeline stages.
+
+[NOTE]
+====
+Executing multiple write stages in a single transaction isolates these changes from other transactions: there won't be any point of time for other TypeDB users where they won't see a `user` s `phone`.
+Moreover, if any other transaction makes a conflicting change before we commit this transaction, then our transaction fails upon a commit.
+====
 
 [#_delete]
 === Delete query
 
-Finally, let's delete a `user` by a given `email`. It can be simply done by a single statement inside a `match`, and a very short `delete` operation.
+Finally, let's delete a `user` by a given `email`.
+It can be simply done by a single statement inside a `match`, and a very short `delete` operation.
 
 [,java,indent=0]
 ----

--- a/drivers/modules/ROOT/pages/python/tutorial.adoc
+++ b/drivers/modules/ROOT/pages/python/tutorial.adoc
@@ -277,21 +277,24 @@ Additionally, let's use a TypeDB function called `all_relatives` that we previou
 include::{page-version}@drivers::partial$tutorials/python/sample.py[tag=match-function]
 ----
 
-// TODO: Rewrite this once update stages are introduced
 [#_update]
 === Update query
 
 Let's replace a `phone` of one of the `user` s by a new one.
-We can do that by deleting ownership of the old path attribute from the file entity and assigning it with ownership of the new path attribute:
+The fastest way is to use an `update` stage, which replaces the old data with the specified values:
 
 [,python]
 ----
 include::{page-version}@drivers::partial$tutorials/python/sample.py[tag=update]
 ----
 
-Here, you can notice how both `delete` and `insert` pipeline stages reuse the same variable from the first `match` stage.
-Executing both write stages in a single transaction isolates these changes from other transactions: there won't be any point of time for other TypeDB users where they won't see a `user` s `phone`.
+We could also do that by deleting ownership of the old path attribute from the file entity and assigning it with ownership of the new path attribute manually by writing consecutive `delete` and `insert` pipeline stages.
+
+[NOTE]
+====
+Executing multiple write stages in a single transaction isolates these changes from other transactions: there won't be any point of time for other TypeDB users where they won't see a `user` s `phone`.
 Moreover, if any other transaction makes a conflicting change before we commit this transaction, then our transaction fails upon a commit.
+====
 
 [#_delete]
 === Delete query

--- a/drivers/modules/ROOT/pages/rust/tutorial.adoc
+++ b/drivers/modules/ROOT/pages/rust/tutorial.adoc
@@ -287,21 +287,24 @@ Additionally, let's use a TypeDB function called `all_relatives` that we previou
 include::{page-version}@drivers::partial$tutorials/rust/src/main.rs[tag=match-function]
 ----
 
-// TODO: Rewrite this once update stages are introduces
 [#_update]
 === Update query
 
 Let's replace a `phone` of one of the `user` s by a new one.
-We can do that by deleting ownership of the old path attribute from the file entity and assigning it with ownership of the new path attribute:
+The fastest way is to use an `update` stage, which replaces the old data with the specified values:
 
 [,rust]
 ----
 include::{page-version}@drivers::partial$tutorials/rust/src/main.rs[tag=update]
 ----
 
-Here, you can notice how both `delete` and `insert` pipeline stages reuse the same variable from the first `match` stage.
-Executing both write stages in a single transaction isolates these changes from other transactions: there won't be any point of time for other TypeDB users where they won't see a `user` s `phone`.
+We could also do that by deleting ownership of the old path attribute from the file entity and assigning it with ownership of the new path attribute manually by writing consecutive `delete` and `insert` pipeline stages.
+
+[NOTE]
+====
+Executing multiple write stages in a single transaction isolates these changes from other transactions: there won't be any point of time for other TypeDB users where they won't see a `user` s `phone`.
 Moreover, if any other transaction makes a conflicting change before we commit this transaction, then our transaction fails upon a commit.
+====
 
 [#_delete]
 === Delete query

--- a/drivers/modules/ROOT/partials/tutorials/java/src/main/java/org/example2/Main.java
+++ b/drivers/modules/ROOT/partials/tutorials/java/src/main/java/org/example2/Main.java
@@ -200,8 +200,7 @@ public class Main {
         try (Transaction tx = driver.transaction(dbName, Transaction.Type.WRITE)) {
             String query = String.format(
                     "match $u isa user, has email '%s', has phone $phone; $phone == '%s';" +
-                            "delete $phone of $u;" +
-                            "insert $u has phone '%s';",
+                            "update $u has phone '%s';",
                     email, oldPhone, newPhone);
             rows = tx.query(query).resolve().asConceptRows().stream().collect(Collectors.toList());
             tx.commit();

--- a/drivers/modules/ROOT/partials/tutorials/python/sample.py
+++ b/drivers/modules/ROOT/partials/tutorials/python/sample.py
@@ -193,8 +193,7 @@ def update_phone_by_email(driver, db_name, email, old, new):
     with driver.transaction(db_name, TransactionType.WRITE) as tx:
         answers = list(tx.query(f"""
           match $u isa user, has email '{email}', has phone $phone; $phone == '{old}';
-          delete $phone of $u;
-          insert $u has phone '{new}';
+          update $u has phone '{new}';
         """).resolve().as_concept_rows())
         tx.commit()
         answers_len = len(answers)

--- a/drivers/modules/ROOT/partials/tutorials/rust/src/main.rs
+++ b/drivers/modules/ROOT/partials/tutorials/rust/src/main.rs
@@ -158,8 +158,7 @@ async fn update_phone_by_email(
     let rows = tx
         .query(&format!(
             "match $u isa user, has email '{email}', has phone $phone; $phone == '{old_phone}';
-            delete $phone of $u;
-            insert $u has phone '{new_phone}';",
+            update $u has phone '{new_phone}';",
         ))
         .await?
         .into_rows()

--- a/manual/modules/ROOT/pages/CRUD/deleting.adoc
+++ b/manual/modules/ROOT/pages/CRUD/deleting.adoc
@@ -121,7 +121,7 @@ However, if you <<_email_deletion, delete the `email` itself>>:
    ------------
 ----
 
-== Preserving or reverting changes
+== Committing
 
 include::{page-version}@manual::page$CRUD/inserting.adoc[tag=preserving-reverting-changes]
 

--- a/manual/modules/ROOT/pages/CRUD/inserting.adoc
+++ b/manual/modules/ROOT/pages/CRUD/inserting.adoc
@@ -75,7 +75,7 @@ If the `username` attribute `"User"` does not yet exist when running the above, 
 [[links]]
 === Inserting role players with `links`
 
-Connections of relations to their "`role players`" data instance can be created using `links` statements
+Connections of relations to their "`role players`" data instances can be created using `links` statements.
 
 [,typeql]
 .Inserting users, a friendship, and links between users via that friendship
@@ -117,7 +117,7 @@ The first stage of the pipeline retrieves the users called `"Bob"` from the data
 
 See the xref:{page-version}@typeql::pipelines/index.adoc[data pipeline reference] for more information.
 
-== Insert stage anwers
+== Insert stage answers
 
 An insert stage returns all concepts inserted into the database as a stream of concept rows.
 A collected stream of concept rows can be interpreted as a table with a header containing variables and rows with respective concept answers for each variable.

--- a/manual/modules/ROOT/pages/CRUD/updating.adoc
+++ b/manual/modules/ROOT/pages/CRUD/updating.adoc
@@ -108,6 +108,19 @@ update
   $gm links ($g);
 ----
 
+As already mentioned, update stages are useful to write shorter queries.
+It is especially noticeable in queries updating multiple things.
+For example, swapping role players after a mistaken insertion.
+
+[,typeql]
+.
+----
+match
+  $p isa parentship (parent: $x, child: $y);
+update
+  $p links (parent: $y, child: $x);
+----
+
 == Update stage answers
 
 An update stage does not modify the input variables from the previous stages.

--- a/manual/modules/ROOT/pages/CRUD/updating.adoc
+++ b/manual/modules/ROOT/pages/CRUD/updating.adoc
@@ -1,8 +1,132 @@
 = Updating data
 :page-aliases: {page-version}@manual::writing/update.adoc
 
+This page explains how to update data in a TypeDB database.
+
+== Overview
+
+Data in TypeDB is updated using `update` or a combination of `delete` and `insert` stages in *write pipelines*, which can executed in `write` (or `schema`) xref:{page-version}@manual::queries/transactions.adoc[transactions].
+It can be used in a xref:{page-version}@typeql::pipelines/index.adoc[pipeline] to operate variables declared on a preceding stage.
+
+Due to safety reasons, only unambiguous statements are allowed in update stages.
+Thus, it can only operate on `has` and `links` statements with their schema xref:{page-version}@typeql::annotations/card.adoc[cardinalities] limited by 1. To have more available actions and manual control over updates, use xref:{page-version}@manual::CRUD/deleting.adoc[deletion] and xref:{page-version}@manual::CRUD/inserting.adoc[insertion] instead.
+
+Update queries replaces the existing data with the values specified.
+The new data insertion happens even if no data existed before the update.
+
+This way, update stages can be used to ensure that the data is in a required state before proceeding with other pipeline stages, ignoring the previous "wrong" state of the database.
+
+Refer to the xref:{page-version}@typeql::pipelines/update.adoc[] page for a detailed explanation and additional examples.
+
+== Running updates
+
+To update data, open a `write` xref:{page-version}@manual::queries/transactions.adoc[transaction].
+This allows you to read and write data to your database while keeping the schema secure.
+
+Update stages begin with the keyword `update`.
+Multiple statements can be combined within the same `update` stage and the same variable may appear in multiple statements.
+
+== Update statements
+
+Let's give a brief overview of what kinds of statements can be used in an update stage.
+
+[[has]]
+=== Updating attribute ownerships with `has`
+
+Connections of attributes to their "`owner`" data instances can be updated using `has` statements.
+
+[,typeql]
+.Updating a single user's username using a value constant
+----
+match
+  $x isa user, has username "User_1";
+update
+  $x has username "User_2";
+----
+
 [NOTE]
 ====
-An update stage will be added to TypeDB pipelines soon. For now, you can use a combination of `delete` and `insert` to update your data.
+If the `username` attribute `"User_2"` does not yet exist when running the above, it will be created anonymously by the above query ("`anonymously`" meaning that we do not assign it to any variable).
+However, no explicit `isa` statements for variable binding are allowed in updates.
 ====
 
+Similarly, an attribute variable can be used in this operation.
+
+[,typeql]
+.Updating a single user's username using an attribute variable
+----
+match
+  $x isa user, has username "User_1";
+  $y isa username "User_2";
+update
+  $x has $y;
+----
+
+Without update stages, you'd be required to write two other stages instead.
+
+[,typeql]
+.Updating a single user's username through delete and insert
+----
+match
+  $y isa username "User_2";
+  $y-old isa username "User_1";
+  $x isa user, has $y-old;
+delete
+  has $y-old of $x;
+insert
+  $x has $y;
+----
+
+[[links]]
+=== Updating role players with `links`
+
+Connections of relations to their "`role players`" data instances can be updated using `links` statements.
+
+[,typeql]
+.Updating all existing group memberships of a user with a new group
+----
+insert
+  $g isa group, has group-id "Group_2";
+match
+  $x isa user, has username "User";
+  $gm isa group-membership, links (member: $x);
+update
+  $gm links (group: $g);
+----
+
+If a role player can only play a single role in the relation, the role can be omitted.
+
+[,typeql]
+.Updating all existing group memberships of a user with a new group without updated role specification
+----
+insert
+  $g isa group, has group-id "Group_2";
+match
+  $x isa user, has username "User";
+  $gm isa group-membership, links (member: $x);
+update
+  $gm links ($g);
+----
+
+== Update stage answers
+
+An update stage does not modify the input variables from the previous stages.
+Thus, it returns a stream of the same concept rows produced by a preceding pipeline stage.
+
+.Update example's result
+[,typeql]
+----
+   ------------
+    $g  | iid 0x1f00020000000000000001 isa group
+    $gm | iid 0x1e00030000000000000000 isa group-membership
+    $x  | iid 0x1e00030000000000000003 isa user
+   ------------
+----
+
+== Committing
+
+include::{page-version}@manual::page$CRUD/inserting.adoc[tag=preserving-reverting-changes]
+
+== Having troubles?
+
+include::{page-version}@manual::page$CRUD/inserting.adoc[tag=having-troubles]

--- a/manual/modules/ROOT/pages/CRUD/updating.adoc
+++ b/manual/modules/ROOT/pages/CRUD/updating.adoc
@@ -113,7 +113,7 @@ It is especially noticeable in queries updating multiple things.
 For example, swapping role players after a mistaken insertion.
 
 [,typeql]
-.
+.Using an update stage to swap role players
 ----
 match
   $p isa parentship (parent: $x, child: $y);

--- a/typeql/modules/ROOT/pages/pipelines/delete.adoc
+++ b/typeql/modules/ROOT/pages/pipelines/delete.adoc
@@ -21,7 +21,7 @@ delete ( <variable> | has <variable> of <variable> | links ( <variable> [ , ... 
 
 == Execution
 
-The delete stage must be preceded by other stages. The body of the delete clause is executed once for each input row. The output is then a
+The delete stage must be preceded by other stages. The body of the delete stage is executed once for each input row. The output is then a
 stream of input rows with the deleted concepts removed.
 
 == Example

--- a/typeql/modules/ROOT/pages/pipelines/insert.adoc
+++ b/typeql/modules/ROOT/pages/pipelines/insert.adoc
@@ -8,6 +8,7 @@ Insertable data includes instances of types, ownerships of attributes, and role 
 
 The body of an insert stage is a sequence of insert statements.
 
+// TODO: We actually introduce constructor and constraint syntaxes: https://discord.com/channels/665254494820368395/1329664928390578247/1339995321266081876
 All insert statements have the same syntax as their corresponding match statements.
 
 [,typeql]
@@ -22,7 +23,7 @@ Each variable introduced in the insert clause must be accompanied by an explicit
 * xref:{page-version}@typeql::statements/has.adoc[Has statements] insert new ownerships of attributes.
 If an attribute is provided by value, the attribute type is mandatory.
 * xref:{page-version}@typeql::statements/links.adoc[Links statements] insert new role players for relations.
-Role tags must be provided for all players.
+Role tags can be omitted if there is only a single role the role player can play.
 
 == Execution
 
@@ -32,6 +33,7 @@ The output stream in that case contains a single row containing the newly insert
 If the insert stage is preceded by other stages, its body is executed once for each input row.
 The output is then a stream of input rows extended with the newly inserted values.
 
+[#_validation]
 == Validation
 
 Attempting to insert the following fail immediately and terminate the transaction:

--- a/typeql/modules/ROOT/pages/pipelines/update.adoc
+++ b/typeql/modules/ROOT/pages/pipelines/update.adoc
@@ -10,7 +10,7 @@ The body of an update stage is a sequence of update statements, which are simila
 
 [,typeql]
 ----
-insert <update-statement> [ <update-statement> ... ]
+update <update-statement> [ <update-statement> ... ]
 ----
 
 == Behavior

--- a/typeql/modules/ROOT/pages/pipelines/update.adoc
+++ b/typeql/modules/ROOT/pages/pipelines/update.adoc
@@ -1,22 +1,48 @@
 = Update stage
 :page-aliases: {page-version}@typeql::queries/update.adoc
 
-[NOTE]
-====
-Coming soon.
-====
+An update stage updates data in the database. Updatable data includes ownerships of attributes and role players of
+relations.
 
-For data updates, combine xref:{page-version}@typeql::pipelines/delete.adoc[delete] and xref:{page-version}@typeql::pipelines/insert.adoc[insert] stages.
+== Syntax
 
-// == Draft example
-//
-// [,typeql]
-// ----
-// match
-//   $person isa person, has username "<username>";
-//   $group isa group, has group-id "<group id>";
-//   $membership isa group-membership,
-//     links (group: $group, member: $person);
-// update
-//   $membership has rank "moderator";
-// ----
+The body of an update stage is a sequence of update statements, which are similar to xref:{page-version}@typeql::statements/has.adoc[`has`] and xref:{page-version}@typeql::statements/links.adoc[`links`] statements of xref:{page-version}@typeql::pipelines/insert.adoc[insert].
+
+[,typeql]
+----
+insert <update-statement> [ <update-statement> ... ]
+----
+
+== Behavior
+
+* xref:{page-version}@typeql::statements/has.adoc[Has statements] replace existing attribute ownerships of the specified attribute's type (xref:{page-version}@typeql::statements/isa.adoc[`isa!`]) with a new ownership of the specified instance.
+If an attribute is provided by value, the attribute type is mandatory.
+* xref:{page-version}@typeql::statements/links.adoc[Links statements] replace existing role players of the specified player's role (xref:{page-version}@typeql::statements/isa.adoc[`isa!`]) with the specified instance.
+Role tags can be omitted if there is only a single role the role player can play.
+
+Update stages cannot bind new variables.
+
+If there is no data to existing replace, the operation is equivalent to xref:{page-version}@typeql::pipelines/insert.adoc[insert].
+
+== Execution
+
+The update stage must be preceded by other stages. The body of the update stage is executed once for each input row. The output is then a stream equivalent to the input rows, as no variables are modified.
+
+== Validation
+
+Only unambiguous operations on xref:{page-version}@typeql::statements/owns.adoc[`owns`] and xref:{page-version}@typeql::statements/relates.adoc[`relates`] with xref:{page-version}@typeql::annotations/card.adoc[cardinalities] limited by 1 are allowed.
+
+The modified concepts are validated the same way as in xref:{page-version}@typeql::pipelines/insert.adoc#_validation[insert stages].
+
+== Example
+
+[,typeql]
+----
+match
+  $group isa group, has group-id "<group id>";
+  $user isa user, has username "<username>";
+  $group-membership isa group-membership, has rank "admin", links (member: $user);
+update
+  $group-membership has rank "member";
+  $group-membership links (group: $group);
+----


### PR DESCRIPTION
## What is the goal of this PR?

We add Manual, TypeQL, and Drivers documentation for update queries, which are going to be [introduced](https://github.com/typedb/typedb/pull/7361) to TypeDB 3.1.

## What are the changes implemented in this PR?

* Add a Manual page about updating data, mentioning the difference between `update` and `delete + insert` and showing usage examples with tips for beginners.
* Add a TypeQL page about the update pipeline stage with documentation about its syntax and limitations with a basic example.
* Change the Driver tutorials to use the update stage instead of the old combination of `delete + insert`.
