### PR TITLE
Update driver github links to point to master

### DIFF
--- a/drivers/modules/ROOT/pages/java/index.adoc
+++ b/drivers/modules/ROOT/pages/java/index.adoc
@@ -6,10 +6,9 @@
 
 The Java driver was developed by the TypeDB team to enable TypeDB support for Java software and developers.
 
-// TODO: Update github links to development when 3.0 is discarded
 [cols-2]
 --
-.link:https://github.com/typedb/typedb-driver/tree/3.0/java[GitHub,window=_blank]
+.link:https://github.com/typedb/typedb-driver/tree/master/java[GitHub,window=_blank]
 [.clickable]
 ****
 The GitHub repository with the driver's source code and release notes.

--- a/drivers/modules/ROOT/pages/python/index.adoc
+++ b/drivers/modules/ROOT/pages/python/index.adoc
@@ -6,10 +6,9 @@
 
 The Python driver was developed by the TypeDB team to enable TypeDB support for Python software and developers.
 
-// TODO: Update github links to development when 3.0 is discarded
 [cols-2]
 --
-.link:https://github.com/typedb/typedb-driver/tree/3.0/python[GitHub,window=_blank]
+.link:https://github.com/typedb/typedb-driver/tree/master/python[GitHub,window=_blank]
 [.clickable]
 ****
 The GitHub repository with the driver's source code and release notes.

--- a/drivers/modules/ROOT/pages/rust/index.adoc
+++ b/drivers/modules/ROOT/pages/rust/index.adoc
@@ -6,10 +6,9 @@
 
 The Rust driver was developed by the TypeDB team to enable TypeDB support for Rust software and developers.
 
-// TODO: Update github links to development when 3.0 is discarded
 [cols-2]
 --
-.link:https://github.com/typedb/typedb-driver/tree/3.0/rust[GitHub,window=_blank]
+.link:https://github.com/typedb/typedb-driver/tree/master/rust[GitHub,window=_blank]
 [.clickable]
 ****
 The GitHub repository with the driver's source code and release notes.


### PR DESCRIPTION
## Goal
Fix broken GitHub links of drivers that got broken after the main `typedb-driver` branch renaming.

## Implementation
