### PR TITLE
Update driver tutorials and pages to support TypeDB Driver 3.1 with the unified constructor

### DIFF
--- a/code_test/runners/base_runner.py
+++ b/code_test/runners/base_runner.py
@@ -19,7 +19,7 @@ class BaseRunner(ABC):
         self.failure_count = 0
 
     def reset_local_databases(self):
-        driver = TypeDB.core_driver(address=self.uri, credentials=Credentials(self.username,self.password), driver_options=DriverOptions())
+        driver = TypeDB.driver(address=self.uri, credentials=Credentials(self.username,self.password), driver_options=DriverOptions())
         for database in driver.databases.all():
             database.delete()
 

--- a/code_test/runners/rust_runner.py
+++ b/code_test/runners/rust_runner.py
@@ -82,7 +82,7 @@ edition = "2021"
 
 [dependencies]
 serde_json = "1.0.114"
-typedb-driver = { version = "3.0.5" }
+typedb-driver = { version = "3.1.0" }
 tokio = "1.43.0"
 futures-util = "0.3.31"
 """

--- a/code_test/runners/typeql_runner.py
+++ b/code_test/runners/typeql_runner.py
@@ -30,11 +30,6 @@ TEST_FAIL_COMMIT_VAL = "commit"
 TEST_FAIL_RUNTIME_VAL = "runtime"
 
 
-class Edition(Enum):
-    Cloud = 1
-    Core = 2
-
-
 class FailureMode(Enum):
     Runtime = 1
     Commit = 2
@@ -49,7 +44,6 @@ class TypeqlRunner:
         self.failure_count = 0
 
         # Tql specific
-        self.edition = Edition.Core
         self.username = "admin"
         self.password = "password"
         self.db = "docs_test"
@@ -57,12 +51,7 @@ class TypeqlRunner:
         self.driver = self.create_driver()
 
     def create_driver(self) -> Driver:
-        if self.edition is Edition.Core:
-            driver = TypeDB.core_driver(self.uri, Credentials(self.username, self.password), DriverOptions(False, None))
-            return driver
-        if self.edition is Edition.Cloud:
-            driver = TypeDB.cloud_driver([self.uri], Credentials(self.username, self.password), DriverOptions(False, None))
-            return driver
+        return TypeDB.driver(self.uri, Credentials(self.username, self.password), DriverOptions(False, None))
 
     def delete_db(self):
         if self.driver.databases.contains(self.db):

--- a/drivers/modules/ROOT/pages/java/index.adoc
+++ b/drivers/modules/ROOT/pages/java/index.adoc
@@ -92,10 +92,12 @@ creates a database, processes driver errors, defines a schema, inserts some data
 ====
 [,java]
 ----
+package com.typedb.driver;
+
 import com.typedb.driver.TypeDB;
-import com.typedb.driver.api.DriverOptions;
 import com.typedb.driver.api.Credentials;
 import com.typedb.driver.api.Driver;
+import com.typedb.driver.api.DriverOptions;
 import com.typedb.driver.api.QueryType;
 import com.typedb.driver.api.Transaction;
 import com.typedb.driver.api.answer.ConceptRow;
@@ -118,7 +120,7 @@ import java.util.stream.Collectors;
 public class TypeDBExample {
     public void example() {
         // Open a driver connection. Try-with-resources can be used for automatic driver connection management
-        try (Driver driver = TypeDB.coreDriver(TypeDB.DEFAULT_ADDRESS, new Credentials("admin", "password"), new DriverOptions(false, null))) {
+        try (Driver driver = TypeDB.driver(TypeDB.DEFAULT_ADDRESS, new Credentials("admin", "password"), new DriverOptions(false, null))) {
             // Create a database
             driver.databases().create("typedb");
             Database database = driver.databases().get("typedb");
@@ -168,10 +170,10 @@ public class TypeDBExample {
                 String columnName = entityHeader.get(0);
 
                 // Get concept by the variable name (column name)
-                Concept conceptByName = entityRow.get(columnName);
+                Concept conceptByName = entityRow.get(columnName).get();
 
                 // Get concept by the header's index
-                Concept conceptByIndex = entityRow.getIndex(0);
+                Concept conceptByIndex = entityRow.getIndex(0).get();
 
                 System.out.printf("Getting concepts by variable names (%s) and indexes (%s) is equally correct. ",
                         conceptByName.getLabel(),
@@ -197,7 +199,7 @@ public class TypeDBExample {
                     Iterator<String> columnNameIterator = attributeRow.columnNames().iterator();
                     columnName = columnNameIterator.next();
 
-                    conceptByName = attributeRow.get(columnName);
+                    conceptByName = attributeRow.get(columnName).get();
 
                     // Check if it's an attribute type before the conversion
                     if (conceptByName.isAttributeType()) {
@@ -218,7 +220,7 @@ public class TypeDBExample {
                 List<ConceptRow> rows = answer.asConceptRows().stream().collect(Collectors.toList());
                 ConceptRow row = rows.get(0);
                 row.columnNames().iterator().forEachRemaining(columnName -> {
-                    Concept insertedConcept = row.get(columnName);
+                    Concept insertedConcept = row.get(columnName).get();
                     System.out.printf("Successfully inserted $%s: %s%n", columnName, insertedConcept);
                     if (insertedConcept.isEntity()) {
                         System.out.println("This time, it's an entity, not a type!");
@@ -228,13 +230,14 @@ public class TypeDBExample {
                 // It is possible to ask for the column names again
                 List<String> header = row.columnNames().collect(Collectors.toList());
 
-                Concept x = row.getIndex(header.indexOf("x"));
+                Concept x = row.getIndex(header.indexOf("x")).get();
                 System.out.printf("As we expect an entity instance, we can try to get its IID (unique identification): %s. ", x.tryGetIID());
                 if (x.isEntity()) {
                     System.out.println("It can also be retrieved directly and safely after a cast: " + x.asEntity().getIID());
                 }
 
                 // Do not forget to commit if the changes should be persisted
+                System.out.println("CAUTION: Committing or closing (including leaving the try-with-resources block) a transaction will invalidate all its uncollected answer iterators");
                 transaction.commit();
             }
 
@@ -274,7 +277,7 @@ public class TypeDBExample {
                 // Simple match queries always return concept rows
                 AtomicInteger matchCount = new AtomicInteger(0);
                 matchAnswer.asConceptRows().stream().forEach(row -> {
-                    Concept x = row.get(var);
+                    Concept x = row.get(var).get();
                     EntityType xType = x.asEntity().getType().asEntityType();
                     matchCount.incrementAndGet();
                     System.out.printf("Found a person %s of type %s%n", x, xType);

--- a/drivers/modules/ROOT/pages/java/tutorial.adoc
+++ b/drivers/modules/ROOT/pages/java/tutorial.adoc
@@ -53,7 +53,6 @@ include::{page-version}@drivers::partial$tutorials/java/src/main/java/org/exampl
 
 where `DB_NAME` -- the name of the database to use;
 `SERVER_ADDR` -- address of the TypeDB server to connect to;
-`TYPEDB_EDITION` -- TypeDB Community Edition or Cloud edition selector;
 `USERNAME`/`PASSWORD` -- authentication credentials.
 
 == Program structure
@@ -70,18 +69,15 @@ The entire `main()` function code is executed in the context of the <<_typedb_co
 [#_typedb_connection]
 == TypeDB connection
 
-The `driverConnect()` function takes `edition` and `addr` as mandatory parameters.
+The `driverConnect()` function takes `addr` as a mandatory parameter.
 
 [,java,indent=0]
 ----
 include::{page-version}@drivers::partial$tutorials/java/src/main/java/org/example2/Main.java[tag=connection]
 ----
 
-The `edition` is expected to be an Enum for selecting a TypeDB edition.
-Depending on the TypeDB edition selected, this function initializes either a TypeDB Community Edition or a TypeDB Cloud / Enterprise connection.
-
 TypeDB connections require objects of the `Credentials` (authentication credentials) and `DriverOptions` (driver-specific connection options like TLS settings) classes.
-For our sample application, we have suitable default values set for all editions.
+For our sample application, the default values are set.
 
 == Database setup
 

--- a/drivers/modules/ROOT/pages/python/index.adoc
+++ b/drivers/modules/ROOT/pages/python/index.adoc
@@ -67,9 +67,12 @@ creates a database, processes driver errors, defines a schema, inserts some data
 from typedb.driver import *
 
 
+class TypeDBExample:
+
     def typedb_example():
-        # Open a driver connection. The connection will be automatically closed on the "with" block exit
-        with TypeDB.core_driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions()) as driver:
+        # Open a driver connection. Specify your parameters if needed
+        # The connection will be automatically closed on the "with" block exit
+        with TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions()) as driver:
             # Create a database
             driver.databases.create("typedb")
             database = driver.databases.get("typedb")
@@ -175,12 +178,14 @@ from typedb.driver import *
                 header = [name for name in row.column_names()]
 
                 x = row.get_index(header.index("x"))
-                print(
-                    "As we expect an entity instance, we can try to get its IID (unique identification): {x.try_get_iid()}. ")
+                print("As we expect an entity instance, we can try to get its IID (unique identification): "
+                      "{x.try_get_iid()}. ")
                 if x.is_entity():
                     print(f"It can also be retrieved directly and safely after a cast: {x.as_entity().get_iid()}")
 
                 # Do not forget to commit if the changes should be persisted
+                print('CAUTION: Committing or closing (including leaving the "with" block) a transaction will '
+                      'invalidate all its uncollected answer iterators')
                 tx.commit()
 
             # Open another write transaction to try inserting even more data

--- a/drivers/modules/ROOT/pages/python/tutorial.adoc
+++ b/drivers/modules/ROOT/pages/python/tutorial.adoc
@@ -60,7 +60,6 @@ include::{page-version}@drivers::partial$tutorials/python/sample.py[tag=constant
 
 where `DB_NAME` -- the name of the database to use;
 `SERVER_ADDR` -- address of the TypeDB server to connect to;
-`TYPEDB_EDITION` -- TypeDB Community Edition or Cloud edition selector;
 `USERNAME`/`PASSWORD` -- authentication credentials.
 
 == Program structure
@@ -77,18 +76,15 @@ The entire `main()` function code is executed in the context of the <<_typedb_co
 [#_typedb_connection]
 == TypeDB connection
 
-The `driver_connect()` function takes `edition` and `addr` as mandatory parameters.
+The `driver_connect()` function takes `addr` as a mandatory parameter.
 
 [,python]
 ----
 include::{page-version}@drivers::partial$tutorials/python/sample.py[tag=connection]
 ----
 
-The `edition` is expected to be an Enum for selecting a TypeDB edition.
-Depending on the TypeDB edition selected, this function initializes either a TypeDB Community Edition or a TypeDB Cloud / Enterprise connection.
-
 TypeDB connections require objects of the `Credentials` (authentication credentials) and `DriverOptions` (driver-specific connection options like TLS settings) classes.
-For our sample application, we have suitable default values set for all editions.
+For our sample application, the default values are set.
 
 == Database setup
 

--- a/drivers/modules/ROOT/pages/rust/index.adoc
+++ b/drivers/modules/ROOT/pages/rust/index.adoc
@@ -77,8 +77,8 @@ use typedb_driver::{
 
 fn typedb_example() {
     async_std::task::block_on(async {
-        // Open a driver connection
-        let driver = TypeDBDriver::new_core(
+        // Open a driver connection. Specify your parameters if needed
+        let driver = TypeDBDriver::new(
             TypeDBDriver::DEFAULT_ADDRESS,
             Credentials::new("admin", "password"),
             DriverOptions::new(false, None).unwrap(),
@@ -127,6 +127,7 @@ fn typedb_example() {
         }
 
         // Commit automatically closes the transaction (don't forget to await the result!)
+        // CAUTION: Committing or closing a transaction will invalidate all its uncollected answer streams
         transaction.commit().await.unwrap();
 
         // Open a read transaction to safely read anything without database modifications
@@ -143,10 +144,10 @@ fn typedb_example() {
         let column_name = column_names.get(0).unwrap();
 
         // Get concept by the variable name (column name)
-        let concept_by_name = row.get(column_name).unwrap();
+        let concept_by_name = row.get(column_name).unwrap().unwrap();
 
         // Get concept by the header's index
-        let concept_by_index = row.get_index(0).unwrap();
+        let concept_by_index = row.get_index(0).unwrap().unwrap();
 
         // Check if it's an entity type
         if concept_by_name.is_entity_type() {
@@ -167,7 +168,7 @@ fn typedb_example() {
             let mut column_names_iter = row.get_column_names().into_iter();
             let column_name = column_names_iter.next().unwrap();
 
-            let concept_by_name = row.get(column_name).unwrap();
+            let concept_by_name = row.get(column_name).unwrap().unwrap();
 
             // Check if it's an attribute type to safely retrieve its value type
             if concept_by_name.is_attribute_type() {
@@ -195,7 +196,7 @@ fn typedb_example() {
         let row = rows.get(0).unwrap();
 
         for column_name in row.get_column_names() {
-            let inserted_concept = row.get(column_name).unwrap();
+            let inserted_concept = row.get(column_name).unwrap().unwrap();
             println!("Successfully inserted ${}: {}", column_name, inserted_concept);
             if inserted_concept.is_entity() {
                 println!("This time, it's an entity, not a type!");
@@ -205,7 +206,7 @@ fn typedb_example() {
         // It is possible to ask for the column names again
         let column_names = row.get_column_names();
 
-        let x = row.get_index(column_names.iter().position(|r| r == "x").unwrap()).unwrap();
+        let x = row.get_index(column_names.iter().position(|r| r == "x").unwrap()).unwrap().unwrap();
         if let Some(iid) = x.try_get_iid() {
             println!("Each entity receives a unique IID. It can be retrieved directly: {}", iid);
         }
@@ -250,7 +251,7 @@ fn typedb_example() {
         let mut count = 0;
         let mut stream = answer.into_rows().map(|result| result.unwrap());
         while let Some(row) = stream.next().await {
-            let x = row.get(var).unwrap();
+            let x = row.get(var).unwrap().unwrap();
             match x {
                 Concept::Entity(x_entity) => {
                     let x_type = x_entity.type_().unwrap();

--- a/drivers/modules/ROOT/pages/rust/tutorial.adoc
+++ b/drivers/modules/ROOT/pages/rust/tutorial.adoc
@@ -64,7 +64,6 @@ include::{page-version}@drivers::partial$tutorials/rust/src/main.rs[tag=constant
 
 where `DB_NAME` -- the name of the database to use;
 `SERVER_ADDR` -- address of the TypeDB server to connect to;
-`TYPEDB_EDITION` -- TypeDB Community Edition or Cloud edition selector;
 `USERNAME`/`PASSWORD` -- authentication credentials.
 
 == Program structure
@@ -81,18 +80,15 @@ The entire `main()` function code is executed in the context of the <<_typedb_co
 [#_typedb_connection]
 == TypeDB connection
 
-The `driver_connect()` function takes `edition`, `uri`, and the credentials as mandatory parameters.
+The `driver_connect()` function takes `uri`, and the credentials as mandatory parameters.
 
 [,rust]
 ----
 include::{page-version}@drivers::partial$tutorials/rust/src/main.rs[tag=connection]
 ----
 
-The `edition` is expected to be an Enum for selecting a TypeDB edition.
-Depending on the TypeDB edition selected, this function initializes either a TypeDB Community Edition or a TypeDB Cloud / Enterprise connection.
-
 TypeDB connections require objects of the `Credentials` (authentication credentials) and `DriverOptions` (driver-specific connection options like TLS settings) classes.
-For our sample application, we have suitable default values set for all editions.
+For our sample application, the default values are set.
 
 == Database setup
 

--- a/drivers/modules/ROOT/partials/tutorials/java/pom.xml
+++ b/drivers/modules/ROOT/partials/tutorials/java/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.typedb</groupId>
             <artifactId>typedb-driver</artifactId>
-            <version>3.0.5</version>
+            <version>3.1.0</version>
         </dependency>
     </dependencies>
 

--- a/drivers/modules/ROOT/partials/tutorials/java/src/main/java/org/example2/Main.java
+++ b/drivers/modules/ROOT/partials/tutorials/java/src/main/java/org/example2/Main.java
@@ -2,16 +2,6 @@ package org.example2;
 // tag::code[]
 // tag::import[]
 
-import com.typedb.driver.TypeDB;
-import com.typedb.driver.api.Credentials;
-import com.typedb.driver.api.Driver;
-import com.typedb.driver.api.DriverOptions;
-import com.typedb.driver.api.Transaction;
-import com.typedb.driver.api.answer.ConceptRow;
-import com.typedb.driver.api.answer.JSON;
-import com.typedb.driver.common.exception.TypeDBDriverException;
-import com.typedb.driver.jni.TypeDBDriver;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -19,7 +9,6 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 // end::import[]
@@ -29,19 +18,13 @@ public class Main {
     private static final String DB_NAME = "sample_app_db";
     private static final String SERVER_ADDR = "127.0.0.1:1729";
 
-    public enum Edition {
-        CORE,
-        CLOUD
-    }
-
-    private static final Edition TYPEDB_EDITION = Edition.CORE;
     private static final String USERNAME = "admin";
     private static final String PASSWORD = "password";
 
     // end::constants[]
     // tag::main[]
     public static void main(String[] args) {
-        try (Driver driver = driverConnect(TYPEDB_EDITION, SERVER_ADDR, USERNAME, PASSWORD)) {
+        try (Driver driver = driverConnect(SERVER_ADDR, USERNAME, PASSWORD)) {
             if (dbSetup(driver, DB_NAME, false)) {
                 System.out.println("Setup complete.");
                 queries(driver, DB_NAME);
@@ -83,28 +66,11 @@ public class Main {
 
     // end::queries[]
     // tag::connection[]
-    private static Driver driverConnect(Edition edition, String uri, String username, String password) throws TypeDBDriverException {
-        if (edition == Edition.CORE) {
-            // tag::driver_new_core[]
-            Driver driver = TypeDB.coreDriver(
-                    uri,
-                    new Credentials(username, password),
-                    new DriverOptions(false, null)
-            );
-            // end::driver_new_core[]
-            return driver;
-        }
-        if (edition == Edition.CLOUD) {
-            // tag::driver_new_cloud[]
-            Driver driver = TypeDB.cloudDriver(
-                    Set.of(uri),
-                    new Credentials(username, password),
-                    new DriverOptions(true, null)
-            );
-            // end::driver_new_cloud[]
-            return driver;
-        }
-        return null;
+    private static Driver driverConnect(String uri, String username, String password) throws TypeDBDriverException {
+        // tag::driver_new[]
+        Driver driver = TypeDB.driver(uri, new Credentials(username, password), new DriverOptions(false, null));
+        // end::driver_new[]
+        return driver;
     }
     // end::connection[]
 

--- a/drivers/modules/ROOT/partials/tutorials/python/sample.py
+++ b/drivers/modules/ROOT/partials/tutorials/python/sample.py
@@ -1,7 +1,6 @@
 # tag::code[]
 # tag::import[]
 from typedb.driver import TypeDB, TransactionType, Credentials, DriverOptions
-from enum import Enum
 # end::import[]
 
 
@@ -9,11 +8,6 @@ from enum import Enum
 DB_NAME = "sample_app_db"
 SERVER_ADDR = "127.0.0.1:1729"
 
-class Edition(Enum):
-    Cloud = 1
-    Core = 2
-
-TYPEDB_EDITION = Edition.Core
 USERNAME = "admin"
 PASSWORD = "password"
 # end::constants[]
@@ -222,17 +216,11 @@ def delete_user_by_email(driver, db_name, email):
 
 
 # tag::connection[]
-def driver_connect(edition, uri, username=USERNAME, password=PASSWORD):
-    if edition is Edition.Core:
-        # tag::driver_new_core[]
-        driver = TypeDB.core_driver(uri, Credentials(username, password), DriverOptions(False, None))
-        # end::driver_new_core[]
-        return driver
-    if edition is Edition.Cloud:
-        # tag::driver_new_cloud[]
-        driver = TypeDB.cloud_driver([uri], Credentials(username, password), DriverOptions(False, None))
-        # end::driver_new_cloud[]
-        return driver
+def driver_connect(uri, username=USERNAME, password=PASSWORD):
+    # tag::driver_new[]
+    driver = TypeDB.driver(uri, Credentials(username, password), DriverOptions(False, None))
+    # end::driver_new[]
+    return driver
 # end::connection[]
 
 
@@ -273,7 +261,7 @@ def queries(driver, db_name):
 
 # tag::main[]
 def main():
-    with driver_connect(TYPEDB_EDITION, SERVER_ADDR) as driver:
+    with driver_connect(SERVER_ADDR) as driver:
         if db_setup(driver, DB_NAME, db_reset=False):
             queries(driver, DB_NAME)
         else:

--- a/drivers/modules/ROOT/partials/tutorials/rust/Cargo.lock
+++ b/drivers/modules/ROOT/partials/tutorials/rust/Cargo.lock
@@ -1345,7 +1345,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typedb-driver"
-version = "3.0.5"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7669a3775fcd59f213ea2fbd1fcc3a00b547d4f1d0e855bb4cf27370c5226e1"
 dependencies = [

--- a/drivers/modules/ROOT/partials/tutorials/rust/Cargo.toml
+++ b/drivers/modules/ROOT/partials/tutorials/rust/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 serde_json = "1.0.114"
-typedb-driver = { version = "3.0.5" }
+typedb-driver = { version = "3.1.0" }
 tokio = "1.43.0"
 futures-util = "0.3.31"

--- a/drivers/modules/ROOT/partials/tutorials/rust/src/main.rs
+++ b/drivers/modules/ROOT/partials/tutorials/rust/src/main.rs
@@ -12,12 +12,6 @@ use typedb_driver::{answer::{ConceptRow, JSON}, Credentials, DriverOptions, Erro
 static DB_NAME: &str = "sample_app_db";
 static SERVER_ADDR: &str = "127.0.0.1:1729";
 
-enum Edition {
-    Core,
-    Cloud,
-}
-
-static TYPEDB_EDITION: Edition = Edition::Core;
 static USERNAME: &str = "admin";
 static PASSWORD: &str = "password";
 
@@ -222,37 +216,21 @@ async fn queries(driver: &TypeDBDriver, db_name: &str) -> Result<(), Box<dyn Err
 // WARNING: keep when changing the AsRef and signatures, ensure they aren't required as-is for code snippets throughout docs
 // tag::connection[]
 async fn driver_connect(
-    edition: &Edition,
     uri: &str,
     username: impl AsRef<str>,
     password: impl AsRef<str>,
 ) -> Result<TypeDBDriver, typedb_driver::Error> {
     let username = username.as_ref();
     let password = password.as_ref();
-    match edition {
-        Edition::Core => {
-            #[allow(clippy::let_and_return, reason = "tutorial readability")]
-            // tag::driver_new_core[]
-            let driver = TypeDBDriver::new_core(
-                &uri,
-                Credentials::new(username, password),
-                DriverOptions::new(false, None).unwrap(),
-            ).await;
-            // end::driver_new_core[]
-            driver
-        }
-        Edition::Cloud => {
-            #[allow(clippy::let_and_return, reason = "tutorial readability")]
-            // tag::driver_new_cloud[]
-            let driver = TypeDBDriver::new_cloud(
-                &vec![&uri],
-                Credentials::new(username, password),
-                DriverOptions::new(true, None).unwrap(),
-            ).await;
-            // end::driver_new_cloud[]
-            driver
-        }
-    }
+    #[allow(clippy::let_and_return, reason = "tutorial readability")]
+    // tag::driver_new[]
+    let driver = TypeDBDriver::new(
+        &uri,
+        Credentials::new(username, password),
+        DriverOptions::new(false, None).unwrap(),
+    ).await;
+    // end::driver_new[]
+    driver
 }
 // end::connection[]
 
@@ -362,7 +340,7 @@ async fn db_setup(driver: &TypeDBDriver, db_name: &str, db_reset: bool) -> Resul
 #[tokio::main]
 async fn main() {
     println!("Sample App");
-    let driver = driver_connect(&TYPEDB_EDITION, SERVER_ADDR, USERNAME, PASSWORD).await
+    let driver = driver_connect(SERVER_ADDR, USERNAME, PASSWORD).await
         .map_err(|err| {
             println!("{err}");
             process::exit(1);

--- a/home/modules/ROOT/pages/crash-course.adoc
+++ b/home/modules/ROOT/pages/crash-course.adoc
@@ -35,7 +35,7 @@ You can similarly delete a database with the command `database delete my_test_db
 Python::
 +
 --
-To connect to TypeDB, use the `core_driver` functionality from the `TypeDB` module. This will return `Driver` object that can be used to manage databases as shown in the script below.
+To connect to TypeDB, use the `driver` functionality from the `TypeDB` module. This will return `Driver` object that can be used to manage databases as shown in the script below.
 [,python]
 ----
 #{{
@@ -48,7 +48,7 @@ database = "test"
 
 #}}
 # Connect to TypeDB server
-driver = TypeDB.core_driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
+driver = TypeDB.driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
 
 # Create a database
 driver.databases.create(database)
@@ -76,7 +76,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 //}}
     // Connect to TypeDB server
-    let driver = TypeDBDriver::new_core(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
+    let driver = TypeDBDriver::new(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
 
     // Create a database
     driver.driver.databases().create(db_name).await?;
@@ -142,7 +142,7 @@ pw = "password"
 address = "127.0.0.1:1729"
 database = "my_test_db"
 
-driver = TypeDB.cloud_driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
+driver = TypeDB.driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
 
 # Some transaction type
 transaction_type = TransactionType.SCHEMA
@@ -179,7 +179,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let db_name = "test";
 
     // Connect to TypeDB server
-    let driver = TypeDBDriver::new_core(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
+    let driver = TypeDBDriver::new(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
 
     // Sample transaction type
     let transaction_type = TransactionType::Schema;
@@ -288,7 +288,7 @@ pw = "password"
 address = "127.0.0.1:1729"
 database = "my_test_db"
 
-driver = TypeDB.cloud_driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
+driver = TypeDB.driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
 
 #}}
 # Define entity and attribute types
@@ -330,7 +330,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let db_name = "test";
 
     // Connect to TypeDB server
-    let driver = TypeDBDriver::new_core(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
+    let driver = TypeDBDriver::new(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
 
 //}}
     // Define entity and attribute types
@@ -458,7 +458,7 @@ pw = "password"
 address = "127.0.0.1:1729"
 database = "my_test_db"
 
-driver = TypeDB.cloud_driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
+driver = TypeDB.driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
 
 #}}
 # Define a start-date attribute for the friendship relation type
@@ -506,7 +506,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let db_name = "test";
 
     // Connect to TypeDB server
-    let driver = TypeDBDriver::new_core(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
+    let driver = TypeDBDriver::new(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
 
 //}}
     // Define a start-date attribute for the friendship relation type
@@ -608,7 +608,7 @@ pw = "password"
 address = "127.0.0.1:1729"
 database = "my_test_db"
 
-driver = TypeDB.cloud_driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
+driver = TypeDB.driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
 
 #}}
 # Define subtypes of organizations
@@ -650,7 +650,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let db_name = "test";
 
     // Connect to TypeDB server
-    let driver = TypeDBDriver::new_core(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
+    let driver = TypeDBDriver::new(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
 
 //}}
     // Define subtypes of organizations
@@ -785,7 +785,7 @@ pw = "password"
 address = "127.0.0.1:1729"
 database = "my_test_db"
 
-driver = TypeDB.cloud_driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
+driver = TypeDB.driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
 
 #}}
 # Try to insert a user without username (will fail)
@@ -847,7 +847,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let db_name = "test";
 
     // Connect to TypeDB server
-    let driver = TypeDBDriver::new_core(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
+    let driver = TypeDBDriver::new(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
 
 //}}
     // Try to insert a user without username (will fail)
@@ -970,7 +970,7 @@ pw = "password"
 address = "127.0.0.1:1729"
 database = "my_test_db"
 
-driver = TypeDB.cloud_driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
+driver = TypeDB.driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
 
 #}}
 # Insert two new users and a friendship between them
@@ -1013,7 +1013,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let db_name = "test";
 
     // Connect to TypeDB server
-    let driver = TypeDBDriver::new_core(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
+    let driver = TypeDBDriver::new(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
 
 //}}
     // Insert two new users and a friendship between them
@@ -1132,7 +1132,7 @@ pw = "password"
 address = "127.0.0.1:1729"
 database = "my_test_db"
 
-driver = TypeDB.cloud_driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
+driver = TypeDB.driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
 
 #}}
 # A complex data pipeline
@@ -1175,7 +1175,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let db_name = "test";
 
     // Connect to TypeDB server
-    let driver = TypeDBDriver::new_core(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
+    let driver = TypeDBDriver::new(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
 
 //}}
     // A complex data pipeline
@@ -1266,7 +1266,7 @@ pw = "password"
 address = "127.0.0.1:1729"
 database = "my_test_db"
 
-driver = TypeDB.cloud_driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
+driver = TypeDB.driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
 
 #}}
 # Find a specific user, their friends, and count their friends
@@ -1302,7 +1302,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let db_name = "test";
 
     // Connect to TypeDB server
-    let driver = TypeDBDriver::new_core(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
+    let driver = TypeDBDriver::new(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
 
 //}}
     // Find a specific user, their friends, and count their friends
@@ -1398,7 +1398,7 @@ pw = "password"
 address = "127.0.0.1:1729"
 database = "my_test_db"
 
-driver = TypeDB.cloud_driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
+driver = TypeDB.driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
 
 #}}
 # Find users with more friends that Alex
@@ -1434,7 +1434,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let db_name = "test";
 
     // Connect to TypeDB server
-    let driver = TypeDBDriver::new_core(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
+    let driver = TypeDBDriver::new(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
 
 //}}
     // Find users with more friends that Alex
@@ -1518,7 +1518,7 @@ pw = "password"
 address = "127.0.0.1:1729"
 database = "my_test_db"
 
-driver = TypeDB.cloud_driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
+driver = TypeDB.driver(address=address, credentials=Credentials(user,pw), driver_options=DriverOptions())
 
 #}}
 # Find users with more friends that Alex
@@ -1554,7 +1554,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let db_name = "test";
 
     // Connect to TypeDB server
-    let driver = TypeDBDriver::new_core(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
+    let driver = TypeDBDriver::new(address, Credentials::new(user, pw), DriverOptions::new(false, None)?).await?;
 
 //}}
     // Find users with more friends that Alex

--- a/manual/modules/ROOT/pages/connect/CE.adoc
+++ b/manual/modules/ROOT/pages/connect/CE.adoc
@@ -40,7 +40,7 @@ Rust::
 [,rust,indent=0]
 ----
             let uri = format!("{}:{}", address, port);
-include::{page-version}@drivers::partial$tutorials/rust/src/main.rs[tags=driver_new_core]
+include::{page-version}@drivers::partial$tutorials/rust/src/main.rs[tags=driver_new]
 ----
 
 --
@@ -51,7 +51,7 @@ Python::
 [,python,indent=0]
 ----
         uri = f"{address}:{port}"
-include::{page-version}@drivers::partial$tutorials/python/sample.py[tags=driver_new_core]
+include::{page-version}@drivers::partial$tutorials/python/sample.py[tags=driver_new]
 ----
 --
 
@@ -61,7 +61,7 @@ Java::
 [,java,indent=0]
 ----
             uri = String.format("%s:%s", address, port)
-include::{page-version}@drivers::partial$tutorials/java/src/main/java/org/example2/Main.java[tags=driver_new_core]
+include::{page-version}@drivers::partial$tutorials/java/src/main/java/org/example2/Main.java[tags=driver_new]
 ----
 
 --

--- a/manual/modules/ROOT/pages/connect/CE.adoc
+++ b/manual/modules/ROOT/pages/connect/CE.adoc
@@ -39,7 +39,7 @@ Rust::
 --
 [,rust,indent=0]
 ----
-            let uri = format!("{}:{}", address, port);
+    let uri = format!("{}:{}", address, port);
 include::{page-version}@drivers::partial$tutorials/rust/src/main.rs[tags=driver_new]
 ----
 
@@ -50,7 +50,7 @@ Python::
 --
 [,python,indent=0]
 ----
-        uri = f"{address}:{port}"
+    uri = f"{address}:{port}"
 include::{page-version}@drivers::partial$tutorials/python/sample.py[tags=driver_new]
 ----
 --
@@ -60,7 +60,7 @@ Java::
 --
 [,java,indent=0]
 ----
-            uri = String.format("%s:%s", address, port)
+        uri = String.format("%s:%s", address, port)
 include::{page-version}@drivers::partial$tutorials/java/src/main/java/org/example2/Main.java[tags=driver_new]
 ----
 

--- a/manual/modules/ROOT/pages/connect/cloud.adoc
+++ b/manual/modules/ROOT/pages/connect/cloud.adoc
@@ -40,7 +40,7 @@ Rust::
 --
 [,rust,indent=0]
 ----
-            let uri = format!("{}:{}", address, port);
+    let uri = format!("{}:{}", address, port);
 include::{page-version}@drivers::partial$tutorials/rust/src/main.rs[tags=driver_new]
 ----
 
@@ -51,7 +51,7 @@ Python::
 --
 [,python,indent=0]
 ----
-        uri = f"{address}:{port}"
+    uri = f"{address}:{port}"
 include::{page-version}@drivers::partial$tutorials/python/sample.py[tags=driver_new]
 ----
 --
@@ -61,7 +61,7 @@ Java::
 --
 [,java,indent=0]
 ----
-            uri = String.format("%s:%s", address, port)
+        uri = String.format("%s:%s", address, port)
 include::{page-version}@drivers::partial$tutorials/java/src/main/java/org/example2/Main.java[tags=driver_new]
 ----
 

--- a/manual/modules/ROOT/pages/connect/cloud.adoc
+++ b/manual/modules/ROOT/pages/connect/cloud.adoc
@@ -41,7 +41,7 @@ Rust::
 [,rust,indent=0]
 ----
             let uri = format!("{}:{}", address, port);
-include::{page-version}@drivers::partial$tutorials/rust/src/main.rs[tags=driver_new_cloud]
+include::{page-version}@drivers::partial$tutorials/rust/src/main.rs[tags=driver_new]
 ----
 
 --
@@ -52,7 +52,7 @@ Python::
 [,python,indent=0]
 ----
         uri = f"{address}:{port}"
-include::{page-version}@drivers::partial$tutorials/python/sample.py[tags=driver_new_cloud]
+include::{page-version}@drivers::partial$tutorials/python/sample.py[tags=driver_new]
 ----
 --
 
@@ -62,7 +62,7 @@ Java::
 [,java,indent=0]
 ----
             uri = String.format("%s:%s", address, port)
-include::{page-version}@drivers::partial$tutorials/java/src/main/java/org/example2/Main.java[tags=driver_new_cloud]
+include::{page-version}@drivers::partial$tutorials/java/src/main/java/org/example2/Main.java[tags=driver_new]
 ----
 
 --

--- a/manual/modules/ROOT/pages/connect/enterprise.adoc
+++ b/manual/modules/ROOT/pages/connect/enterprise.adoc
@@ -41,7 +41,7 @@ Rust::
 --
 [,rust,indent=0]
 ----
-            let uri = format!("{}:{}", address, port);
+    let uri = format!("{}:{}", address, port);
 include::{page-version}@drivers::partial$tutorials/rust/src/main.rs[tags=driver_new]
 ----
 
@@ -52,7 +52,7 @@ Python::
 --
 [,python,indent=0]
 ----
-        uri = f"{address}:{port}"
+    uri = f"{address}:{port}"
 include::{page-version}@drivers::partial$tutorials/python/sample.py[tags=driver_new]
 ----
 --
@@ -62,7 +62,7 @@ Java::
 --
 [,java,indent=0]
 ----
-            uri = String.format("%s:%s", address, port)
+        uri = String.format("%s:%s", address, port)
 include::{page-version}@drivers::partial$tutorials/java/src/main/java/org/example2/Main.java[tags=driver_new]
 ----
 

--- a/manual/modules/ROOT/pages/connect/enterprise.adoc
+++ b/manual/modules/ROOT/pages/connect/enterprise.adoc
@@ -42,7 +42,7 @@ Rust::
 [,rust,indent=0]
 ----
             let uri = format!("{}:{}", address, port);
-include::{page-version}@drivers::partial$tutorials/rust/src/main.rs[tags=driver_new_cloud]
+include::{page-version}@drivers::partial$tutorials/rust/src/main.rs[tags=driver_new]
 ----
 
 --
@@ -53,7 +53,7 @@ Python::
 [,python,indent=0]
 ----
         uri = f"{address}:{port}"
-include::{page-version}@drivers::partial$tutorials/python/sample.py[tags=driver_new_cloud]
+include::{page-version}@drivers::partial$tutorials/python/sample.py[tags=driver_new]
 ----
 --
 
@@ -63,7 +63,7 @@ Java::
 [,java,indent=0]
 ----
             uri = String.format("%s:%s", address, port)
-include::{page-version}@drivers::partial$tutorials/java/src/main/java/org/example2/Main.java[tags=driver_new_cloud]
+include::{page-version}@drivers::partial$tutorials/java/src/main/java/org/example2/Main.java[tags=driver_new]
 ----
 
 --

--- a/manual/modules/ROOT/pages/tools/studio.adoc
+++ b/manual/modules/ROOT/pages/tools/studio.adoc
@@ -84,7 +84,7 @@ Enterprise::
 . Fill in the `Username` and `Password` fields with valid user credentials.
 . Turn on the `Enable TLS` option and leave the `CA Certificate` field empty. For self-hosted deployments, encryption parameters may vary.
 . Click `Connect`.
-// end::connect_cloud_studio[]
+// end::connect_enterprise_studio[]
 --
 
 Community Edition::


### PR DESCRIPTION
## What is the goal of this PR?

Update driver tutorials and pages to support TypeDB Driver 3.1, specifically its [unified constructor](https://github.com/typedb/typedb-driver/pull/741) for all editions of TypeDB.

## What are the changes implemented in this PR?
Remove mentions of `edition`s and substitute `new_core` / `new_cloud` / `core_driver` / `cloud_driver`with `new` / `driver`.