### PR TITLE
Fix "Running big queries" headers in http/index.adoc

### DIFF
--- a/drivers/modules/ROOT/pages/http/index.adoc
+++ b/drivers/modules/ROOT/pages/http/index.adoc
@@ -150,9 +150,9 @@ If this limit is hit:
 - Write queries will be fully executed, and their changes can be committed.
 The results will be returned with `206 Partial Content`.
 
-====
 
 For example:
+
 Sending a request to `/v1/transactions/:transaction-id/query` with the following body:
 
 [source,json]


### PR DESCRIPTION
## Goal
Fix rendering of the `http/index.adoc`'s "Running big queries" section.

## Implementation
Remove a wrongly placed separator in `http/index.adoc`.
