### PR TITLE
Add backup configuration and cluster update cloud API to the TypeDB Cloud API docs

### DIFF
--- a/manual/modules/ROOT/pages/cloud/api/reference.adoc
+++ b/manual/modules/ROOT/pages/cloud/api/reference.adoc
@@ -154,7 +154,7 @@ Python::
 ----
 import requests
 
-url = "https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/deploy[https://cloud.typedb.com/api/auth]"
+url = "https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/deploy"
 
 headers = {
     "Authorization": "Bearer {ACCESS-TOKEN}"
@@ -558,6 +558,119 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ]
 ----
 
+=== Update
+
+[cols="h,3a"]
+|===
+| Required access          | *write* to `team/TEAM_ID/spaces/SPACE_ID`
+| Method                   | `PATCH`
+| URL                      | `/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID`
+| Request body             | include::{page-version}@manual:resources:partial$cloud-api/cluster-update.json.adoc[]
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@manual:resources:partial$cloud-api/response-details.adoc[tags="200-single,400,401,403,404,500"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+curl --request PATCH \
+    --url https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID \
+    --header 'Authorization: Bearer {ACCESS-TOKEN}' \
+    --json '{"id":"new-id"}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+body = {
+    "id": "new-id"
+}
+
+response = requests.patch(url, headers=headers, json=body)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct ClusterUpdate {
+    id: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cluster_update = ClusterUpdate {
+        id: "api-cluster".into(),
+    };
+    let client = reqwest::Client::new();
+    let resp = client
+        .patch("https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .json(&cluster_deploy)
+        .send().await;
+    Ok(())
+}
+----
+
+Request Body::
++
+[source,json]
+----
+{
+    "id": "api-cluster",
+    "backupConfiguration": {
+        "frequency": "daily"
+    }
+}
+----
+====
+
+*Example response:*
+[source,json]
+----
+{
+    "id":"new-id",
+    "serverCount":1,
+    "storageSizeGB":10,
+    "isFree":true,
+    "status":"running",
+    "createdAt":1738256490070,
+    "teamID":"new-team",
+    "spaceID":"default",
+    "version":"3.1.0",
+    "provider":"gcp",
+    "region":"europe-west2",
+    "machineType":"c2d-highcpu-2",
+    "storageType":"standard-rwo",
+    "servers": [
+        {
+          "address": "abc123-0.cluster.typedb.com:80",
+          "status": "running"
+        }
+    ]
+}
+----
 
 === Suspend
 

--- a/manual/modules/ROOT/pages/cloud/api/reference.adoc
+++ b/manual/modules/ROOT/pages/cloud/api/reference.adoc
@@ -283,14 +283,14 @@ If set to `false`, there must be a valid payment method on the team.
 * `2.29.3`
 * `3.0.6`
 * `3.1.0`
-| `backupConfiguration` | Optional. If unset, it will take default values as below
+| `backupConfiguration` | Optional for free clusters. If unset, it will take default values as below
 | `backupConfiguration.frequency` a| Must be one of:
 
 * `disabled`
 * `hourly`
 * `daily`
 
-Must be `disabled` for free clusters. Defaults to `daily` for paid clusters if `backupConfiguration` is unset.
+Must be `disabled` for free clusters.
 | `backupConfiguration.retentionDays` | Must be either 7 or 30. Defaults to `7` if `backupConfiguration` is unset.
 |===
 

--- a/manual/modules/ROOT/pages/cloud/api/reference.adoc
+++ b/manual/modules/ROOT/pages/cloud/api/reference.adoc
@@ -364,7 +364,7 @@ Must be `disabled` for free clusters.
 |===
 | Provider | Storage Type
 | GCP      | standard-rwo
-| AWS      | gp2
+| AWS      | gp2-csi
 |===
 ====
 

--- a/manual/modules/ROOT/pages/cloud/api/reference.adoc
+++ b/manual/modules/ROOT/pages/cloud/api/reference.adoc
@@ -283,6 +283,15 @@ If set to `false`, there must be a valid payment method on the team.
 * `2.29.3`
 * `3.0.6`
 * `3.1.0`
+| `backupConfiguration` | Optional. If unset, it will take default values as below
+| `backupConfiguration.frequency` a| Must be one of:
+
+* `disabled`
+* `hourly`
+* `daily`
+
+Must be `disabled` for free clusters. Defaults to `daily` for paid clusters if `backupConfiguration` is unset.
+| `backupConfiguration.retentionDays` | Must be either 7 or 30. Defaults to `7` if `backupConfiguration` is unset.
 |===
 
 [#regionsmachinetypes]

--- a/manual/modules/ROOT/pages/cloud/api/reference.adoc
+++ b/manual/modules/ROOT/pages/cloud/api/reference.adoc
@@ -281,8 +281,7 @@ If set to `false`, there must be a valid payment method on the team.
 | `version` a| Currently available versions are:
 
 * `2.29.3`
-* `3.0.6`
-* `3.1.0`
+* `3.3.0`
 | `backupConfiguration` | Optional for free clusters. If unset, it will take default values as below
 | `backupConfiguration.frequency` a| Must be one of:
 

--- a/manual/modules/resources/partials/cloud-api/cluster-deploy.json.adoc
+++ b/manual/modules/resources/partials/cloud-api/cluster-deploy.json.adoc
@@ -3,12 +3,16 @@
 {
     "id": string,
     "serverCount": number,
-    "storageSizeGB":number,
+    "storageSizeGB": number,
     "provider": string,
     "region": string,
     "isFree": boolean,
     "machineType": string,
     "storageType": string,
-    "version":string
+    "version":string,
+    "backupConfiguration": {
+      "frequency": string,
+      "retentionDays": number
+    }
 }
 ----

--- a/manual/modules/resources/partials/cloud-api/cluster-deploy.json.adoc
+++ b/manual/modules/resources/partials/cloud-api/cluster-deploy.json.adoc
@@ -9,7 +9,7 @@
     "isFree": boolean,
     "machineType": string,
     "storageType": string,
-    "version":string,
+    "version": string,
     "backupConfiguration": {
       "frequency": string,
       "retentionDays": number

--- a/manual/modules/resources/partials/cloud-api/cluster-update.json.adoc
+++ b/manual/modules/resources/partials/cloud-api/cluster-update.json.adoc
@@ -1,0 +1,10 @@
+[source,json]
+----
+{
+    "id": string,
+    "backupConfiguration": {
+      "frequency": string,
+      "retentionDays": number
+    }
+}
+----


### PR DESCRIPTION
## Goal

Add information regarding backup configuration the new Update endpoint for TypeDB Cloud clusters to the TypeDB Cloud API docs.

## Implementation

We add information about the `backupConfiguration` object added in https://github.com/typedb/typedb-cloud/pull/1315 to the documentation for the TypeDB Cloud API. We also add documentation for the new endpoint for updating TypeDB Cloud clusters.