### PR TITLE
Update HTTP endpoint's API reference for the 3.2.0 release

### DIFF
--- a/drivers/modules/ROOT/pages/http/api-reference.adoc
+++ b/drivers/modules/ROOT/pages/http/api-reference.adoc
@@ -118,6 +118,75 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ----
 // end::token-example[]
 
+== Server information
+
+=== Version
+
+Get the server's distribution and version information.
+
+[cols="h,3a"]
+|===
+| Token required           | No
+| Method                   | `GET`
+| URL                      | `/v1/version`
+| Request body             | None
+| Request headers          | None
+|===
+
+*Responses:*
+
+include::{page-version}@drivers:resources:partial$http-api/responses/details.adoc[tags="200-version"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+curl --request GET \
+  --url http://0.0.0.0:8000/v1/version
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://0.0.0.0:8000/v1/version"
+
+response = requests.get(url)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get("http://0.0.0.0:8000/v1/version")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+*Example response:*
+
+[source]
+----
+{
+    "distribution": "TypeDB",
+    "version": "3.2.0"
+}
+----
+
 == Databases
 
 === Get databases
@@ -369,6 +438,134 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = reqwest::Client::new();
     let resp = client
         .delete("http://0.0.0.0:8000/v1/databases/DATABASE_NAME")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+=== Get database's schema
+
+Retrieve a full schema text as a valid TypeQL define query string. This includes function definitions.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `GET`
+| URL                      | `/v1/databases/DATABASE_NAME/schema`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@drivers:resources:partial$http-api/responses/details.adoc[tags="200-database-schema,400,401,404"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request GET \
+  --url http://0.0.0.0:8000/v1/databases/DATABASE_NAME/schema \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://0.0.0.0:8000/v1/databases/DATABASE_NAME/schema"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.get(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get("http://0.0.0.0:8000/v1/databases/DATABASE_NAME/schema")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+=== Get database's type schema
+
+Retrieve the types in the schema as a valid TypeQL define query string.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `GET`
+| URL                      | `/v1/databases/DATABASE_NAME/type-schema`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@drivers:resources:partial$http-api/responses/details.adoc[tags="200-database-schema,400,401,404"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request GET \
+  --url http://0.0.0.0:8000/v1/databases/DATABASE_NAME/type-schema \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://0.0.0.0:8000/v1/databases/DATABASE_NAME/type-schema"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.get(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get("http://0.0.0.0:8000/v1/databases/DATABASE_NAME/type-schema")
         .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
         .send().await;
     Ok(())

--- a/drivers/modules/resources/partials/http-api/responses/details.adoc
+++ b/drivers/modules/resources/partials/http-api/responses/details.adoc
@@ -14,6 +14,14 @@ include::{page-version}@drivers:resources:partial$http-api/responses/get-databas
 ====
 // end::200-databases[]
 
+// tag::200-version[]
+.200: OK
+[%collapsible]
+====
+include::{page-version}@drivers:resources:partial$http-api/responses/version.json.adoc[]
+====
+// end::200-version[]
+
 // tag::200-database[]
 .200: OK
 [%collapsible]
@@ -21,6 +29,14 @@ include::{page-version}@drivers:resources:partial$http-api/responses/get-databas
 include::{page-version}@drivers:resources:partial$http-api/responses/get-database.json.adoc[]
 ====
 // end::200-database[]
+
+// tag::200-database-schema[]
+.200: OK
+[%collapsible]
+====
+include::{page-version}@drivers:resources:partial$http-api/responses/get-database-schema.adoc[]
+====
+// end::200-database-schema[]
 
 // tag::200-users[]
 .200: OK

--- a/drivers/modules/resources/partials/http-api/responses/get-database-schema.adoc
+++ b/drivers/modules/resources/partials/http-api/responses/get-database-schema.adoc
@@ -1,0 +1,10 @@
+.If schema is defined
+[source,bash]
+----
+"define <statements>;"
+----
+.If schema is not defined
+[source,bash]
+----
+""
+----

--- a/drivers/modules/resources/partials/http-api/responses/query-concept-rows-example.json.adoc
+++ b/drivers/modules/resources/partials/http-api/responses/query-concept-rows-example.json.adoc
@@ -5,52 +5,54 @@
     "answerType": "conceptRows",
     "answers": [
         {
-            "entity": {
-                "kind": "entity",
-                "iid": "0x1e00000000000000000001",
-                "type": {
-                    "kind": "entityType",
-                    "label": "person"
-                }
-            },
-            "role-type": {
-                "kind": "roleType",
-                "label": "parentship:parent"
-            },
-            "relation": {
-                "kind": "relation",
-                "iid": "0x1f00000000000000000000",
-                "type": {
+            "data": {
+                "entity": {
+                    "kind": "entity",
+                    "iid": "0x1e00000000000000000001",
+                    "type": {
+                        "kind": "entityType",
+                        "label": "person"
+                    }
+                },
+                "role-type": {
+                    "kind": "roleType",
+                    "label": "parentship:parent"
+                },
+                "relation": {
+                    "kind": "relation",
+                    "iid": "0x1f00000000000000000000",
+                    "type": {
+                        "kind": "relationType",
+                        "label": "parentship"
+                    }
+                },
+                "relation-type": {
                     "kind": "relationType",
                     "label": "parentship"
-                }
-            },
-            "relation-type": {
-                "kind": "relationType",
-                "label": "parentship"
-            },
-            "attribute-type": {
-                "kind": "attributeType",
-                "label": "name",
-                "valueType": "string"
-            },
-            "entity-type": {
-                "kind": "entityType",
-                "label": "person"
-            },
-            "value": {
-                "kind": "value",
-                "value": "John",
-                "valueType": "string"
-            },
-            "attribute": {
-                "kind": "attribute",
-                "value": "John",
-                "valueType": "string",
-                "type": {
+                },
+                "attribute-type": {
                     "kind": "attributeType",
                     "label": "name",
                     "valueType": "string"
+                },
+                "entity-type": {
+                    "kind": "entityType",
+                    "label": "person"
+                },
+                "value": {
+                    "kind": "value",
+                    "value": "John",
+                    "valueType": "string"
+                },
+                "attribute": {
+                    "kind": "attribute",
+                    "value": "John",
+                    "valueType": "string",
+                    "type": {
+                        "kind": "attributeType",
+                        "label": "name",
+                        "valueType": "string"
+                    }
                 }
             }
         }

--- a/drivers/modules/resources/partials/http-api/responses/version.json.adoc
+++ b/drivers/modules/resources/partials/http-api/responses/version.json.adoc
@@ -1,0 +1,7 @@
+[source,json]
+----
+{
+    "distribution": string,
+    "version": string
+}
+----


### PR DESCRIPTION
## Goal
Add new schema retrieval and version API references and adjust outdated query response examples.

## Implementation
Add schema retrieval and version API references. Update query row examples to align with the updated server's response format.