### PR TITLE
Replace `long` with `integer` in actual docs

### DIFF
--- a/typeql/modules/ROOT/pages/keywords.adoc
+++ b/typeql/modules/ROOT/pages/keywords.adoc
@@ -220,7 +220,7 @@ Reduces the stream to a list of occurrences of a specified variable. See xref:{p
 `boolean`::
 Declares the values of an attribute type to be booleans. See xref:{page-version}@typeql::values/index.adoc[] for more information.
 
-`long`::
+`integer`::
 Declares the values of an attribute type to be 64-bit signed integers. See xref:{page-version}@typeql::values/index.adoc[] for more information.
 
 `double`::

--- a/typeql/modules/ROOT/pages/pipelines/with.adoc
+++ b/typeql/modules/ROOT/pages/pipelines/with.adoc
@@ -30,7 +30,7 @@ The usual function validation applies to the function declaration in a with clau
 +
 [,typeql]
 ----
-with fun friend_count($user: user) -> long:
+with fun friend_count($user: user) -> integer:
   match friendship($user, $x)
   return count;
 match
@@ -45,7 +45,7 @@ select $name;
 +
 [,typeql]
 ----
-with fun friend_count($user: user) -> long:
+with fun friend_count($user: user) -> integer:
   match friendship($user, $x)
   return count;
 with fun popular_users() -> { user }:


### PR DESCRIPTION
## Goal
Fix outdated references to the `long` value type by replacing it with `integer`.

## Implementation
Update only actual 3.x pages.