### PR TITLE
Cloud and TypeDB HTTP API references

### DIFF
--- a/new_reference/modules/ROOT/pages/cloud-http-api.adoc
+++ b/new_reference/modules/ROOT/pages/cloud-http-api.adoc
@@ -1,4 +1,940 @@
-= Cloud HTTP API
+= TypeDB Cloud API
+:page-toclevels: 2
 
-[placeholder]
-HTTP API reference for TypeDB Cloud. 
+== Authorization
+
+=== Token Exchange
+
+Exchange an API token's client ID and client secret for a short-lived access token to authenticate against the rest of the API.
+
+[cols="h,3a"]
+|===
+| Required access          | None
+| Method                   | `POST`
+| URL                      | `/api/auth`
+| Request body             | None
+| Request headers          | `Authorization: Basic CLIENT_ID:CLIENT_SECRET`
+|===
+
+*Responses:*
+
+.200: OK
+[%collapsible]
+====
+This response will contain only the access token
+
+Response format:
+
+[source]
+----
+string
+----
+====
+
+.400: Bad Request
+[%collapsible]
+====
+Possible causes:
+
+* Incorrectly formatted request (e.g. Authorization header missing a token)
+* Invalid client ID
+* Invalid client secret
+
+Response format:
+
+include::{page-version}@new_reference::partial$cloud-api/error-response.json.adoc[]
+====
+
+*Example request:*
+[tabs]
+====
+curl::
++
+[source,console]
+----
+curl --request POST \
+    --url https://cloud.typedb.com/api/auth \
+    --header 'Authorization: Basic {CLIENT_ID}:{CLIENT_SECRET}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "https://cloud.typedb.com/api/auth"
+
+headers = {
+    "Authorization": "Basic {CLIENT_ID}:{CLIENT_SECRET}"
+}
+
+response = requests.post(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("https://cloud.typedb.com/api/auth")
+        .header(reqwest::header::AUTHORIZATION, "Basic {CLIENT_ID}:{CLIENT_SECRET}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+*Example response:*
+[source]
+----
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+----
+
+[#accesslevels]
+=== API Token Access Levels
+
+When generating your API token, you will grant it a certain access level to a space of your choice.
+It will be able to perform the actions within that space as described below:
+
+[options="header"]
+|===
+| Project access level | Available cluster actions
+| Admin                | Destroy
+| Write                | Deploy, Suspend, Resume
+| Read                 | Get, List
+|===
+
+== Clusters
+
+=== Deploy
+
+[cols="h,3a"]
+|===
+| Required access          | *write* to `team/TEAM_ID/spaces/SPACE_ID`
+| Method                   | `POST`
+| URL                      | `/api/team/TEAM_ID/spaces/SPACE_ID/clusters/deploy`
+| Request body             | include::{page-version}@new_reference::partial$cloud-api/cluster-deploy.json.adoc[]
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$cloud-api/response-details.adoc[tags="200-single,400,401,403,404,409,500"]
+
+[NOTE]
+====
+Clusters deployed through the API will have a default user with the username `admin` and the password `password`.
+We recommend xref:{page-version}@manual::users/passwords.adoc[updating the default password] before using the cluster -
+which can also be done through the TypeDB Cloud UI by clicking the "Connect" button on the cluster's page.
+====
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+curl --request POST \
+    --url https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/deploy \
+    --header 'Authorization: Bearer {ACCESS-TOKEN}' \
+    --json '{"id":"api-cluster","serverCount":1,"storageSizeGB":10,"provider":"gcp","region":"europe-west2","isFree":true,"machineType":"c2d-highcpu-2","storageType":"standard-rwo","version":"3.1.0"}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/deploy"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+body = {
+    "id": "api-cluster",
+    "serverCount": 1,
+    "storageSizeGB": 10,
+    "provider": "gcp",
+    "region": "europe-west2",
+    "isFree": True,
+    "machineType": "c2d-highcpu-2",
+    "storageType": "standard-rwo",
+    "version": "3.1.0"
+}
+
+response = requests.post(url, headers=headers, json=body)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct ClusterDeploy {
+    id: String,
+    serverCount: i32,
+    storageSizeGB: i32,
+    provider: String,
+    region: String,
+    isFree: bool,
+    machineType: String,
+    storageType: String,
+    version: String
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cluster_deploy = ClusterDeploy {
+        id: "api-cluster".into(),
+        serverCount: 1,
+        storageSizeGB: 10,
+        provider: "gcp".into(),
+        region: "europe-west2".into(),
+        isFree: true,
+        machineType: "c2d-highcpu-2".into(),
+        storageType: "standard-rwo".into(),
+        version: "3.1.0".into()
+    };
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/deploy")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .json(&cluster_deploy)
+        .send().await;
+    Ok(())
+}
+----
+
+Request Body::
++
+[source,json]
+----
+{
+    "id":"api-cluster",
+    "serverCount":1,
+    "storageSizeGB":10,
+    "provider":"gcp",
+    "region":"europe-west2",
+    "isFree":true,
+    "machineType":"c2d-highcpu-2",
+    "storageType":"standard-rwo",
+    "version":"3.1.0"
+}
+----
+====
+
+*Example response:*
+[source,json]
+----
+{
+    "id":"api-cluster",
+    "serverCount":1,
+    "storageSizeGB":10,
+    "isFree":true,
+    "status":"starting",
+    "createdAt":1738256490070,
+    "teamID":"new-team",
+    "spaceID":"default",
+    "version":"3.1.0",
+    "provider":"gcp",
+    "region":"europe-west2",
+    "machineType":"c2d-highcpu-2",
+    "storageType":"standard-rwo",
+    "servers": [
+        {
+          "address": "abc123-0.cluster.typedb.com:80",
+          "status": "pending"
+        }
+    ]
+}
+----
+
+[options="header"]
+|===
+| Field | Allowed Values
+| `id` | The cluster's ID must be unique within its space,
+and consist only of lowercase alphanumeric characters, optionally separated by underscores and hyphens.
+| `serverCount` | An odd integer value between 1 and 9.
+TypeDB version 3.0 and onwards can currently only have one server.
+| `storageSizeGB` | An integer value between 10 and 1000.
+| `provider` | Must be either `gcp` or `aws`
+| `isFree` | If set to `true`, must use a valid free machine type, and have at most 1 server and 10GB of storage.
+You may only have one free cluster per team.
+
+If set to `false`, there must be a valid payment method on the team.
+| `region` | See <<regionsmachinetypes,below>>
+| `machineType` | See <<regionsmachinetypes,below>>
+| `storageType` | See <<storagetypes,below>>
+| `version` a| Currently available versions are:
+
+* `2.29.3`
+* `3.4.3`
+| `backupConfiguration` | Optional for free clusters. If unset, it will take default values as below
+| `backupConfiguration.frequency` a| Must be one of:
+
+* `disabled`
+* `hourly`
+* `daily`
+
+Must be `disabled` for free clusters.
+| `backupConfiguration.retentionDays` | Must be either 7 or 30. Defaults to `7` if `backupConfiguration` is unset.
+|===
+
+[#regionsmachinetypes]
+.GCP regions and machine types
+[%collapsible]
+====
+[options="header",cols=",,a"]
+|===
+| Machine Types    | Free Available | Regions
+| c2d-highcpu-2    | Yes            |
+* europe-west2
+* europe-west3
+* us-west4
+* us-east1
+| c2d-highcpu-4    | No             |
+* europe-west2
+* europe-west3
+* us-west4
+* us-east1
+| c2d-highcpu-8    | No             |
+* europe-west2
+* europe-west3
+* us-west4
+* us-east1
+| c2d-highcpu-16   | No             |
+* europe-west2
+* europe-west3
+* us-west4
+* us-east1
+|===
+====
+
+.AWS regions and machine types
+[%collapsible]
+====
+[options="header",cols=",,a"]
+|===
+| Machine Types    | Free Available | Regions
+| c7g.large        | Yes            |
+* eu-west-2
+| c7g.xlarge       | No             |
+* eu-west-2
+| c7g.2xlarge      | No             |
+* eu-west-2
+| c7g.4xlarge      | No             |
+* eu-west-2
+| c8g.large        | Yes            |
+* us-west-2
+* us-east-1
+* eu-central-1
+| c8g.xlarge       | No             |
+* us-west-2
+* us-east-1
+* eu-central-1
+| c8g.2xlarge      | No             |
+* us-west-2
+* us-east-1
+* eu-central-1
+| c8g.4xlarge      | No             |
+* us-west-2
+* us-east-1
+* eu-central-1
+|===
+====
+
+.Storage types
+[#storagetypes]
+[%collapsible]
+====
+[options="header"]
+|===
+| Provider | Storage Type
+| GCP      | standard-rwo
+| AWS      | gp2-csi
+|===
+====
+
+=== Get
+
+[cols="h,3a"]
+|===
+| Required access          | *read* to `team/TEAM_ID/spaces/SPACE_ID`
+| Method                   | `GET`
+| URL                      | `/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$cloud-api/response-details.adoc[tags="200-single,400,401,403,404,500"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+curl --request GET \
+    --url https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID \
+    --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.get(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get("https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+*Example response:*
+[source,json]
+----
+{
+    "id":"new-cluster",
+    "serverCount":1,
+    "storageSizeGB":10,
+    "isFree":true,
+    "status":"running",
+    "createdAt":1738256490070,
+    "teamID":"new-team",
+    "spaceID":"default",
+    "version":"3.1.0",
+    "provider":"gcp",
+    "region":"europe-west2",
+    "machineType":"c2d-highcpu-2",
+    "storageType":"standard-rwo",
+    "servers": [
+        {
+          "address": "abc123-0.cluster.typedb.com:80",
+          "status": "running"
+        }
+    ]
+}
+----
+
+=== List
+
+[cols="h,3a"]
+|===
+| Required access          | *read* to `team/TEAM_ID/spaces/SPACE_ID`
+| Method                   | `GET`
+| URL                      | `/api/team/TEAM_ID/spaces/SPACE_ID/clusters`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$cloud-api/response-details.adoc[tags="200-list,400,401,403,404,500"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+curl --request GET \
+    --url https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters \
+    --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.get(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get("https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+*Example response:*
+[source,json]
+----
+[
+    {
+        "id":"new-cluster",
+        "serverCount":1,
+        "storageSizeGB":10,
+        "isFree":true,
+        "status":"running",
+        "createdAt":1738256490070,
+        "teamID":"new-team",
+        "spaceID":"default",
+        "version":"3.1.0",
+        "provider":"gcp",
+        "region":"europe-west2",
+        "machineType":"c2d-highcpu-2",
+        "storageType":"standard-rwo",
+        "servers": [
+            {
+              "address": "abc123-0.cluster.typedb.com:80",
+              "status": "running"
+            }
+        ]
+    },
+    {
+        "id":"cluster-two",
+        "serverCount":1,
+        "storageSizeGB":10,
+        "isFree":false,
+        "status":"suspended",
+        "createdAt":1738256490090,
+        "teamID":"new-team",
+        "spaceID":"default",
+        "version":"3.1.0",
+        "provider":"aws",
+        "region":"eu-west-2",
+        "machineType":"c7g.large",
+        "storageType":"gp2",
+        "servers": []
+    }
+]
+----
+
+=== Update
+
+[cols="h,3a"]
+|===
+| Required access          | *write* to `team/TEAM_ID/spaces/SPACE_ID`
+| Method                   | `PATCH`
+| URL                      | `/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID`
+| Request body             | include::{page-version}@new_reference::partial$cloud-api/cluster-update.json.adoc[]
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+[NOTE]
+====
+* All fields are optional, but at least one field must be set.
+* For free clusters, updating any field other than `id` requires an active payment method.
+====
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$cloud-api/response-details.adoc[tags="200-single,400,401,403,404,500"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+curl --request PATCH \
+    --url https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID \
+    --header 'Authorization: Bearer {ACCESS-TOKEN}' \
+    --json '{"id":"new-id"}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+body = {
+    "id": "new-id"
+}
+
+response = requests.patch(url, headers=headers, json=body)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct ClusterUpdate {
+    id: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cluster_update = ClusterUpdate {
+        id: "api-cluster".into(),
+    };
+    let client = reqwest::Client::new();
+    let resp = client
+        .patch("https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .json(&cluster_deploy)
+        .send().await;
+    Ok(())
+}
+----
+
+Request Body::
++
+[source,json]
+----
+{
+    "id": "api-cluster",
+    "backupConfiguration": {
+        "frequency": "daily"
+    }
+}
+----
+====
+
+*Example response:*
+[source,json]
+----
+{
+    "id":"new-id",
+    "serverCount":1,
+    "storageSizeGB":10,
+    "isFree":true,
+    "status":"running",
+    "createdAt":1738256490070,
+    "teamID":"new-team",
+    "spaceID":"default",
+    "version":"3.1.0",
+    "provider":"gcp",
+    "region":"europe-west2",
+    "machineType":"c2d-highcpu-2",
+    "storageType":"standard-rwo",
+    "servers": [
+        {
+          "address": "abc123-0.cluster.typedb.com:80",
+          "status": "running"
+        }
+    ]
+}
+----
+
+=== Suspend
+
+[cols="h,3a"]
+|===
+| Required access          | *write* to `team/TEAM_ID/spaces/SPACE_ID`
+| Method                   | `POST`
+| URL                      | `/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID/suspend`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$cloud-api/response-details.adoc[tags="200-single,400,401,403,404,500"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+curl --request POST \
+    --url https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID/suspend \
+    --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID/suspend"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.post(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID/suspend")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+*Example response:*
+[source,json]
+----
+{
+    "id":"new-cluster",
+    "serverCount":1,
+    "storageSizeGB":10,
+    "isFree":true,
+    "status":"suspending",
+    "createdAt":1738256490070,
+    "teamID":"new-team",
+    "spaceID":"default",
+    "version":"3.1.0",
+    "provider":"gcp",
+    "region":"europe-west2",
+    "machineType":"c2d-highcpu-2",
+    "storageType":"standard-rwo",
+    "servers": [
+        {
+          "address": "abc123-0.cluster.typedb.com:80",
+          "status": "running"
+        }
+    ]
+}
+----
+
+=== Resume
+
+[cols="h,3a"]
+|===
+| Required access          | *write* to `team/TEAM_ID/spaces/SPACE_ID`
+| Method                   | `POST`
+| URL                      | `/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID/resume`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$cloud-api/response-details.adoc[tags="200-single,400,401,403,404,500"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+curl --request POST \
+    --url https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID/resume \
+    --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID/resume"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.post(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID/resume")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+*Example response:*
+[source,json]
+----
+{
+    "id":"new-cluster",
+    "serverCount":1,
+    "storageSizeGB":10,
+    "isFree":true,
+    "status":"resuming",
+    "createdAt":1738256490070,
+    "teamID":"new-team",
+    "spaceID":"default",
+    "version":"3.1.0",
+    "provider":"gcp",
+    "region":"europe-west2",
+    "machineType":"c2d-highcpu-2",
+    "storageType":"standard-rwo",
+    "servers": [
+        {
+          "address": "abc123-0.cluster.typedb.com:80",
+          "status": "pending"
+        }
+    ]
+}
+----
+
+=== Destroy
+
+[cols="h,3a"]
+|===
+| Required access          | *admin* to `team/TEAM_ID/spaces/SPACE_ID`
+| Method                   | `DELETE`
+| URL                      | `/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$cloud-api/response-details.adoc[tags="200-single,400,401,403,404,500"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+curl --request DELETE \
+    --url https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID \
+    --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.delete(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .delete("https://cloud.typedb.com/api/team/TEAM_ID/spaces/SPACE_ID/clusters/CLUSTER_ID")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+*Example response:*
+[source,json]
+----
+{
+    "id":"new-cluster",
+    "serverCount":1,
+    "storageSizeGB":10,
+    "isFree":true,
+    "status":"destroying",
+    "createdAt":1738256490070,
+    "teamID":"new-team",
+    "spaceID":"default",
+    "version":"3.1.0",
+    "provider":"gcp",
+    "region":"europe-west2",
+    "machineType":"c2d-highcpu-2",
+    "storageType":"standard-rwo",
+    "servers": [
+        {
+          "address": "abc123-0.cluster.typedb.com:80",
+          "status": "running"
+        }
+    ]
+}
+----

--- a/new_reference/modules/ROOT/pages/typedb-http-api.adoc
+++ b/new_reference/modules/ROOT/pages/typedb-http-api.adoc
@@ -946,17 +946,17 @@ Open a new transaction and receive a unique transaction id.
 |===
 | Field | Description
 | `transactionTimeoutMillis` |
-include::{page-version}@manual:resources:partial$options-descriptions/transaction.adoc[tag=transaction-timeout]
+include::{page-version}@new_reference::partial$options-descriptions/transaction.adoc[tag=transaction-timeout]
 
 Specified in milliseconds. **Default:**
-include::{page-version}@manual:resources:partial$options-descriptions/transaction.adoc[tag=transaction-timeout-default]
+include::{page-version}@new_reference::partial$options-descriptions/transaction.adoc[tag=transaction-timeout-default]
 
 
 | `schemaLockAcquireTimeoutMillis` |
-include::{page-version}@manual:resources:partial$options-descriptions/transaction.adoc[tag=schema-lock-acquire-timeout]
+include::{page-version}@new_reference::partial$options-descriptions/transaction.adoc[tag=schema-lock-acquire-timeout]
 
 Specified in milliseconds. **Default:**
-include::{page-version}@manual:resources:partial$options-descriptions/transaction.adoc[tag=schema-lock-acquire-timeout-default]
+include::{page-version}@new_reference::partial$options-descriptions/transaction.adoc[tag=schema-lock-acquire-timeout-default]
 |===
 // end::transaction-options[]
 
@@ -1251,18 +1251,18 @@ This endpoint allows running multiple sequential queries before committing.
 |===
 | Field | Description
 | `includeInstanceTypes` |
-include::{page-version}@manual:resources:partial$options-descriptions/query.adoc[tag=include-instance-types]
+include::{page-version}@new_reference::partial$options-descriptions/query.adoc[tag=include-instance-types]
 
 **Default:**
-include::{page-version}@manual:resources:partial$options-descriptions/query.adoc[tag=include-instance-types-default]
+include::{page-version}@new_reference::partial$options-descriptions/query.adoc[tag=include-instance-types-default]
 
 
 | `answerCountLimit` |
-include::{page-version}@manual:resources:partial$options-descriptions/query.adoc[tag=answer-count-limit]
+include::{page-version}@new_reference::partial$options-descriptions/query.adoc[tag=answer-count-limit]
 If there are more answers cut, a relevant `warning` will be provided in the response.
 
 **Default:**
-include::{page-version}@manual:resources:partial$options-descriptions/query.adoc[tag=answer-count-limit-default]
+include::{page-version}@new_reference::partial$options-descriptions/query.adoc[tag=answer-count-limit-default]
 
 |===
 // end::query-options[]

--- a/new_reference/modules/ROOT/pages/typedb-http-api.adoc
+++ b/new_reference/modules/ROOT/pages/typedb-http-api.adoc
@@ -1,4 +1,1541 @@
 = TypeDB HTTP API
+:page-toclevels: 2
 
-[placeholder]
-HTTP API reference for TypeDB server. 
+== Authorization
+
+[#_sign_in]
+=== Sign in
+
+Request an API token to authenticate against the rest of the API using user credentials.
+This token must be used as `ACCESS_TOKEN` for other protected methods.
+
+[cols="h,3a"]
+|===
+| Token required           | No
+| Method                   | `POST`
+| URL                      | `/v1/signin`
+| Request body             | include::{page-version}@new_reference::partial$http-api/requests/signin.json.adoc[]
+| Request headers          | None
+|===
+
+*Responses:*
+
+.200: OK
+[%collapsible]
+====
+include::{page-version}@new_reference::partial$http-api/responses/signin.json.adoc[]
+====
+
+.400: Bad Request
+[%collapsible]
+====
+Possible causes:
+
+* Incorrectly formatted request
+
+Response format:
+
+include::{page-version}@new_reference::partial$http-api/responses/error.json.adoc[]
+====
+
+.401: Unauthorized
+[%collapsible]
+====
+Possible causes:
+
+* Invalid credentials
+
+Response format:
+
+include::{page-version}@new_reference::partial$http-api/responses/error.json.adoc[]
+====
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+curl --request POST \
+  --url http://localhost:8000/v1/signin \
+  --json '{"username": "USERNAME", "password": "PASSWORD"}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/signin"
+body = {
+    "username": "USERNAME",
+    "password": "PASSWORD"
+}
+
+response = requests.post(url, json=body)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct Signin {
+    username: String,
+    password: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let signin = Signin {
+        username: "username".to_string(),
+        password: "password".to_string(),
+    };
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("http://localhost:8000/v1/signin")
+        .json(&signin)
+        .send().await;
+    Ok(())
+}
+----
+====
+
+*Example response:*
+
+// tag::token-example[]
+[source]
+----
+{
+    "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsImV4cCI6MTc0NDYzNTI5NSwiaWF0IjoxNzQ0NjIwODk1fQ.WEhmBTAXI_qZUlAB7zw52LDGJhnqfNTXS63QDSZlqds"
+}
+----
+// end::token-example[]
+
+== Server information
+
+=== Version
+
+Get the server's distribution and version information.
+
+[cols="h,3a"]
+|===
+| Token required           | No
+| Method                   | `GET`
+| URL                      | `/v1/version`
+| Request body             | None
+| Request headers          | None
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-version"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+curl --request GET \
+  --url http://localhost:8000/v1/version
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/version"
+
+response = requests.get(url)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get("http://localhost:8000/v1/version")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+*Example response:*
+
+[source]
+----
+{
+    "distribution": "TypeDB",
+    "version": "3.2.0"
+}
+----
+
+== Databases
+
+=== Get databases
+
+Get all databases present on the server.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `GET`
+| URL                      | `/v1/databases`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-databases,401"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request GET \
+  --url http://localhost:8000/v1/databases \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/databases"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.get(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get("http://localhost:8000/v1/databases")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+=== Get database
+
+Get a single database present on the server by name.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `GET`
+| URL                      | `/v1/databases/DATABASE_NAME`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-database,401,404"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request GET \
+  --url http://localhost:8000/v1/databases/DATABASE_NAME \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/databases/DATABASE_NAME"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.get(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get("http://localhost:8000/v1/databases/DATABASE_NAME")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+=== Create database
+
+Create a database on the server.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `POST`
+| URL                      | `/v1/databases/DATABASE_NAME`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-empty,400,401"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request POST \
+  --url http://localhost:8000/v1/databases/DATABASE_NAME \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/databases/DATABASE_NAME"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.post(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("http://localhost:8000/v1/databases/DATABASE_NAME")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+=== Delete database
+
+Delete a database from the server by name.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `DELETE`
+| URL                      | `/v1/databases/DATABASE_NAME`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-empty,400,401,404"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request DELETE \
+  --url http://localhost:8000/v1/databases/DATABASE_NAME \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/databases/DATABASE_NAME"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.delete(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .delete("http://localhost:8000/v1/databases/DATABASE_NAME")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+=== Get database's schema
+
+Retrieve a full schema text as a valid TypeQL define query string. This includes function definitions.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `GET`
+| URL                      | `/v1/databases/DATABASE_NAME/schema`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-database-schema,400,401,404"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request GET \
+  --url http://localhost:8000/v1/databases/DATABASE_NAME/schema \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/databases/DATABASE_NAME/schema"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.get(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get("http://localhost:8000/v1/databases/DATABASE_NAME/schema")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+=== Get database's type schema
+
+Retrieve the types in the schema as a valid TypeQL define query string.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `GET`
+| URL                      | `/v1/databases/DATABASE_NAME/type-schema`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-database-schema,400,401,404"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request GET \
+  --url http://localhost:8000/v1/databases/DATABASE_NAME/type-schema \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/databases/DATABASE_NAME/type-schema"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.get(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get("http://localhost:8000/v1/databases/DATABASE_NAME/type-schema")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+== Users
+
+=== Get users
+
+Get all users present on the server.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `GET`
+| URL                      | `/v1/users`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-users,401,403"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request GET \
+  --url http://localhost:8000/v1/users \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/users"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.get(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get("http://localhost:8000/v1/users")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+=== Get user
+
+Get a single user present on the server by name.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `GET`
+| URL                      | `/v1/users/USERNAME`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-user,401,403,404"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request GET \
+  --url http://localhost:8000/v1/users/USERNAME \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/users/USERNAME"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.get(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get("http://localhost:8000/v1/users/USERNAME")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+=== Create user
+
+Create a new user on the server.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `POST`
+| URL                      | `/v1/users/USERNAME`
+| Request body             | include::{page-version}@new_reference::partial$http-api/requests/post-users.json.adoc[]
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-empty,400,401,403"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request POST \
+  --url http://localhost:8000/v1/users/USERNAME \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}' \
+  --json '{"password": "PASSWORD"}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/users/USERNAME"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+body = {
+    "password": "PASSWORD"
+}
+
+response = requests.post(url, headers=headers, json=body)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct UserCredentials {
+    password: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let user_credentials = UserCredentials {
+        password: "password".to_string(),
+    };
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("http://localhost:8000/v1/users/USERNAME")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .json(&user_credentials)
+        .send().await;
+    Ok(())
+}
+----
+====
+
+=== Update user
+
+Update credentials for a user present on the server.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `PUT`
+| URL                      | `/v1/users/USERNAME`
+| Request body             | include::{page-version}@new_reference::partial$http-api/requests/put-users.json.adoc[]
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-empty,400,401,403,404"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request PUT \
+  --url http://localhost:8000/v1/users/USERNAME \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}' \
+  --json '{"password": "PASSWORD"}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/users/USERNAME"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+body = {
+    "password": "PASSWORD"
+}
+
+response = requests.put(url, headers=headers, json=body)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct UserCredentials {
+    password: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let user_credentials = UserCredentials {
+        password: "password".to_string(),
+    };
+    let client = reqwest::Client::new();
+    let resp = client
+        .put("http://localhost:8000/v1/users/USERNAME")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .json(&user_credentials)
+        .send().await;
+    Ok(())
+}
+----
+====
+
+=== Delete user
+
+Delete a user from the server by name.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `DELETE`
+| URL                      | `/v1/users/USERNAME`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-empty,400,401,403,404"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request DELETE \
+  --url http://localhost:8000/v1/users/USERNAME \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/users/USERNAME"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.delete(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .delete("http://localhost:8000/v1/users/USERNAME")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+== Transactions
+
+=== Open transaction
+
+Open a new transaction and receive a unique transaction id.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `POST`
+| URL                      | `/v1/transactions/open`
+| Request body             | include::{page-version}@new_reference::partial$http-api/requests/transactions-open.json.adoc[]
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+// tag::transaction-options[]
+*Transaction options:*
+
+[options="header"]
+[cols="h,3a"]
+|===
+| Field | Description
+| `transactionTimeoutMillis` |
+include::{page-version}@manual:resources:partial$options-descriptions/transaction.adoc[tag=transaction-timeout]
+
+Specified in milliseconds. **Default:**
+include::{page-version}@manual:resources:partial$options-descriptions/transaction.adoc[tag=transaction-timeout-default]
+
+
+| `schemaLockAcquireTimeoutMillis` |
+include::{page-version}@manual:resources:partial$options-descriptions/transaction.adoc[tag=schema-lock-acquire-timeout]
+
+Specified in milliseconds. **Default:**
+include::{page-version}@manual:resources:partial$options-descriptions/transaction.adoc[tag=schema-lock-acquire-timeout-default]
+|===
+// end::transaction-options[]
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-transaction,400,404"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request POST \
+  --url http://localhost:8000/v1/transactions/open \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}' \
+  --json '{"databaseName": "DATABASE_NAME", "transactionType": "schema"}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/transactions/open"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+body = {
+    "databaseName": "DATABASE_NAME",
+    "transactionType": "schema",
+}
+
+response = requests.post(url, headers=headers, json=body)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+use serde::Serialize;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TransactionType {
+    Read,
+    Write,
+    Schema,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Transaction {
+    database_name: String,
+    transaction_type: TransactionType,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let transaction = Transaction {
+        database_name: DATABASE_NAME,
+        transaction_type: TransactionType::Schema,
+    };
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("http://localhost:8000/v1/transactions/open")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .json(&transaction)
+        .send().await;
+    Ok(())
+}
+----
+====
+
+=== Close transaction
+
+Close a transaction without preserving its changes by transaction id.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `POST`
+| URL                      | `/v1/transactions/TRANSACTION_ID/close`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-empty,400,403,404"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request POST \
+  --url http://localhost:8000/v1/transactions/TRANSACTION_ID/close \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/transactions/TRANSACTION_ID/close"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.post(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("http://localhost:8000/v1/transactions/TRANSACTION_ID/close")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+=== Commit transaction
+
+Commit and close a transaction, preserving it changes on the server.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `POST`
+| URL                      | `/v1/transactions/TRANSACTION_ID/commit`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-empty,400,403,404"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request POST \
+  --url http://localhost:8000/v1/transactions/TRANSACTION_ID/commit \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/transactions/TRANSACTION_ID/commit"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.post(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("http://localhost:8000/v1/transactions/TRANSACTION_ID/commit")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+=== Rollback transaction
+
+Rolls back the uncommitted changes made via a transaction.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `POST`
+| URL                      | `/v1/transactions/TRANSACTION_ID/rollback`
+| Request body             | None
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-empty,400,403,404"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request POST \
+  --url http://localhost:8000/v1/transactions/TRANSACTION_ID/rollback \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/transactions/TRANSACTION_ID/rollback"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+
+response = requests.post(url, headers=headers)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("http://localhost:8000/v1/transactions/TRANSACTION_ID/rollback")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .send().await;
+    Ok(())
+}
+----
+====
+
+=== Query in transaction
+
+Run a query within an open transaction.
+This endpoint allows running multiple sequential queries before committing.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `POST`
+| URL                      | `/v1/transactions/TRANSACTION_ID/query`
+| Request body             | include::{page-version}@new_reference::partial$http-api/requests/transactions-query.json.adoc[]
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+// tag::query-options[]
+*Query options:*
+
+[options="header"]
+[cols="h,3a"]
+|===
+| Field | Description
+| `includeInstanceTypes` |
+include::{page-version}@manual:resources:partial$options-descriptions/query.adoc[tag=include-instance-types]
+
+**Default:**
+include::{page-version}@manual:resources:partial$options-descriptions/query.adoc[tag=include-instance-types-default]
+
+
+| `answerCountLimit` |
+include::{page-version}@manual:resources:partial$options-descriptions/query.adoc[tag=answer-count-limit]
+If there are more answers cut, a relevant `warning` will be provided in the response.
+
+**Default:**
+include::{page-version}@manual:resources:partial$options-descriptions/query.adoc[tag=answer-count-limit-default]
+
+|===
+// end::query-options[]
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-query,400,403,404,408"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request POST \
+  --url http://localhost:8000/v1/transactions/TRANSACTION_ID/query \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}' \
+  --json '{"query": "define entity person;"}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/transactions/TRANSACTION_ID/query"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+body = {
+    "query": "define entity person;"
+}
+
+response = requests.post(url, headers=headers, json=body)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+use serde::Serialize;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Query {
+    query: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let query = Query {
+        query: "define entity person;".to_string(),
+    };
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("http://localhost:8000/v1/transactions/TRANSACTION_ID/query")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .json(&query)
+        .send().await;
+    Ok(())
+}
+----
+====
+
+*Example responses for each concept:*
+
+.Concept rows
+[%collapsible]
+====
+.Request body
+[%collapsible]
+=====
+include::{page-version}@new_reference::partial$http-api/requests/transactions-query-concept-rows-example.json.adoc[]
+=====
+
+include::{page-version}@new_reference::partial$http-api/responses/query-concept-rows-example.json.adoc[]
+====
+
+.Concept documents
+[%collapsible]
+====
+.Request body
+[%collapsible]
+=====
+include::{page-version}@new_reference::partial$http-api/requests/transactions-query-concept-documents-example.json.adoc[]
+=====
+
+include::{page-version}@new_reference::partial$http-api/responses/query-concept-documents-example.json.adoc[]
+====
+
+== One-shot query
+
+Run a one-shot query.
+This endpoint executes a query within a temporary transaction that is opened and then either committed or closed exclusively for this query.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `POST`
+| URL                      | `/v1/query`
+| Request body             | include::{page-version}@new_reference::partial$http-api/requests/query.json.adoc[]
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+include::{page-version}@drivers::http/api-reference.adoc[tags="transaction-options,query-options"]
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="200-query,400,403,404,408"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request POST \
+  --url http://localhost:8000/v1/query \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}' \
+  --json '{"databaseName": "DATABASE_NAME", "transactionType": "schema", "query": "define entity person;"}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/query"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+body = {
+    "databaseName": "DATABASE_NAME",
+    "transactionType": "schema",
+    "query": "define entity person;"
+}
+
+response = requests.post(url, headers=headers, json=body)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+use serde::Serialize;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TransactionType {
+    Read,
+    Write,
+    Schema,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OneshotQuery {
+    database_name: String,
+    transaction_type: TransactionType,
+    query: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let query = OneshotQuery {
+        database_name: DATABASE_NAME,
+        transaction_type: TransactionType::Schema,
+        query: "define entity person;".to_string(),
+    };
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("http://localhost:8000/v1/query")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .json(&query)
+        .send().await;
+    Ok(())
+}
+----
+====
+
+*Example responses for each concept:*
+
+[#_query_example_responses_rows]
+.Concept rows
+[%collapsible]
+====
+.Request body
+[%collapsible]
+=====
+include::{page-version}@new_reference::partial$http-api/requests/query-concept-rows-example.json.adoc[]
+=====
+
+include::{page-version}@new_reference::partial$http-api/responses/query-concept-rows-example.json.adoc[]
+====
+
+[#_query_example_responses_documents]
+.Concept documents
+[%collapsible]
+====
+.Request body
+[%collapsible]
+=====
+include::{page-version}@new_reference::partial$http-api/requests/query-concept-documents-example.json.adoc[]
+=====
+
+include::{page-version}@new_reference::partial$http-api/responses/query-concept-documents-example.json.adoc[]
+====
+
+== Health check
+
+Check that the server is accessible and healthy.
+
+[cols="h,3a"]
+|===
+| Token required           | No
+| Method                   | `GET`
+| URL                      | `/health`
+| Request body             | None
+| Request headers          | None
+|===
+
+*Responses:*
+
+include::{page-version}@new_reference::partial$http-api/responses/details.adoc[tags="204-empty"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+curl --request GET \
+  --url http://localhost:8000/health
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/health"
+
+response = requests.get(url)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get("http://localhost:8000/health")
+        .send().await;
+    Ok(())
+}
+----
+====

--- a/new_reference/modules/ROOT/partials/cloud-api/cluster-deploy.json.adoc
+++ b/new_reference/modules/ROOT/partials/cloud-api/cluster-deploy.json.adoc
@@ -1,0 +1,18 @@
+[source,json]
+----
+{
+    "id": string,
+    "serverCount": number,
+    "storageSizeGB": number,
+    "provider": string,
+    "region": string,
+    "isFree": boolean,
+    "machineType": string,
+    "storageType": string,
+    "version": string,
+    "backupConfiguration": {
+      "frequency": string,
+      "retentionDays": number
+    }
+}
+----

--- a/new_reference/modules/ROOT/partials/cloud-api/cluster-response.json.adoc
+++ b/new_reference/modules/ROOT/partials/cloud-api/cluster-response.json.adoc
@@ -1,0 +1,55 @@
+// tag::single[]
+[source,json]
+----
+{
+    "id": string,
+    "serverCount": number,
+    "storageSizeGB": number,
+    "isFree": boolean,
+    "status": string,
+    "createdAt": number,
+    "organization": string,
+    "project": string,
+    "version": string,
+    "provider": string,
+    "region": string,
+    "machineType": string,
+    "storageType": string,
+    "servers": [
+        {
+          "address": string,
+          "status": string
+        }
+    ]
+}
+----
+// end::single[]
+// tag::list[]
+[source,json]
+----
+[
+    {
+        "id": string,
+        "serverCount": number,
+        "storageSizeGB": number,
+        "isFree": boolean,
+        "status": string,
+        "createdAt": number,
+        "organization": string,
+        "project": string,
+        "version": string,
+        "provider": string,
+        "region": string,
+        "machineType": string,
+        "storageType": string,
+        "servers": [
+            {
+              "address": string,
+              "status": string
+            }
+        ]
+    }
+]
+----
+// end::list[]
+

--- a/new_reference/modules/ROOT/partials/cloud-api/cluster-update.json.adoc
+++ b/new_reference/modules/ROOT/partials/cloud-api/cluster-update.json.adoc
@@ -1,0 +1,12 @@
+[source,json]
+----
+{
+    "id": string,
+    "storageSizeGB": number,
+    "machineType": string,
+    "backupConfiguration": {
+      "frequency": string,
+      "retentionDays": number
+    }
+}
+----

--- a/new_reference/modules/ROOT/partials/cloud-api/error-response.json.adoc
+++ b/new_reference/modules/ROOT/partials/cloud-api/error-response.json.adoc
@@ -1,0 +1,7 @@
+[source,json]
+----
+{
+    "code": string,
+    "message": string
+}
+----

--- a/new_reference/modules/ROOT/partials/cloud-api/response-details.adoc
+++ b/new_reference/modules/ROOT/partials/cloud-api/response-details.adoc
@@ -1,0 +1,106 @@
+// tag::200-single[]
+.200: OK
+[%collapsible]
+====
+
+Response format:
+
+include::{page-version}@manual:resources:partial$cloud-api/cluster-response.json.adoc[tags=single]
+====
+// end::200-single[]
+
+// tag::200-list[]
+.200: OK
+[%collapsible]
+====
+
+Response format:
+
+include::{page-version}@manual:resources:partial$cloud-api/cluster-response.json.adoc[tags=list]
+====
+// end::200-list[]
+
+// tag::400[]
+.400: Bad Request
+[%collapsible]
+====
+Possible causes:
+
+* Incorrectly formatted request (e.g. Authorization header missing a token)
+
+Response format:
+
+include::{page-version}@manual:resources:partial$cloud-api/error-response.json.adoc[]
+====
+// end::400[]
+
+// tag::401[]
+.401: Unauthorized
+[%collapsible]
+====
+Possible causes:
+
+* Invalid token
+* Expired token
+
+Response format:
+
+include::{page-version}@manual:resources:partial$cloud-api/error-response.json.adoc[]
+====
+// end::401[]
+
+// tag::403[]
+.403: Forbidden
+[%collapsible]
+====
+Possible causes:
+
+* The supplied access token lacks the required access level for the request
+
+Response format:
+
+include::{page-version}@manual:resources:partial$cloud-api/error-response.json.adoc[]
+====
+// end::403[]
+
+// tag::404[]
+.404: Not Found
+[%collapsible]
+====
+Possible causes:
+
+* One or more resources referenced in the request could not be found
+
+Response format:
+
+include::{page-version}@manual:resources:partial$cloud-api/error-response.json.adoc[]
+====
+// end::404[]
+
+// tag::409[]
+.409: Conflict
+[%collapsible]
+====
+Possible causes:
+
+* Attempting to create a resource with an already-in-use ID
+
+Response format:
+
+include::{page-version}@manual:resources:partial$cloud-api/error-response.json.adoc[]
+====
+// end::409[]
+
+// tag::500[]
+.500: Internal Server Error
+[%collapsible]
+====
+Possible causes:
+
+* An unexpected error prevented TypeDB Cloud from serving your request
+
+Response format:
+
+include::{page-version}@manual:resources:partial$cloud-api/error-response.json.adoc[]
+====
+// end::500[]

--- a/new_reference/modules/ROOT/partials/http-api/requests/post-users.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/requests/post-users.json.adoc
@@ -1,0 +1,6 @@
+[source,json]
+----
+{
+    "password": string
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/requests/put-users.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/requests/put-users.json.adoc
@@ -1,0 +1,6 @@
+[source,json]
+----
+{
+    "password": string
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/requests/query-concept-documents-example.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/requests/query-concept-documents-example.json.adoc
@@ -1,0 +1,8 @@
+[source,json]
+----
+{
+    "databaseName": "test",
+    "transactionType": "read",
+    "query": "match $entity isa $entity-type, has $attribute-type $attribute; $relation isa $relation-type, links ($entity); $relation-type relates $role-type; fetch { 'entity type': $entity-type, 'relation type': $relation-type, 'entity attributes': { $entity.* }, 'sub query': [ match let $value = $attribute; fetch { 'value': $value }; ] };"
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/requests/query-concept-rows-example.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/requests/query-concept-rows-example.json.adoc
@@ -1,0 +1,11 @@
+[source,json]
+----
+{
+    "databaseName": "test",
+    "transactionType": "read",
+    "query": "match $entity isa $entity-type, has $attribute-type $attribute; $relation isa $relation-type, links ($entity); $relation-type relates $role-type; let $value = $attribute;",
+    "queryOptions": {
+        "includeInstanceTypes": true
+    }
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/requests/query.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/requests/query.json.adoc
@@ -1,0 +1,17 @@
+[source,json]
+----
+{
+    "query": string,
+    "commit": boolean,                             // optional
+    "databaseName": string,
+    "transactionType": "read" | "write" | "schema",
+    "transactionOptions": {                        // optional
+        "schemaLockAcquireTimeoutMillis": integer, // optional
+        "transactionTimeoutMillis": integer        // optional
+    },
+    "queryOptions": {                              // optional
+        "includeInstanceTypes": boolean,           // optional
+        "answerCountLimit": integer                // optional
+    }
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/requests/signin.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/requests/signin.json.adoc
@@ -1,0 +1,7 @@
+[source,json]
+----
+{
+    "username": string,
+    "password": string
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/requests/transactions-open.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/requests/transactions-open.json.adoc
@@ -1,0 +1,11 @@
+[source,json]
+----
+{
+    "databaseName": string,
+    "transactionType": "read" | "write" | "schema",
+    "transactionOptions": {                        // optional
+        "schemaLockAcquireTimeoutMillis": integer, // optional
+        "transactionTimeoutMillis": integer        // optional
+    }
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/requests/transactions-query-concept-documents-example.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/requests/transactions-query-concept-documents-example.json.adoc
@@ -1,0 +1,6 @@
+[source,json]
+----
+{
+    "query": "match $entity isa $entity-type, has $attribute-type $attribute; $relation isa $relation-type, links ($entity); $relation-type relates $role-type; fetch { 'entity type': $entity-type, 'relation type': $relation-type, 'entity attributes': { $entity.* }, 'sub query': [ match let $value = $attribute; fetch { 'value': $value }; ] };"
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/requests/transactions-query-concept-rows-example.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/requests/transactions-query-concept-rows-example.json.adoc
@@ -1,0 +1,9 @@
+[source,json]
+----
+{
+    "query": "match $entity isa $entity-type, has $attribute-type $attribute; $relation isa $relation-type, links ($entity); $relation-type relates $role-type; let $value = $attribute;",
+    "queryOptions": {
+        "includeInstanceTypes": true
+    }
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/requests/transactions-query.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/requests/transactions-query.json.adoc
@@ -1,0 +1,10 @@
+[source,json]
+----
+{
+    "query": string,
+    "queryOptions": {                    // optional
+        "includeInstanceTypes": boolean, // optional
+        "answerCountLimit": integer      // optional
+    }
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/responses/details.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/responses/details.adoc
@@ -1,0 +1,164 @@
+// tag::200-empty[]
+.200: OK
+[%collapsible]
+====
+No body.
+====
+// end::200-empty[]
+
+// tag::200-databases[]
+.200: OK
+[%collapsible]
+====
+include::{page-version}@drivers:resources:partial$http-api/responses/get-databases.json.adoc[]
+====
+// end::200-databases[]
+
+// tag::200-version[]
+.200: OK
+[%collapsible]
+====
+include::{page-version}@drivers:resources:partial$http-api/responses/version.json.adoc[]
+====
+// end::200-version[]
+
+// tag::200-database[]
+.200: OK
+[%collapsible]
+====
+include::{page-version}@drivers:resources:partial$http-api/responses/get-database.json.adoc[]
+====
+// end::200-database[]
+
+// tag::200-database-schema[]
+.200: OK
+[%collapsible]
+====
+include::{page-version}@drivers:resources:partial$http-api/responses/get-database-schema.adoc[]
+====
+// end::200-database-schema[]
+
+// tag::200-users[]
+.200: OK
+[%collapsible]
+====
+include::{page-version}@drivers:resources:partial$http-api/responses/get-users.json.adoc[]
+====
+// end::200-users[]
+
+// tag::200-user[]
+.200: OK
+[%collapsible]
+====
+include::{page-version}@drivers:resources:partial$http-api/responses/get-user.json.adoc[]
+====
+// end::200-user[]
+
+// tag::200-transaction[]
+.200: OK
+[%collapsible]
+====
+include::{page-version}@drivers:resources:partial$http-api/responses/transaction.json.adoc[]
+====
+// end::200-transaction[]
+
+// tag::200-query[]
+.200: OK
+[%collapsible]
+====
+include::{page-version}@drivers:resources:partial$http-api/responses/query.json.adoc[]
+====
+// end::200-query[]
+
+// tag::204-empty[]
+.204: No Content
+[%collapsible]
+====
+No body.
+====
+// end::204-empty[]
+
+// tag::400[]
+.400: Bad Request
+[%collapsible]
+====
+Possible causes:
+
+* Incorrectly formatted request (e.g. Authorization header missing a token)
+
+Response format:
+
+include::{page-version}@drivers:resources:partial$http-api/responses/error.json.adoc[]
+====
+// end::400[]
+
+// tag::401[]
+.401: Unauthorized
+[%collapsible]
+====
+Possible causes:
+
+* Invalid token
+* Expired token
+
+Response format:
+
+include::{page-version}@drivers:resources:partial$http-api/responses/error.json.adoc[]
+====
+// end::401[]
+
+// tag::403[]
+.403: Forbidden
+[%collapsible]
+====
+Possible causes:
+
+* The supplied access token lacks the required access level for the request
+
+Response format:
+
+include::{page-version}@drivers:resources:partial$http-api/responses/error.json.adoc[]
+====
+// end::403[]
+
+// tag::404[]
+.404: Not Found
+[%collapsible]
+====
+Possible causes:
+
+* One or more resources referenced in the request could not be found
+
+Response format:
+
+include::{page-version}@drivers:resources:partial$http-api/responses/error.json.adoc[]
+====
+// end::404[]
+
+// tag::408[]
+.408: Request Timeout
+[%collapsible]
+====
+Possible causes:
+
+* Request finished with an error due to an execution timeout
+
+Response format:
+
+include::{page-version}@drivers:resources:partial$http-api/responses/error.json.adoc[]
+====
+// end::408[]
+
+// tag::500[]
+.500: Internal Server Error
+[%collapsible]
+====
+Possible causes:
+
+* An unexpected error prevented TypeDB Cloud from serving your request
+
+Response format:
+
+include::{page-version}@drivers:resources:partial$http-api/responses/error.json.adoc[]
+====
+// end::500[]

--- a/new_reference/modules/ROOT/partials/http-api/responses/error.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/responses/error.json.adoc
@@ -1,0 +1,7 @@
+[source,json]
+----
+{
+    "code": string,
+    "message": string
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/responses/get-database-schema.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/responses/get-database-schema.adoc
@@ -1,0 +1,10 @@
+.If schema is defined
+[source,bash]
+----
+"define <statements>;"
+----
+.If schema is not defined
+[source,bash]
+----
+""
+----

--- a/new_reference/modules/ROOT/partials/http-api/responses/get-database.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/responses/get-database.json.adoc
@@ -1,0 +1,6 @@
+[source,json]
+----
+{
+    "name": string
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/responses/get-databases.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/responses/get-databases.json.adoc
@@ -1,0 +1,10 @@
+[source,json]
+----
+{
+    "databases": [
+        {
+            "name": string
+        }
+    ]
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/responses/get-user.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/responses/get-user.json.adoc
@@ -1,0 +1,6 @@
+[source,json]
+----
+{
+    "username": string
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/responses/get-users.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/responses/get-users.json.adoc
@@ -1,0 +1,10 @@
+[source,json]
+----
+{
+    "users": [
+        {
+            "username": string
+        }
+    ]
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/responses/query-concept-documents-example.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/responses/query-concept-documents-example.json.adoc
@@ -1,0 +1,28 @@
+[source,json]
+----
+{
+    "queryType": "read",
+    "answerType": "conceptDocuments",
+    "answers": [
+        {
+            "entity attributes": {
+                "name": "John"
+            },
+            "sub query": [
+                {
+                    "value": "John"
+                }
+            ],
+            "entity type": {
+                "kind": "entity",
+                "label": "person"
+            },
+            "relation type": {
+                "kind": "relation",
+                "label": "parentship"
+            }
+        }
+    ],
+    "warning": null
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/responses/query-concept-rows-example.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/responses/query-concept-rows-example.json.adoc
@@ -1,0 +1,62 @@
+[source,json]
+----
+{
+    "queryType": "read",
+    "answerType": "conceptRows",
+    "answers": [
+        {
+            "data": {
+                "entity": {
+                    "kind": "entity",
+                    "iid": "0x1e00000000000000000001",
+                    "type": {
+                        "kind": "entityType",
+                        "label": "person"
+                    }
+                },
+                "role-type": {
+                    "kind": "roleType",
+                    "label": "parentship:parent"
+                },
+                "relation": {
+                    "kind": "relation",
+                    "iid": "0x1f00000000000000000000",
+                    "type": {
+                        "kind": "relationType",
+                        "label": "parentship"
+                    }
+                },
+                "relation-type": {
+                    "kind": "relationType",
+                    "label": "parentship"
+                },
+                "attribute-type": {
+                    "kind": "attributeType",
+                    "label": "name",
+                    "valueType": "string"
+                },
+                "entity-type": {
+                    "kind": "entityType",
+                    "label": "person"
+                },
+                "value": {
+                    "kind": "value",
+                    "value": "John",
+                    "valueType": "string"
+                },
+                "attribute": {
+                    "kind": "attribute",
+                    "value": "John",
+                    "valueType": "string",
+                    "type": {
+                        "kind": "attributeType",
+                        "label": "name",
+                        "valueType": "string"
+                    }
+                }
+            }
+        }
+    ],
+    "warning": null
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/responses/query.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/responses/query.json.adoc
@@ -1,0 +1,9 @@
+[source,json]
+----
+{
+  "queryType": "read" | "write" | "schema",
+  "answerType": "ok" | "conceptRows" | "conceptDocuments",
+  "answers": [ ... ], // optional
+  "warning": string   // optional
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/responses/signin.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/responses/signin.json.adoc
@@ -1,0 +1,6 @@
+[source,json]
+----
+{
+    "token": string
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/responses/transaction.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/responses/transaction.json.adoc
@@ -1,0 +1,6 @@
+[source,json]
+----
+{
+  "transactionId": string
+}
+----

--- a/new_reference/modules/ROOT/partials/http-api/responses/version.json.adoc
+++ b/new_reference/modules/ROOT/partials/http-api/responses/version.json.adoc
@@ -1,0 +1,7 @@
+[source,json]
+----
+{
+    "distribution": string,
+    "version": string
+}
+----


### PR DESCRIPTION
## Goal

Move the Cloud and TypeDB HTTP API reference docs into the new reference section

## Implementation

- Move the pages
- Move the partials
  - Important note: this includes both the `cloud-api` partials and the `options-descriptions` partials - which are currently also used outside of the cloud API. We should be careful not to duplicate the options descriptions partials during the docathon process.
- Update the partials references