### PR TITLE
Test TypeQL reference

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -45,7 +45,7 @@ build:
         
         # TODO: test node and java
         
-        TEST_DIRS=("home" "core-concepts", "reference/modules/ROOT/pages/typeql")
+        TEST_DIRS=("home" "core-concepts" "reference/modules/ROOT/pages/typeql")
         TEST_LANGS=("typeql" "python" "rust")
         
         FAILED=false

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -45,7 +45,7 @@ build:
         
         # TODO: test node and java
         
-        TEST_DIRS=("home" "core-concepts")
+        TEST_DIRS=("home" "core-concepts", "reference/modules/ROOT/pages/typeql")
         TEST_LANGS=("typeql" "python" "rust")
         
         FAILED=false

--- a/reference/modules/ROOT/examples/tql/conjunction.tql
+++ b/reference/modules/ROOT/examples/tql/conjunction.tql
@@ -4,6 +4,21 @@ define
   attribute name, value string;
 # pipeline::schema::end
 
+# tag::patterns-schema[]
+define
+    attribute email, value string;
+    attribute phone, value string;
+    attribute username, value string;
+    relation friendship, relates friend @card(0..2);
+    relation marriage, relates spouse @card(0..2);
+    relation policy, relates covered @card(0..);
+    entity user,
+        owns username, owns email, owns phone,
+        plays friendship:friend;
+    entity person, plays marriage:spouse, plays policy:covered;
+
+# end::patterns-schema[]
+
 # pipeline::read::start
 match
 # tag::conjunction-example[]

--- a/reference/modules/ROOT/examples/tql/read_statements_functions.tql
+++ b/reference/modules/ROOT/examples/tql/read_statements_functions.tql
@@ -4,6 +4,7 @@ with fun karma_with_squared_value($user: user) -> karma, double:
     $user has karma $karma;
     let $karma-squared = $karma * $karma;
   return first $karma, $karma-squared;
+
 # tag::with-fun-match[]
 match
   $user isa user, has username $name;

--- a/reference/modules/ROOT/examples/tql/read_statements_functions.tql
+++ b/reference/modules/ROOT/examples/tql/read_statements_functions.tql
@@ -1,38 +1,38 @@
-// tag::with-fun[]
+# tag::with-fun[]
 with fun karma_with_squared_value($user: user) -> karma, double:
   match
     $user has karma $karma;
     let $karma-squared = $karma * $karma;
   return first $karma, $karma-squared;
-// tag::with-fun-match[]
+# tag::with-fun-match[]
 match
   $user isa user, has username $name;
   let $karma, $karma-squared = karma_with_squared_value($user);
 select $name, $karma-squared;
-// end::with-fun-match[]
-// end::with-fun[]
+# end::with-fun-match[]
+# end::with-fun[]
 
 
 
-// tag::fun-stream-scalar-return-type[]
+# tag::fun-stream-scalar-return-type[]
 match
   $user isa user;
   let $phone in user_phones($user);
-// end::fun-stream-scalar-return-type[]
+# end::fun-stream-scalar-return-type[]
 
 
-// tag::match-users[]
+# tag::match-users[]
 match
   $user isa user;
-// end::match-users[]
+# end::match-users[]
 
-// tag::fun-stream-tuple-return-type[]
+# tag::fun-stream-tuple-return-type[]
 match
   let $user, $phone, $phone-value in all_users_and_phones();
-// end::fun-stream-tuple-return-type[]
+# end::fun-stream-tuple-return-type[]
 
 
-// tag::fun-single-scalar-return-value[]
+# tag::fun-single-scalar-return-value[]
 match
   let $answer = add(2016, 9);
-// end::fun-single-scalar-return-value[]
+# end::fun-single-scalar-return-value[]

--- a/reference/modules/ROOT/examples/tql/redefine_statements_functions.tql
+++ b/reference/modules/ROOT/examples/tql/redefine_statements_functions.tql
@@ -1,10 +1,10 @@
-// tag::redefine-keyword[]
+# tag::redefine-keyword[]
 redefine
-// end::redefine-keyword[]
+# end::redefine-keyword[]
 
-// tag::with-fun-redefined[]
+# tag::with-fun-redefined[]
   fun karma_with_squared_value($karma: karma) -> double:
     match
       let $karma-squared = $karma * $karma;
     return first $karma-squared;
-// end::with-fun-redefined[]
+# end::with-fun-redefined[]

--- a/reference/modules/ROOT/examples/tql/schema_statements_functions.tql
+++ b/reference/modules/ROOT/examples/tql/schema_statements_functions.tql
@@ -65,6 +65,7 @@ define
 # tag::extended-attributes[]
 attribute bio value string;
 attribute profile-picture value string;
+attribute email value string @regex("^.*@.*\.com");
 user owns bio, owns profile-picture;
 # end::extended-attributes[]
 

--- a/reference/modules/ROOT/examples/tql/schema_statements_functions.tql
+++ b/reference/modules/ROOT/examples/tql/schema_statements_functions.tql
@@ -2,18 +2,18 @@
 define
 // end::define-keyword[]
 // tag::entities[]
+// tag::user-supertypes[]
   entity content owns id;
   entity page sub content,
     owns page-id,
     owns name;
   entity profile sub page,
     owns username;
+// end::user-supertypes[]
 // tag::entity-user[]
   entity user sub profile,
     owns phone,
-    owns karma,
-    plays parentship:parent,
-    plays parentship:child;
+    owns karma;
 // end::entity-user[]
 
 // end::entities[]
@@ -23,8 +23,6 @@ define
   user sub profile;
   user owns phone;
   user owns karma;
-  user plays parentship:parent;
-  user plays parentship:child;
 // end::entity-user-breakdown[]
 
 // tag::entities-annotations[]

--- a/reference/modules/ROOT/examples/tql/schema_statements_functions.tql
+++ b/reference/modules/ROOT/examples/tql/schema_statements_functions.tql
@@ -1,137 +1,135 @@
-// tag::define-keyword[]
+# tag::define-keyword[]
 define
-// end::define-keyword[]
-// tag::entities[]
-// tag::user-supertypes[]
+# end::define-keyword[]
+# tag::entities[]
   entity content owns id;
   entity page sub content,
     owns page-id,
     owns name;
   entity profile sub page,
     owns username;
-// end::user-supertypes[]
-// tag::entity-user[]
+# tag::entity-user[]
   entity user sub profile,
     owns phone,
     owns karma;
-// end::entity-user[]
+# end::entity-user[]
 
-// end::entities[]
+# end::entities[]
 
-// tag::entity-user-breakdown[]
+# tag::entity-user-breakdown[]
   entity user;
   user sub profile;
   user owns phone;
   user owns karma;
-// end::entity-user-breakdown[]
+# end::entity-user-breakdown[]
 
-// tag::entities-annotations[]
+# tag::entities-annotations[]
   content @abstract, owns id @key;
   page @abstract, owns name @card(0..);
   profile @abstract, owns name @card(0..3);
   user owns phone @regex("^\d{8,15}$") @unique;
-// end::entities-annotations[]
+# end::entities-annotations[]
 
-// tag::entities-type-annotations[]
+# tag::entities-type-annotations[]
   content @abstract;
   page @abstract;
   profile @abstract;
-// end::entities-type-annotations[]
+# end::entities-type-annotations[]
 
-// tag::entities-cap-annotations[]
+# tag::entities-cap-annotations[]
   content owns id @key;
   page owns name @card(0..);
   profile owns name @card(0..3);
   user owns phone @regex("^\d{8,15}$") @unique;
-// end::entities-cap-annotations[]
+# end::entities-cap-annotations[]
 
-// tag::all-owns-name[]
+# tag::all-owns-name[]
   entity content;
-// tag::all-owns-name-cards[]
+# tag::all-owns-name-cards[]
   entity page sub content, owns name @card(0..);
   entity profile sub page, owns name @card(0..3);
   entity user sub profile;
-// end::all-owns-name-cards[]
+# end::all-owns-name-cards[]
   attribute name value string;
-// end::all-owns-name[]
+# end::all-owns-name[]
 
-// tag::attributes[]
+# tag::attributes[]
   attribute id value string;
   attribute page-id sub id;
   attribute username sub page-id;
   attribute name value string;
   attribute phone value string;
   attribute karma value double;
-// end::attributes[]
+# end::attributes[]
 
-// tag::attributes-type-annotations[]
+# tag::attributes-type-annotations[]
   attribute id @abstract;
   attribute page-id @abstract;
-// end::attributes-type-annotations[]
+# end::attributes-type-annotations[]
 
 
-// tag::fun-stream-scalar-return-type[]
+# tag::fun-stream-scalar-return-type[]
   fun user_phones($user: user) -> { phone }:
     match
       $user has phone $phone;
     return { $phone };
-// end::fun-stream-scalar-return-type[]
+# end::fun-stream-scalar-return-type[]
 
-// tag::fun-stream-tuple-return-type[]
+# tag::fun-stream-tuple-return-type[]
   fun all_users_and_phones() -> { user, phone, string }:
     match
       $user isa user, has phone $phone;
       let $phone-value = $phone;
     return { $user, $phone, $phone-value };
-// end::fun-stream-tuple-return-type[]
+# end::fun-stream-tuple-return-type[]
 
-// tag::fun-stream-scalar-return-value[]
+# tag::fun-stream-scalar-return-value[]
   fun add_streamed($x: integer, $y: integer) -> { integer }:
     match
       let $z = $x + $y;
     return { $z };
-// end::fun-stream-scalar-return-value[]
+# end::fun-stream-scalar-return-value[]
 
-// tag::fun-single-scalar-return-value[]
+# tag::fun-single-scalar-return-value[]
   fun add($x: integer, $y: integer) -> integer:
     match
       let $z = $x + $y;
     return first $z;
-// end::fun-single-scalar-return-value[]
+# end::fun-single-scalar-return-value[]
 
-// tag::fun-aggregate-single-scalar-return[]
+# tag::fun-aggregate-single-scalar-return[]
   fun mean_karma() -> double:
     match
       $user isa user, has karma $karma;
     return mean($karma);
-// end::fun-aggregate-single-scalar-return[]
+# end::fun-aggregate-single-scalar-return[]
 
-// tag::fun-aggregate-single-tuple-return[]
+# tag::fun-aggregate-single-tuple-return[]
   fun karma_sum_and_sum_squares() -> double, double:
     match
       $karma isa karma;
       let $karma-squared = $karma * $karma;
     return sum($karma), sum($karma-squared);
-// end::fun-aggregate-single-tuple-return[]
+# end::fun-aggregate-single-tuple-return[]
 
-// tag::with-fun-defined[]
+# tag::with-fun-defined[]
   fun karma_with_squared_value($user: user) -> karma, double:
     match
       $user has karma $karma;
       let $karma-squared = $karma * $karma;
     return first $karma, $karma-squared;
-// end::with-fun-defined[]
+# end::with-fun-defined[]
 
-// tag::fun-stream-users[]
+# tag::fun-stream-users[]
   fun users() -> { user }:
     match
       $user isa user;
     return { $user };
-// end::fun-stream-users[]
+# end::fun-stream-users[]
 
-// tag::fun-stream-users-with-first[]
+# tag::fun-stream-users-with-first[]
   fun first_user() -> user:
     match
       $user isa user;
     return first $user;
-// end::fun-stream-users-with-first[]
+# end::fun-stream-users-with-first[]

--- a/reference/modules/ROOT/examples/tql/schema_statements_functions.tql
+++ b/reference/modules/ROOT/examples/tql/schema_statements_functions.tql
@@ -62,11 +62,25 @@ define
   attribute karma value double;
 # end::attributes[]
 
+# tag::extended-attributes[]
+attribute tag value string;
+attribute bio value string;
+attribute profile-picture value string;
+user owns bio, owns profile-picture;
+# end::extended-attributes[]
+
 # tag::attributes-type-annotations[]
   attribute id @abstract;
   attribute page-id @abstract;
 # end::attributes-type-annotations[]
 
+# tag::relation-group[]
+attribute group-id sub id;
+attribute rank, value string @values("admin", "member");
+relation group-membership, relates group, relates member,  owns rank;
+entity group, owns name, owns group-id, owns tag, plays group-membership:group;
+user, plays group-membership:member;
+# end::relation-group[]
 
 # tag::fun-stream-scalar-return-type[]
   fun user_phones($user: user) -> { phone }:

--- a/reference/modules/ROOT/examples/tql/schema_statements_functions.tql
+++ b/reference/modules/ROOT/examples/tql/schema_statements_functions.tql
@@ -65,7 +65,7 @@ define
 # tag::extended-attributes[]
 attribute bio value string;
 attribute profile-picture value string;
-attribute email value string @regex("^.*@.*\.com");
+attribute email @independent, value string @regex("^.*@.*\.com");
 user owns bio, owns profile-picture;
 # end::extended-attributes[]
 

--- a/reference/modules/ROOT/examples/tql/schema_statements_functions.tql
+++ b/reference/modules/ROOT/examples/tql/schema_statements_functions.tql
@@ -74,6 +74,12 @@ user owns bio, owns profile-picture;
   attribute page-id @abstract;
 # end::attributes-type-annotations[]
 
+# tag::relation-friendship[]
+attribute start-date, value date;
+relation friendship relates friend @card(0..2), owns start-date;
+user plays friendship:friend;
+# end::relation-friendship[]
+
 # tag::relation-group[]
 attribute group-id sub id;
 attribute rank, value string @values("admin", "member");

--- a/reference/modules/ROOT/examples/tql/schema_statements_functions.tql
+++ b/reference/modules/ROOT/examples/tql/schema_statements_functions.tql
@@ -63,7 +63,6 @@ define
 # end::attributes[]
 
 # tag::extended-attributes[]
-attribute tag value string;
 attribute bio value string;
 attribute profile-picture value string;
 user owns bio, owns profile-picture;
@@ -83,6 +82,7 @@ user plays friendship:friend;
 # tag::relation-group[]
 attribute group-id sub id;
 attribute rank, value string @values("admin", "member");
+attribute tag value string;
 relation group-membership, relates group, relates member,  owns rank;
 entity group, owns name, owns group-id, owns tag, plays group-membership:group;
 user, plays group-membership:member;

--- a/reference/modules/ROOT/examples/tql/undefine_statements_functions.tql
+++ b/reference/modules/ROOT/examples/tql/undefine_statements_functions.tql
@@ -1,7 +1,7 @@
-// tag::undefine-keyword[]
+# tag::undefine-keyword[]
 undefine
-// end::undefine-keyword[]
+# end::undefine-keyword[]
 
-// tag::with-fun-undefined[]
+# tag::with-fun-undefined[]
   fun karma_with_squared_value;
-// end::with-fun-undefined[]
+# end::with-fun-undefined[]

--- a/reference/modules/ROOT/pages/typeql/annotations/abstract.adoc
+++ b/reference/modules/ROOT/pages/typeql/annotations/abstract.adoc
@@ -39,7 +39,6 @@ However, it is possible to define an abstract subtype of an abstract type.
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;abstract-attribute]
-#!---
 ----
 
 It is impossible to define an abstract subtype of a concrete type.
@@ -50,7 +49,6 @@ It is impossible to define an abstract subtype of a concrete type.
 #!test[schema, fail_at=runtime]
 define
   attribute categorized-username @abstract, sub username;
-#!---
 ----
 
 === Specialization of role types
@@ -61,5 +59,6 @@ A concrete sub role type can be defined using **specialization** (keyword `as`).
 
 [,typeql]
 ----
+#!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;abstract-relation]
 ----

--- a/reference/modules/ROOT/pages/typeql/annotations/abstract.adoc
+++ b/reference/modules/ROOT/pages/typeql/annotations/abstract.adoc
@@ -1,5 +1,6 @@
 = `@abstract` annotation
 :page-aliases: {page-version}@reference::typeql/statements/abstract.adoc
+:test-typeql: linear
 
 The `@abstract` annotation is used
 // tag::overview[]
@@ -36,7 +37,9 @@ However, it is possible to define an abstract subtype of an abstract type.
 
 [,typeql]
 ----
+#!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;abstract-attribute]
+#!---
 ----
 
 It is impossible to define an abstract subtype of a concrete type.
@@ -44,8 +47,10 @@ It is impossible to define an abstract subtype of a concrete type.
 .Wrong definition!
 [,typeql]
 ----
+#!test[schema, fail_at=runtime]
 define
   attribute categorized-username @abstract, sub username;
+#!---
 ----
 
 === Specialization of role types

--- a/reference/modules/ROOT/pages/typeql/annotations/card.adoc
+++ b/reference/modules/ROOT/pages/typeql/annotations/card.adoc
@@ -53,7 +53,6 @@ include::{page-version}@reference::example$tql/schema_annotations.tql[tags=defin
 #}}
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;card-owns-13]
-#!---
 ----
 
 At the same time, the `page` type can play the `posting:page` role an unlimited number of times:
@@ -66,7 +65,6 @@ define relation posting relates page;
 #}}
 #!test[schema, rollback]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;card-plays-0inf]
-#!---
 ----
 
 However, an instance of the `posting` relation type can have up to a thousand `page` instances:
@@ -75,7 +73,6 @@ However, an instance of the `posting` relation type can have up to a thousand `p
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;card-relates-01k]
-#!---
 ----
 
 [#subtyping]
@@ -93,7 +90,6 @@ For example, the following query defines that:
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;card-owns-13;profile-sub-page;user-owns-name;name-subattributes]
-#!---
 ----
 
 Valid statements based on this schema include:

--- a/reference/modules/ROOT/pages/typeql/annotations/card.adoc
+++ b/reference/modules/ROOT/pages/typeql/annotations/card.adoc
@@ -1,4 +1,5 @@
 = `@card` annotation
+:test-typeql: linear
 
 The `@card` annotation is used
 // tag::overview[]
@@ -46,21 +47,35 @@ For example, the following definition specifies that an instance of the `page` t
 
 [,typeql]
 ----
+#!test[schema]
+#{{
+include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;name-attribute]
+#}}
+#!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;card-owns-13]
+#!---
 ----
 
 At the same time, the `page` type can play the `posting:page` role an unlimited number of times:
 
 [,typeql]
 ----
+#!test[schema]
+#{{
+define relation posting relates page;
+#}}
+#!test[schema, rollback]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;card-plays-0inf]
+#!---
 ----
 
 However, an instance of the `posting` relation type can have up to a thousand `page` instances:
 
 [,typeql]
 ----
+#!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;card-relates-01k]
+#!---
 ----
 
 [#subtyping]
@@ -76,7 +91,9 @@ For example, the following query defines that:
 
 [,typeql]
 ----
+#!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;card-owns-13;profile-sub-page;user-owns-name;name-subattributes]
+#!---
 ----
 
 Valid statements based on this schema include:

--- a/reference/modules/ROOT/pages/typeql/annotations/independent.adoc
+++ b/reference/modules/ROOT/pages/typeql/annotations/independent.adoc
@@ -1,4 +1,5 @@
 = `@independent` annotation
+:test-typeql: linear
 
 The `@independent` annotation is used
 // tag::overview[]
@@ -33,13 +34,17 @@ In contrast, attributes of independent types can exist without owners.
 .Independent attribute types definition
 [,typeql]
 ----
-include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;independent-attribute;]
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;independent-attribute]
+#!---
 ----
 
 .Inserting independent attributes
 [,typeql]
 ----
-include::{page-version}@reference::example$tql/data_annotations.tql[tags=insert-keyword;independent-attribute;]
+#!test[write]
+include::{page-version}@reference::example$tql/data_annotations.tql[tags=insert-keyword;independent-attribute]
+#!---
 ----
 
 === Subtyping

--- a/reference/modules/ROOT/pages/typeql/annotations/independent.adoc
+++ b/reference/modules/ROOT/pages/typeql/annotations/independent.adoc
@@ -36,7 +36,6 @@ In contrast, attributes of independent types can exist without owners.
 ----
 #!test[schema, commit]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;independent-attribute]
-#!---
 ----
 
 .Inserting independent attributes
@@ -44,7 +43,6 @@ include::{page-version}@reference::example$tql/schema_annotations.tql[tags=defin
 ----
 #!test[write]
 include::{page-version}@reference::example$tql/data_annotations.tql[tags=insert-keyword;independent-attribute]
-#!---
 ----
 
 === Subtyping

--- a/reference/modules/ROOT/pages/typeql/annotations/key.adoc
+++ b/reference/modules/ROOT/pages/typeql/annotations/key.adoc
@@ -30,7 +30,6 @@ For example, the following statement declares that any `content` should have exa
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;key;key-attribute]
-#!---
 ----
 
 === Subtyping

--- a/reference/modules/ROOT/pages/typeql/annotations/key.adoc
+++ b/reference/modules/ROOT/pages/typeql/annotations/key.adoc
@@ -1,5 +1,6 @@
 = `@key` annotation
 :page-aliases: {page-version}@reference::typeql/statements/key.adoc
+:test-typeql: linear
 
 The `@key` annotation is used
 // tag::overview[]
@@ -27,7 +28,9 @@ For example, the following statement declares that any `content` should have exa
 
 [,typeql]
 ----
+#!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;key;key-attribute]
+#!---
 ----
 
 === Subtyping

--- a/reference/modules/ROOT/pages/typeql/annotations/range.adoc
+++ b/reference/modules/ROOT/pages/typeql/annotations/range.adoc
@@ -42,7 +42,6 @@ include::{page-version}@reference::typeql/annotations/values.adoc[tags=values-an
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;range-value]
-#!---
 ----
 
 [#_example_owns]
@@ -53,7 +52,6 @@ In the following example, an instance of the `creation-timestamp` type can conta
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;creation-timestamp-attribute;range-owns]
-#!---
 ----
 
 === Subtyping for attribute types' values

--- a/reference/modules/ROOT/pages/typeql/annotations/range.adoc
+++ b/reference/modules/ROOT/pages/typeql/annotations/range.adoc
@@ -1,4 +1,5 @@
 = `@range` annotation
+:test-typeql: linear
 
 The `@range` annotation is used
 // tag::overview[]
@@ -39,7 +40,9 @@ include::{page-version}@reference::typeql/annotations/values.adoc[tags=values-an
 
 [,typeql]
 ----
+#!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;range-value]
+#!---
 ----
 
 [#_example_owns]
@@ -48,7 +51,9 @@ In the following example, an instance of the `creation-timestamp` type can conta
 
 [,typeql]
 ----
+#!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;creation-timestamp-attribute;range-owns]
+#!---
 ----
 
 === Subtyping for attribute types' values

--- a/reference/modules/ROOT/pages/typeql/annotations/regex.adoc
+++ b/reference/modules/ROOT/pages/typeql/annotations/regex.adoc
@@ -37,7 +37,6 @@ include::{page-version}@reference::typeql/annotations/values.adoc[tags=values-an
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;regex-value]
-#!---
 ----
 
 [#_example_owns]
@@ -48,7 +47,6 @@ In the following example, an instance of the `phone` type can contain any `strin
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;phone-attribute;regex-owns]
-#!---
 ----
 
 === Subtyping

--- a/reference/modules/ROOT/pages/typeql/annotations/regex.adoc
+++ b/reference/modules/ROOT/pages/typeql/annotations/regex.adoc
@@ -1,5 +1,6 @@
 = `@regex` annotation
 :page-aliases: {page-version}@reference::typeql/statements/regex.adoc
+:test-typeql: linear
 
 The `@regex` annotation is used
 // tag::overview[]
@@ -34,7 +35,9 @@ include::{page-version}@reference::typeql/annotations/values.adoc[tags=values-an
 
 [,typeql]
 ----
+#!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;regex-value]
+#!---
 ----
 
 [#_example_owns]
@@ -43,7 +46,9 @@ In the following example, an instance of the `phone` type can contain any `strin
 
 [,typeql]
 ----
+#!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;phone-attribute;regex-owns]
+#!---
 ----
 
 === Subtyping

--- a/reference/modules/ROOT/pages/typeql/annotations/unique.adoc
+++ b/reference/modules/ROOT/pages/typeql/annotations/unique.adoc
@@ -31,7 +31,6 @@ For example, the following statement defines that every `user` should have a uni
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;phone-attribute;unique]
-#!---
 ----
 
 With this constraint, no instance of `user` can share the same `phone` value.
@@ -45,7 +44,6 @@ The `unique` constraint would also affect the following schema extension:
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;phone-sub-attributes;unique-sub-entity]
-#!---
 ----
 
 With the `unique` constraint on the `phone`, there is a protection ensuring that:

--- a/reference/modules/ROOT/pages/typeql/annotations/unique.adoc
+++ b/reference/modules/ROOT/pages/typeql/annotations/unique.adoc
@@ -1,5 +1,6 @@
 = `@unique` annotation
 :page-aliases: {page-version}@reference::typeql/statements/unique.adoc
+:test-typeql: linear
 
 The `@unique` annotation is used
 // tag::overview[]
@@ -28,7 +29,9 @@ For example, the following statement defines that every `user` should have a uni
 
 [,typeql]
 ----
+#!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;phone-attribute;unique]
+#!---
 ----
 
 With this constraint, no instance of `user` can share the same `phone` value.
@@ -40,7 +43,9 @@ The `unique` constraint would also affect the following schema extension:
 
 [,typeql]
 ----
+#!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;phone-sub-attributes;unique-sub-entity]
+#!---
 ----
 
 With the `unique` constraint on the `phone`, there is a protection ensuring that:

--- a/reference/modules/ROOT/pages/typeql/annotations/values.adoc
+++ b/reference/modules/ROOT/pages/typeql/annotations/values.adoc
@@ -41,7 +41,6 @@ When defined for an attribute type's value type, the annotation creates a constr
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;values-value]
-#!---
 ----
 [#_example_owns]
 // tag::values-and-owns-annotations-description-owns[]
@@ -57,7 +56,6 @@ define relation reaction relates parent;
 #}}
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;emoji-attribute;values-owns]
-#!---
 ----
 
 === Subtyping

--- a/reference/modules/ROOT/pages/typeql/annotations/values.adoc
+++ b/reference/modules/ROOT/pages/typeql/annotations/values.adoc
@@ -1,4 +1,5 @@
 = `@values` annotation
+:test-typeql: linear
 
 The `@values` annotation is used
 // tag::overview[]
@@ -38,7 +39,9 @@ When defined for an attribute type's value type, the annotation creates a constr
 
 [,typeql]
 ----
+#!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;values-value]
+#!---
 ----
 [#_example_owns]
 // tag::values-and-owns-annotations-description-owns[]
@@ -48,7 +51,13 @@ In the following example, an instance of the `emoji` type can contain any value,
 
 [,typeql]
 ----
+#!test[schema]
+#{{
+define relation reaction relates parent;
+#}}
+#!test[schema]
 include::{page-version}@reference::example$tql/schema_annotations.tql[tags=define-keyword;emoji-attribute;values-owns]
+#!---
 ----
 
 === Subtyping

--- a/reference/modules/ROOT/pages/typeql/expressions/index.adoc
+++ b/reference/modules/ROOT/pages/typeql/expressions/index.adoc
@@ -1,5 +1,6 @@
 = Expressions
 :page-aliases: {page-version}@typeql::expressions.adoc
+:test-typeql: linear
 
 A TypeQL expression uses operators and functions to
 compute a value from other values. It uses the following syntax:
@@ -10,11 +11,14 @@ let <var> = <expression>;
 Examples:
 [,typeql]
 ----
+#!test[read]
+match
 let $x = 5;
 
 let $y = $x * 3.1;
 
 let $z = ceil($y + 1);
+#!---
 ----
 
 == Validation

--- a/reference/modules/ROOT/pages/typeql/expressions/index.adoc
+++ b/reference/modules/ROOT/pages/typeql/expressions/index.adoc
@@ -18,7 +18,6 @@ let $x = 5;
 let $y = $x * 3.1;
 
 let $z = ceil($y + 1);
-#!---
 ----
 
 == Validation

--- a/reference/modules/ROOT/pages/typeql/functions/scalar.adoc
+++ b/reference/modules/ROOT/pages/typeql/functions/scalar.adoc
@@ -34,7 +34,7 @@ For example, the following example uses a query with a number of results based o
 ----
 #!test[schema, commit]
 #{{
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;user-supertypes;entity-user;attributes]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes]
 #}}
 #!test[read]
 include::{page-version}@reference::example$tql/read_statements_functions.tql[tags=match-users]

--- a/reference/modules/ROOT/pages/typeql/functions/scalar.adoc
+++ b/reference/modules/ROOT/pages/typeql/functions/scalar.adoc
@@ -77,7 +77,6 @@ As already discussed, this function should return a stream of answers.
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;fun-stream-users]
-#!---
 ----
 
 To make sure that there is maximum one result for a function, an instruction for picking this one result in case of ambiguity is required.
@@ -96,7 +95,6 @@ With the `last` keyword, the whole stream is consumed, and only its last answer 
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;fun-stream-users-with-first]
-#!---
 ----
 
 [#scalar_functions]
@@ -109,7 +107,6 @@ The following example illustrate simple usages of functions for retrieving an `i
 ----
 #!test[schema, commit]
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;fun-single-scalar-return-value]
-#!---
 ----
 
 To retrieve the results of such functions calls, the following read query can be used:
@@ -118,7 +115,6 @@ To retrieve the results of such functions calls, the following read query can be
 ----
 #!test[read]
 include::{page-version}@reference::example$tql/read_statements_functions.tql[tags=fun-single-scalar-return-value]
-#!---
 ----
 
 === Tuple functions
@@ -129,7 +125,6 @@ include::{page-version}@reference::typeql/functions/stream.adoc[tags=tuple-funct
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;with-fun-defined]
-#!---
 ----
 
 To retrieve the results of such functions calls, the following read query can be used:
@@ -138,5 +133,4 @@ To retrieve the results of such functions calls, the following read query can be
 ----
 #!test[read]
 include::{page-version}@reference::example$tql/read_statements_functions.tql[tags=with-fun-match]
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/functions/scalar.adoc
+++ b/reference/modules/ROOT/pages/typeql/functions/scalar.adoc
@@ -24,6 +24,16 @@ Single functions can be identified by their return type not containing curly bra
 Single functions are defined and called like any other function.
 To retrieve the results of the called function, a simple assignment is enough (however, a general `in` used for xref:{page-version}@reference::typeql/functions/stream.adoc[streamed] results is also allowed).
 
+.Schema for the following examples
+[%collapsible]
+====
+[,typeql]
+----
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes]
+----
+====
+
 === Transforming stream outputs to single outputs
 
 TypeQL pipelines generally produce streams of results as not every query always returns a specific number of answers.
@@ -32,13 +42,8 @@ For example, the following example uses a query with a number of results based o
 [#_transforming_general_example]
 [,typeql]
 ----
-#!test[schema, commit]
-#{{
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes]
-#}}
 #!test[read]
 include::{page-version}@reference::example$tql/read_statements_functions.tql[tags=match-users]
-#!---
 ----
 
 There are two main ways of transforming streams into single results: aggregation and stream modification.
@@ -54,7 +59,6 @@ These aggregations are usually scalar single functions by themselves, so calling
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;fun-aggregate-single-scalar-return]
-#!---
 ----
 
 .Example of an aggregate function used in a tuple function
@@ -62,7 +66,6 @@ include::{page-version}@reference::example$tql/schema_statements_functions.tql[t
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;fun-aggregate-single-tuple-return]
-#!---
 ----
 
 ==== Stream modification

--- a/reference/modules/ROOT/pages/typeql/functions/scalar.adoc
+++ b/reference/modules/ROOT/pages/typeql/functions/scalar.adoc
@@ -1,4 +1,5 @@
 = Scalar and tuple functions
+:test-typeql: linear
 
 Scalar and tuple functions are xref:{page-version}@reference::typeql/functions/index.adoc#fun_types[function types] which return at most one row of outputs.
 
@@ -31,7 +32,13 @@ For example, the following example uses a query with a number of results based o
 [#_transforming_general_example]
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;user-supertypes;entity-user;attributes]
+#}}
+#!test[read]
 include::{page-version}@reference::example$tql/read_statements_functions.tql[tags=match-users]
+#!---
 ----
 
 There are two main ways of transforming streams into single results: aggregation and stream modification.
@@ -45,13 +52,17 @@ These aggregations are usually scalar single functions by themselves, so calling
 .Example of an aggregate function used in a scalar function
 [,typeql]
 ----
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=fun-aggregate-single-scalar-return]
+#!test[schema]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;fun-aggregate-single-scalar-return]
+#!---
 ----
 
 .Example of an aggregate function used in a tuple function
 [,typeql]
 ----
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=fun-aggregate-single-tuple-return]
+#!test[schema]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;fun-aggregate-single-tuple-return]
+#!---
 ----
 
 ==== Stream modification
@@ -61,7 +72,9 @@ As already discussed, this function should return a stream of answers.
 
 [,typeql]
 ----
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=fun-stream-users]
+#!test[schema]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;fun-stream-users]
+#!---
 ----
 
 To make sure that there is maximum one result for a function, an instruction for picking this one result in case of ambiguity is required.
@@ -78,7 +91,9 @@ With the `last` keyword, the whole stream is consumed, and only its last answer 
 .Example of a stream modification
 [,typeql]
 ----
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=fun-stream-users-with-first]
+#!test[schema]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;fun-stream-users-with-first]
+#!---
 ----
 
 [#scalar_functions]
@@ -89,14 +104,18 @@ The following example illustrate simple usages of functions for retrieving an `i
 
 [,typeql]
 ----
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=fun-single-scalar-return-value]
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;fun-single-scalar-return-value]
+#!---
 ----
 
 To retrieve the results of such functions calls, the following read query can be used:
 
 [,typeql]
 ----
+#!test[read]
 include::{page-version}@reference::example$tql/read_statements_functions.tql[tags=fun-single-scalar-return-value]
+#!---
 ----
 
 === Tuple functions
@@ -105,12 +124,16 @@ include::{page-version}@reference::typeql/functions/stream.adoc[tags=tuple-funct
 
 [,typeql]
 ----
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=with-fun-defined]
+#!test[schema]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;with-fun-defined]
+#!---
 ----
 
 To retrieve the results of such functions calls, the following read query can be used:
 
 [,typeql]
 ----
+#!test[read]
 include::{page-version}@reference::example$tql/read_statements_functions.tql[tags=with-fun-match]
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/functions/stream.adoc
+++ b/reference/modules/ROOT/pages/typeql/functions/stream.adoc
@@ -49,7 +49,6 @@ include::{page-version}@reference::example$tql/schema_statements_functions.tql[t
 ----
 #!test[schema, commit]
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;fun-stream-scalar-return-value]
-#!---
 ----
 
 To retrieve the results of such functions calls, the following read query can be used:
@@ -58,7 +57,6 @@ To retrieve the results of such functions calls, the following read query can be
 ----
 #!test[read]
 include::{page-version}@reference::example$tql/read_statements_functions.tql[tags=fun-stream-scalar-return-type]
-#!---
 ----
 
 === Tuple functions
@@ -72,7 +70,6 @@ Tuples can contain any combinations of scalar returned values.
 ----
 #!test[schema, commit]
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;fun-stream-tuple-return-type]
-#!---
 ----
 
 To retrieve the results of such functions calls, the following read query can be used:
@@ -81,5 +78,4 @@ To retrieve the results of such functions calls, the following read query can be
 ----
 #!test[read]
 include::{page-version}@reference::example$tql/read_statements_functions.tql[tags=fun-stream-tuple-return-type]
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/functions/stream.adoc
+++ b/reference/modules/ROOT/pages/typeql/functions/stream.adoc
@@ -34,7 +34,7 @@ The following examples illustrate simple usages of functions for retrieving a st
 ----
 #!test[schema, commit]
 #{{
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;user-supertypes;entity-user;attributes]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes]
 #}}
 #!test[schema, commit]
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;fun-stream-scalar-return-type]

--- a/reference/modules/ROOT/pages/typeql/functions/stream.adoc
+++ b/reference/modules/ROOT/pages/typeql/functions/stream.adoc
@@ -1,4 +1,5 @@
 = Stream functions
+:test-typeql: linear
 
 Stream functions are xref:{page-version}@reference::typeql/functions/index.adoc#fun_types[function types] which return zero or more output rows.
 
@@ -31,19 +32,29 @@ The following examples illustrate simple usages of functions for retrieving a st
 
 [,typeql]
 ----
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=fun-stream-scalar-return-type]
+#!test[schema, commit]
+#{{
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;user-supertypes;entity-user;attributes]
+#}}
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;fun-stream-scalar-return-type]
+#!---
 ----
 
 [,typeql]
 ----
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=fun-stream-scalar-return-value]
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;fun-stream-scalar-return-value]
+#!---
 ----
 
 To retrieve the results of such functions calls, the following read query can be used:
 
 [,typeql]
 ----
+#!test[read]
 include::{page-version}@reference::example$tql/read_statements_functions.tql[tags=fun-stream-scalar-return-type]
+#!---
 ----
 
 === Tuple functions
@@ -55,12 +66,16 @@ Tuples can contain any combinations of scalar returned values.
 
 [,typeql]
 ----
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=fun-stream-tuple-return-type]
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;fun-stream-tuple-return-type]
+#!---
 ----
 
 To retrieve the results of such functions calls, the following read query can be used:
 
 [,typeql]
 ----
+#!test[read]
 include::{page-version}@reference::example$tql/read_statements_functions.tql[tags=fun-stream-tuple-return-type]
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/functions/stream.adoc
+++ b/reference/modules/ROOT/pages/typeql/functions/stream.adoc
@@ -23,6 +23,15 @@ Stream functions can be identified by their return type containing curly braces 
 
 Stream functions are defined and called like any other function.
 To retrieve the results of the called function, considering that the number of results for a single call is undefined, use the keyword `in`.
+.Schema for the following examples
+[%collapsible]
+====
+[,typeql]
+----
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes]
+----
+====
 
 [#scalar_functions]
 === Scalar functions
@@ -33,12 +42,7 @@ The following examples illustrate simple usages of functions for retrieving a st
 [,typeql]
 ----
 #!test[schema, commit]
-#{{
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes]
-#}}
-#!test[schema, commit]
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;fun-stream-scalar-return-type]
-#!---
 ----
 
 [,typeql]

--- a/reference/modules/ROOT/pages/typeql/functions/writing.adoc
+++ b/reference/modules/ROOT/pages/typeql/functions/writing.adoc
@@ -2,6 +2,37 @@
 :page-aliases: {page-version}@typeql::functions/writing.adoc
 :test-typeql: linear
 
+.Schema for the following examples
+[%collapsible]
+====
+[,typeql]
+----
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes]
+# Some extra just to test the snippets
+fun f1($a: integer) -> integer:
+match let $x = $a;
+return first $x;
+
+fun f2($a: integer) -> integer:
+match let $x = $a;
+return first $x;
+
+fun scalar_fun($a: integer, $b: integer) -> integer:
+match let $x = $a + $b;
+return first $x;
+
+fun tuple_fun($a: integer, $b: integer) -> integer, integer:
+match let $x = $a + $b; let $y = $a - $b;
+return first $x, $y;
+
+fun stream_fun($a: integer, $b: integer) -> { integer, integer }:
+match let $x = $a + $b; let $y = $a - $b;
+return { $x, $y };
+
+----
+====
+
 == Syntax
 
 [[declaration]]
@@ -70,12 +101,20 @@ Function can be called:
 [,typeql]
 .Scalar expression comparison
 ----
+#!test[read, count = 1]
+#{{
+match let $x = 0 ; let $y = 1;
+#}}
 $x + 1 < f1($y) + f2($y);
 ----
 [,typeql]
 .Scalar expression assignment
 ----
-let $x = scalar_fun($a, $b) / 2; # f3 is
+#!test[read, count = 1]
+#{{
+match let $a = 0 ; let $b = 1;
+#}}
+let $x = scalar_fun($a, $b) / 2;
 ----
 --
 1. as part of a tuple or stream assignment, for example:
@@ -84,11 +123,19 @@ let $x = scalar_fun($a, $b) / 2; # f3 is
 [,typeql]
 .Tuple assignment
 ----
+#!test[read, count = 1]
+#{{
+match let $a = 0 ; let $b = 1;
+#}}
 let $x, $y = tuple_fun($a, $b);
 ----
 .Stream assignment
 [,typeql]
 ----
+#!test[read, count = 1]
+#{{
+match let $a = 0 ; let $b = 1;
+#}}
 let $x, $y in stream_fun($a, $b);
 ----
 --
@@ -127,13 +174,8 @@ For example, the following read pipeline defines and uses a temporary function u
 
 [,typeql]
 ----
-#!test[schema]
-#{{
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes]
-#}}
 #!test[read]
 include::{page-version}@reference::example$tql/read_statements_functions.tql[tag=with-fun]
-#!---
 ----
 
 === Using Functions in definition queries
@@ -146,9 +188,8 @@ Replace the keyword `with` with `define` and execute the query in a schema trans
 // tag::define[]
 [,typeql]
 ----
-#!test[schema]
+#!test[schema, commit]
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;with-fun-defined]
-#!---
 ----
 // end::define[]
 
@@ -158,7 +199,6 @@ Once persisted, these functions can be called directly in read queries:
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/read_statements_functions.tql[tag=with-fun-match]
-#!---
 ----
 
 ==== Redefine
@@ -170,7 +210,6 @@ Everything except for the function name can be redefined using redefine queries.
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/redefine_statements_functions.tql[tags=redefine-keyword;with-fun-redefined]
-#!---
 ----
 // end::redefine[]
 
@@ -183,7 +222,6 @@ To undefine a function, specify the `fun` keyword and its name.
 ----
 #!test[schema]
 include::{page-version}@reference::example$tql/undefine_statements_functions.tql[tags=undefine-keyword;with-fun-undefined]
-#!---
 ----
 // end::undefine[]
 

--- a/reference/modules/ROOT/pages/typeql/functions/writing.adoc
+++ b/reference/modules/ROOT/pages/typeql/functions/writing.adoc
@@ -1,5 +1,6 @@
 = Writing functions
 :page-aliases: {page-version}@typeql::functions/writing.adoc
+:test-typeql: linear
 
 == Syntax
 
@@ -126,7 +127,13 @@ For example, the following read pipeline defines and uses a temporary function u
 
 [,typeql]
 ----
+#!test[schema]
+#{{
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;user-supertypes;entity-user;attributes]
+#}}
+#!test[read]
 include::{page-version}@reference::example$tql/read_statements_functions.tql[tag=with-fun]
+#!---
 ----
 
 === Using Functions in definition queries

--- a/reference/modules/ROOT/pages/typeql/functions/writing.adoc
+++ b/reference/modules/ROOT/pages/typeql/functions/writing.adoc
@@ -129,7 +129,7 @@ For example, the following read pipeline defines and uses a temporary function u
 ----
 #!test[schema]
 #{{
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;user-supertypes;entity-user;attributes]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes]
 #}}
 #!test[read]
 include::{page-version}@reference::example$tql/read_statements_functions.tql[tag=with-fun]
@@ -146,7 +146,9 @@ Replace the keyword `with` with `define` and execute the query in a schema trans
 // tag::define[]
 [,typeql]
 ----
+#!test[schema]
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;with-fun-defined]
+#!---
 ----
 // end::define[]
 
@@ -154,7 +156,9 @@ Once persisted, these functions can be called directly in read queries:
 
 [,typeql]
 ----
+#!test[schema]
 include::{page-version}@reference::example$tql/read_statements_functions.tql[tag=with-fun-match]
+#!---
 ----
 
 ==== Redefine
@@ -164,7 +168,9 @@ Everything except for the function name can be redefined using redefine queries.
 
 [,typeql]
 ----
+#!test[schema]
 include::{page-version}@reference::example$tql/redefine_statements_functions.tql[tags=redefine-keyword;with-fun-redefined]
+#!---
 ----
 // end::redefine[]
 
@@ -175,7 +181,9 @@ To undefine a function, specify the `fun` keyword and its name.
 
 [,typeql]
 ----
+#!test[schema]
 include::{page-version}@reference::example$tql/undefine_statements_functions.tql[tags=undefine-keyword;with-fun-undefined]
+#!---
 ----
 // end::undefine[]
 

--- a/reference/modules/ROOT/pages/typeql/index.adoc
+++ b/reference/modules/ROOT/pages/typeql/index.adoc
@@ -1,5 +1,6 @@
 = TypeQL language guide
 :page-aliases: {page-version}@reference::typeql/concepts/concept-variables.adoc, {page-version}@reference::typeql/concepts/data-instances.adoc, {page-version}@reference::typeql/concepts/overview.adoc, {page-version}@reference::typeql/overview.adoc, {page-version}@reference::typeql/concepts/types.adoc
+:test-typeql: linear
 
 This page gives an overview of the TypeQL query language. For an overview of the data model on which TypeQL queries are built see xref:{page-version}@reference::typeql/data-model.adoc[here].
 
@@ -88,16 +89,20 @@ Definitions and patterns play distinct roles in TypeQL.
 As a simple example of this distinction, compare:
 [,typeql]
 ----
+#!test[schema]
 define
   entity user, plays friendship:friend;
   relation friendship, relates friend @card(2);
+#!---
 ----
 with
 [,typeql]
 ----
+#!test[read]
 match
   $some-type plays $some-role;
   friendship relates $some-role;
+#!---
 ----
 The former query introduces types, while the latter will query for types. The general idea here is as follows.
 

--- a/reference/modules/ROOT/pages/typeql/index.adoc
+++ b/reference/modules/ROOT/pages/typeql/index.adoc
@@ -93,7 +93,6 @@ As a simple example of this distinction, compare:
 define
   entity user, plays friendship:friend;
   relation friendship, relates friend @card(2);
-#!---
 ----
 with
 [,typeql]
@@ -102,7 +101,6 @@ with
 match
   $some-type plays $some-role;
   friendship relates $some-role;
-#!---
 ----
 The former query introduces types, while the latter will query for types. The general idea here is as follows.
 

--- a/reference/modules/ROOT/pages/typeql/patterns/disjunctions.adoc
+++ b/reference/modules/ROOT/pages/typeql/patterns/disjunctions.adoc
@@ -34,21 +34,26 @@ or {
 == Behavior
 A disjunction pattern is satisfied if one of its branches is satisfied.
 
+.Schema for the following examples
+[%collapsible]
+====
+[,typeql]
+----
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/conjunction.tql[tags=patterns-schema]
+----
+====
+
 ===  Variable scopes
 A variable that appears in every branch will appear in the answers to the disjunction,
 and is considered to be in the scope of the parent pattern.
 Results to the following query will contain answers for `$x` and `$id`:
 [,typeql]
 ----
-#!test[schema, commit]
-#{{
-include::{page-version}@reference::example$tql/conjunction.tql[tags=patterns-schema]
-#}}
 #!test[read]
 match
   $x isa user;
   { $x has email $id; } or { $x has phone $id; };
-#!---
 ----
 
 A variable that occurs in only one branch AND not outside the disjunction is considered local to the branch.
@@ -59,7 +64,6 @@ Results to the following query will only contain answers for `$x`:
 match
   $x isa user;
   { $x has email $e; } or { $x has phone $p; };
-#!---
 ----
 
 In line with the unique scope principle, a variable that is local to more than one pattern is invalid.
@@ -71,7 +75,6 @@ match
   $x isa user;
   { $x has email $e; } or { $x has phone $p; };
   not { $e contains "@typedb.com"; };
-#!---
 ----
 
 // Note: A version of this document exists for the version of disjunctions
@@ -89,5 +92,4 @@ match
   $y isa user;
   { friendship($x, $y); }
   or { friendship($x, $z); friendship($z, $y); };
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/patterns/disjunctions.adoc
+++ b/reference/modules/ROOT/pages/typeql/patterns/disjunctions.adoc
@@ -1,5 +1,6 @@
 = Disjunctions
 :page-aliases: {page-version}@reference::typeql/patterns/disjunction.adoc
+:test-typeql: linear
 
 Disjunctive patterns can be used in `match` stages. They allow queries to match several cases (or "`branches`") of patterns in parallel.
 
@@ -39,28 +40,38 @@ and is considered to be in the scope of the parent pattern.
 Results to the following query will contain answers for `$x` and `$id`:
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+include::{page-version}@reference::example$tql/conjunction.tql[tags=patterns-schema]
+#}}
+#!test[read]
 match
-  $x isa $user;
+  $x isa user;
   { $x has email $id; } or { $x has phone $id; };
+#!---
 ----
 
 A variable that occurs in only one branch AND not outside the disjunction is considered local to the branch.
 Results to the following query will only contain answers for `$x`:
 [,typeql]
 ----
+#!test[read]
 match
-  $x isa $user;
+  $x isa user;
   { $x has email $e; } or { $x has phone $p; };
+#!---
 ----
 
 In line with the unique scope principle, a variable that is local to more than one pattern is invalid.
 The following query is invalid as `$e` has multiple scopes.
 [,typeql]
 ----
+#!test[read, fail_at=runtime]
 match
-  $x isa $user;
+  $x isa user;
   { $x has email $e; } or { $x has phone $p; };
   not { $e contains "@typedb.com"; };
+#!---
 ----
 
 // Note: A version of this document exists for the version of disjunctions
@@ -72,9 +83,11 @@ match
 +
 [,typeql]
 ----
+#!test[read]
 match
   $x isa user, has username "john_1";
   $y isa user;
   { friendship($x, $y); }
   or { friendship($x, $z); friendship($z, $y); };
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/patterns/negations.adoc
+++ b/reference/modules/ROOT/pages/typeql/patterns/negations.adoc
@@ -1,5 +1,6 @@
 = Negations
 :page-aliases: {page-version}@reference::typeql/patterns/negation.adoc
+:test-typeql: linear
 
 Negations can be used to exclude certain subpatterns from your query results -
  an answer is excluded if it matches the subpattern.
@@ -48,9 +49,15 @@ Negations may appear in `match` stages of data pipelines or functions, where the
 --
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+include::{page-version}@reference::example$tql/conjunction.tql[tags=patterns-schema]
+#}}
+#!test[read]
 match
   $x isa user, has username $name;
   not { friendship($x, $y); };
+#!---
 ----
 --
 
@@ -59,11 +66,13 @@ match
 --
 [,typeql]
 ----
+#!test[read]
 match
   $x isa user, has username $name;
   not { friendship($x, $y);
     not { friendship($y, $z); };
   };
+#!---
 ----
 [NOTE]
 ====

--- a/reference/modules/ROOT/pages/typeql/patterns/negations.adoc
+++ b/reference/modules/ROOT/pages/typeql/patterns/negations.adoc
@@ -44,20 +44,25 @@ Negations may appear in `match` stages of data pipelines or functions, where the
 
 == Examples
 
+.Schema for the following examples
+[%collapsible]
+====
+[,typeql]
+----
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/conjunction.tql[tags=patterns-schema]
+----
+====
+
 . Retrieve users without friends
 +
 --
 [,typeql]
 ----
-#!test[schema, commit]
-#{{
-include::{page-version}@reference::example$tql/conjunction.tql[tags=patterns-schema]
-#}}
 #!test[read]
 match
   $x isa user, has username $name;
   not { friendship($x, $y); };
-#!---
 ----
 --
 
@@ -72,7 +77,6 @@ match
   not { friendship($x, $y);
     not { friendship($y, $z); };
   };
-#!---
 ----
 [NOTE]
 ====

--- a/reference/modules/ROOT/pages/typeql/patterns/optionals.adoc
+++ b/reference/modules/ROOT/pages/typeql/patterns/optionals.adoc
@@ -1,4 +1,6 @@
 = Optionals
+:page-aliases: {page-version}@reference::typeql/patterns/optionals.adoc
+:test-typeql: linear
 
 Optional patterns can be used in `match` stages to optionally match a pattern,
 or in `insert` stages to insert a pattern *if* all the variables involved are bound.
@@ -16,18 +18,28 @@ If it has no matches, it produces a single answer with all optional variables bo
 
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+include::{page-version}@reference::example$tql/conjunction.tql[tags=patterns-schema]
+#}}
+#!test[read]
 match
     $person isa person;
     try {
         $_ isa marriage, links (spouse: $person, spouse: $spouse);
     };
+#!---
 ----
 Here, `$spouse` will be bound to the spouse if `$person` is in a `marriage`.
 Else, `$spouse` will be bound to `None`
 
 === insert & delete
+[NOTE]
+====
+Coming soon!
+====
 Optional patterns in insert or delete stages will execute only if ALL the variables present in them are bound.
-
+// Re-enable the tests when we do implement it
 [,typeql]
 ----
 match
@@ -53,6 +65,7 @@ Optional patterns are banned in `put` stages.
 In the stage that it first occurs, An optional variable may only occur in a single try-block.
 [,typeql]
 ----
+#!test[read, fail_at=runtime]
 match
     $person isa person;
     try {
@@ -61,6 +74,7 @@ match
     try {
         $policy isa policy, links (covered: $spouse); # Invalid
     };
+#!---
 ----
 
 === Optional variables in subsequent stages
@@ -70,6 +84,7 @@ An unbound optional variable will cause the pattern to fail.
 The following is a valid way to express the intent of the example above:
 [,typeql]
 ----
+#!test[read]
 match
     $person isa person;
     try {
@@ -79,6 +94,7 @@ match
     try {
         $policy isa policy, links (covered: $spouse);
     };
+#!---
 ----
 
 
@@ -86,6 +102,7 @@ match
 Optional patterns can be nested. This is also an option for the previous example
 [,typeql]
 ----
+#!test[read]
 match
     $person isa person;
     try {
@@ -94,6 +111,7 @@ match
             $policy isa policy, links (covered: $spouse); # Ok
         };
     };
+#!---
 ----
 
 === Disallowed in negations

--- a/reference/modules/ROOT/pages/typeql/patterns/optionals.adoc
+++ b/reference/modules/ROOT/pages/typeql/patterns/optionals.adoc
@@ -1,5 +1,4 @@
 = Optionals
-:page-aliases: {page-version}@reference::typeql/patterns/optionals.adoc
 :test-typeql: linear
 
 Optional patterns can be used in `match` stages to optionally match a pattern,

--- a/reference/modules/ROOT/pages/typeql/patterns/optionals.adoc
+++ b/reference/modules/ROOT/pages/typeql/patterns/optionals.adoc
@@ -4,6 +4,16 @@
 Optional patterns can be used in `match` stages to optionally match a pattern,
 or in `insert` stages to insert a pattern *if* all the variables involved are bound.
 
+.Schema for the following examples
+[%collapsible]
+====
+[,typeql]
+----
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/conjunction.tql[tags=patterns-schema]
+----
+====
+
 == Syntax & Basic behavior
 [,typeql]
 ----
@@ -17,17 +27,12 @@ If it has no matches, it produces a single answer with all optional variables bo
 
 [,typeql]
 ----
-#!test[schema, commit]
-#{{
-include::{page-version}@reference::example$tql/conjunction.tql[tags=patterns-schema]
-#}}
 #!test[read]
 match
     $person isa person;
     try {
         $_ isa marriage, links (spouse: $person, spouse: $spouse);
     };
-#!---
 ----
 Here, `$spouse` will be bound to the spouse if `$person` is in a `marriage`.
 Else, `$spouse` will be bound to `None`
@@ -73,7 +78,6 @@ match
     try {
         $policy isa policy, links (covered: $spouse); # Invalid
     };
-#!---
 ----
 
 === Optional variables in subsequent stages
@@ -93,7 +97,6 @@ match
     try {
         $policy isa policy, links (covered: $spouse);
     };
-#!---
 ----
 
 
@@ -110,7 +113,6 @@ match
             $policy isa policy, links (covered: $spouse); # Ok
         };
     };
-#!---
 ----
 
 === Disallowed in negations

--- a/reference/modules/ROOT/pages/typeql/pipelines/delete.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/delete.adoc
@@ -1,5 +1,6 @@
 = Delete stage
 :page-aliases: {page-version}@reference::typeql/queries/delete.adoc
+:test-typeql: linear
 
 A delete stage deletes data from the database. Deletable data includes instances of types, ownerships of attributes, and role players of
 relations.
@@ -30,13 +31,19 @@ stream of input rows with the deleted concepts removed.
 
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;extended-attributes;relation-group]
+#}}
+#!test[write]
 match
-  $person isa person, has name "<name>";
+  $user isa user, has name "<name>";
   $group isa group, has group-id "<group id>";
-  $membership isa group-membership(group: $group, member: $person) has rank $rank;
+  $membership isa group-membership(group: $group, member: $user), has rank $rank;
   $rank == "member";
 delete
   has $rank of $membership;
-  links ($person) of $membership;
+  links ($user) of $membership;
   $group;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/pipelines/delete.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/delete.adoc
@@ -33,7 +33,7 @@ stream of input rows with the deleted concepts removed.
 ----
 #!test[schema, commit]
 #{{
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;extended-attributes;relation-group]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-group]
 #}}
 #!test[write]
 match

--- a/reference/modules/ROOT/pages/typeql/pipelines/delete.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/delete.adoc
@@ -29,12 +29,18 @@ stream of input rows with the deleted concepts removed.
 
 == Example
 
+.Schema for the following examples
+[%collapsible]
+====
 [,typeql]
 ----
 #!test[schema, commit]
-#{{
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-group]
-#}}
+----
+====
+
+[,typeql]
+----
 #!test[write]
 match
   $user isa user, has name "<name>";
@@ -45,5 +51,4 @@ delete
   has $rank of $membership;
   links ($user) of $membership;
   $group;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/pipelines/fetch.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/fetch.adoc
@@ -203,13 +203,19 @@ The following example demonstrates a single `fetch` stage containing different v
 ====
 Every sub statement inside this `fetch` stage can be written as separate `fetch` es and can be considered as separate examples.
 ====
-
+.Schema for the following examples
+[%collapsible]
+====
 [,typeql]
 ----
 #!test[schema, commit]
-#{{
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-group;fun-aggregate-single-scalar-return]
-#}}
+----
+====
+
+
+[,typeql]
+----
 #!test[read, documents]
 match
   $group isa group;
@@ -248,7 +254,6 @@ fetch {
     return mean($karma);
   ]
 };
-#!---
 ----
 
 .Example TypeDB Console output

--- a/reference/modules/ROOT/pages/typeql/pipelines/fetch.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/fetch.adoc
@@ -208,7 +208,7 @@ Every sub statement inside this `fetch` stage can be written as separate `fetch`
 ----
 #!test[schema, commit]
 #{{
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;extended-attributes;relation-group;fun-aggregate-single-scalar-return]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-group;fun-aggregate-single-scalar-return]
 #}}
 #!test[read, documents]
 match

--- a/reference/modules/ROOT/pages/typeql/pipelines/fetch.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/fetch.adoc
@@ -1,5 +1,6 @@
 = Fetch stage
 :page-aliases: {page-version}@typeql::pipelines/fetch.adoc
+:test-typeql: linear
 
 Fetch is primarily used to convert row answers into document (JSON) answers.
 The `fetch` clause is **terminal**, meaning that it cannot be followed by any other pipeline stage.
@@ -205,6 +206,11 @@ Every sub statement inside this `fetch` stage can be written as separate `fetch`
 
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;extended-attributes;relation-group;fun-aggregate-single-scalar-return]
+#}}
+#!test[read, documents]
 match
   $group isa group;
 fetch {
@@ -242,6 +248,7 @@ fetch {
     return mean($karma);
   ]
 };
+#!---
 ----
 
 .Example TypeDB Console output

--- a/reference/modules/ROOT/pages/typeql/pipelines/insert.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/insert.adoc
@@ -49,12 +49,18 @@ NOTE: xref:{page-version}@reference::typeql/annotations/card.adoc[Cardinality an
 
 == Examples
 
+.Schema for the following examples
+[%collapsible]
+====
 [,typeql]
 ----
 #!test[schema, commit]
-#{{
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;extended-attributes;relation-group]
-#}}
+----
+====
+
+[,typeql]
+----
 #!test[write, documents]
 insert
   $group isa group,
@@ -64,7 +70,6 @@ insert
     has bio "<bio>",
     has profile-picture "<uuid>";
   group-membership(group: $group, member: $user) has rank "member";
-#!---
 ----
 
 [,typeql]
@@ -75,6 +80,5 @@ match
   $group isa group, has group-id "<group id>";
 insert
   group-membership(group: $group, member: $user) has rank "member";
-#!---
 ----
 

--- a/reference/modules/ROOT/pages/typeql/pipelines/insert.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/insert.adoc
@@ -1,5 +1,6 @@
 = Insert stage
 :page-aliases: {page-version}@reference::typeql/queries/insert.adoc
+:test-typeql: linear
 
 An insert stage inserts new data into the database.
 Insertable data includes instances of types, ownerships of attributes, and role players of relations.
@@ -50,22 +51,30 @@ NOTE: xref:{page-version}@reference::typeql/annotations/card.adoc[Cardinality an
 
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;extended-attributes;relation-group;fun-aggregate-single-scalar-return]
+#}}
+#!test[write, documents]
 insert
   $group isa group,
     has group-id "<group id>";
-  $person isa person,
+  $user isa user,
     has name "<name>",
     has bio "<bio>",
     has profile-picture "<uuid>";
-  group-membership(group: $group, member: $person) has rank "member";
+  group-membership(group: $group, member: $user) has rank "member";
+#!---
 ----
 
 [,typeql]
 ----
+#!test[write]
 match
-  $person isa person, has name "<name>";
+  $user isa user, has name "<name>";
   $group isa group, has group-id "<group id>";
 insert
-  group-membership(group: $group, member: $person) has rank "member";
+  group-membership(group: $group, member: $user) has rank "member";
+#!---
 ----
 

--- a/reference/modules/ROOT/pages/typeql/pipelines/insert.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/insert.adoc
@@ -53,7 +53,7 @@ NOTE: xref:{page-version}@reference::typeql/annotations/card.adoc[Cardinality an
 ----
 #!test[schema, commit]
 #{{
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;extended-attributes;relation-group;fun-aggregate-single-scalar-return]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;extended-attributes;relation-group]
 #}}
 #!test[write, documents]
 insert

--- a/reference/modules/ROOT/pages/typeql/pipelines/limit.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/limit.adoc
@@ -1,5 +1,6 @@
 = Limit operator
 :page-aliases: {page-version}@reference::typeql/modifiers/pagination.adoc
+:test-typeql: linear
 
 The limit operator stops producing rows after the specified row limit has been reached.
 
@@ -16,12 +17,18 @@ Match all friends of friends of a given person, sorted by the number of mutual f
 
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
+#}}
+#!test[read]
 match
-  $person isa person, has username "<username>";
-  friendship (friend: $person, friend: $friend);
+  $user isa user, has username "<username>";
+  friendship (friend: $user, friend: $friend);
   friendship (friend: $friend, friend: $possible-friend);
-  not { friendship (friend: $person, friend: $possible-friend); };
-reduce $num-mutuals = count($friend) within $possible-friend;
+  not { friendship (friend: $user, friend: $possible-friend); };
+reduce $num-mutuals = count($friend) groupby $possible-friend;
 sort $num-mutuals desc;
 limit 10;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/pipelines/limit.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/limit.adoc
@@ -13,14 +13,20 @@ limit <number>;
 
 == Example
 
+.Schema for the following examples
+[%collapsible]
+====
+[,typeql]
+----
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
+----
+====
+
 Match all friends of friends of a given person, sorted by the number of mutual friends, highest to lowest. Return first 10.
 
 [,typeql]
 ----
-#!test[schema, commit]
-#{{
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
-#}}
 #!test[read]
 match
   $user isa user, has username "<username>";
@@ -30,5 +36,4 @@ match
 reduce $num-mutuals = count($friend) groupby $possible-friend;
 sort $num-mutuals desc;
 limit 10;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/pipelines/match.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/match.adoc
@@ -1,5 +1,6 @@
 = Match stage
 :page-aliases: {page-version}@typeql::pipelines/match.adoc
+:test-typeql: linear
 
 A match stage performs pattern-based data retrieval and filtering. It takes input data assigned variables and verifies that this data satisfies the patterns in the body of the stage, while producing new results for any additional variables that the pattern
 
@@ -49,6 +50,11 @@ If no valid combinations of types can be inferred for the variables in body patt
 +
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
+#}}
+#!test[read]
 match
   $x isa user;
   friendship($x, $y);
@@ -57,15 +63,18 @@ match
   $y_count > 500;
   $x has username $name;
 select $name;
+#!---
 ----
 
 1. Retrieve users with no friends:
 +
 [,typeql]
 ----
+#!test[read]
 match
   $x isa user;
   not { friendship($x, $y); };
+#!---
 ----
 
 
@@ -73,17 +82,28 @@ match
 +
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+define
+  attribute access-level, value integer;
+  entity VIP sub user;
+  entity admin sub user, owns access-level;
+#}}
+#!test[read]
 match
   $x isa user;
   { $x isa VIP; } or { $x isa admin, has access-level > 9000; };
+#!---
 ----
 
 1. Find all attributes that are set for a specific user, return them together with their type;
 +
 [,typeql]
 ----
+#!test[read]
 match
   $x isa user, has username "specific_user";
   $x has $type $value;
 select $type, $value;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/pipelines/match.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/match.adoc
@@ -46,14 +46,20 @@ If no valid combinations of types can be inferred for the variables in body patt
 
 == Examples
 
+.Schema for the following examples
+[%collapsible]
+====
+[,typeql]
+----
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
+----
+====
+
 1. Retrieve usernames of user who have more than 400 friends:
 +
 [,typeql]
 ----
-#!test[schema, commit]
-#{{
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
-#}}
 #!test[read]
 match
   $x isa user;
@@ -63,7 +69,6 @@ match
   $y_count > 500;
   $x has username $name;
 select $name;
-#!---
 ----
 
 1. Retrieve users with no friends:
@@ -74,7 +79,6 @@ select $name;
 match
   $x isa user;
   not { friendship($x, $y); };
-#!---
 ----
 
 

--- a/reference/modules/ROOT/pages/typeql/pipelines/match.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/match.adoc
@@ -97,7 +97,6 @@ define
 match
   $x isa user;
   { $x isa VIP; } or { $x isa admin, has access-level > 9000; };
-#!---
 ----
 
 1. Find all attributes that are set for a specific user, return them together with their type;
@@ -109,5 +108,4 @@ match
   $x isa user, has username "specific_user";
   $x has $type $value;
 select $type, $value;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/pipelines/offset.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/offset.adoc
@@ -1,4 +1,5 @@
 = Offset operator
+:test-typeql: linear
 
 The offset operator skips rows until the specified number has been skipped, then produces the remaining rows as normal.
 
@@ -11,18 +12,24 @@ offset <number>;
 
 == Example
 
-Retrieve all people employed by the company, sorted by employment start time from earliest to latest.
+Retrieve all friends of a user, sorted by the time they became friends from earliest to latest.
 Skip first 10, then return the following 10.
 
 This can be thought as retrieving the second page with 10 employees per page.
 
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
+#}}
+#!test[read]
 match
-  $company isa company, has company-name "<name>";
-  employment (employer: $company, employee: $person),
+  $user isa user, has name "<name>";
+  friendship (friend: $user, friend: $friend),
     has start-date $start;
 sort $start;
 offset 10;
 limit 10;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/pipelines/offset.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/offset.adoc
@@ -12,6 +12,16 @@ offset <number>;
 
 == Example
 
+.Schema for the following examples
+[%collapsible]
+====
+[,typeql]
+----
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
+----
+====
+
 Retrieve all friends of a user, sorted by the time they became friends from earliest to latest.
 Skip first 10, then return the following 10.
 
@@ -19,10 +29,6 @@ This can be thought as retrieving the second page with 10 employees per page.
 
 [,typeql]
 ----
-#!test[schema, commit]
-#{{
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
-#}}
 #!test[read]
 match
   $user isa user, has name "<name>";
@@ -31,5 +37,4 @@ match
 sort $start;
 offset 10;
 limit 10;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/pipelines/put.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/put.adoc
@@ -1,4 +1,5 @@
 = Put stage
+:test-typeql: linear
 
 A put stage will xref:{page-version}@reference::typeql/pipelines/insert.adoc[insert] data according to a pattern if no existing data xref:{page-version}@reference::typeql/pipelines/match.adoc[matches] that pattern.
 
@@ -13,15 +14,23 @@ put <insert-statement> [ <insert-statement> ... ]
 
 == Example
 
-The following query creates a friendship relation between two persons, if one does not already exist.
+The following query creates a friendship relation between two users, if one does not already exist.
 
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
+attribute age, value integer;
+user owns age;
+#}}
+#!test[write]
 match
-  $person-1 isa person, has username "Alice";
-  $person-2 isa person, has username "Bob";
+  $user-1 isa user, has username "Alice";
+  $user-2 isa user, has username "Bob";
 put
-  friendship (friend: $person-1, friend: $person-2);
+  friendship (friend: $user-1, friend: $user-2);
+#!---
 ----
 
 == Behavior
@@ -47,17 +56,20 @@ Hence, a put stage is expected to be only as performant as running both the matc
 ====
 Multiple inputs will cause the pattern to be inserted multiple times.
 
-For example, assume there are two `person` instances in our database named "John",
+For example, assume there are two `user` instances in our database named "John",
 and we run the following query:
-```
-match $john isa person, has name "John";
-put $jane isa person, has name "Jane";
-```
+[,typeql]
+----
+#!test[write]
+match $john isa user, has username "John";
+put $jane isa user, has username "Jane";
+#!---
+----
 
 What happens in this case is:
 
-- If a person named Jane already exists: nothing is inserted.
-- Else: two new `person` instances with name "Jane" are inserted.
+- If a user named Jane already exists: nothing is inserted.
+- Else: two new `user` instances with name "Jane" are inserted.
 
 This behavior is currently under review.
 Please open a Github issue if it is blocking your progress!
@@ -71,28 +83,32 @@ To illustrate, consider running the following queries sequentially.
 
 [,typeql]
 ----
+#!test[write]
 # Creates some initial data
-put $p isa person, has name "Alice";
+put $p isa user, has name "Alice";
 
 # Does nothing, as the match succeeds
-put $p1 isa person, has name "Alice";
+put $p1 isa user, has name "Alice";
 
-# Creates a new person with name "Bob"
-put $p2 isa person, has name "Bob";
+# Creates a new user with name "Bob"
+put $p2 isa user, has name "Bob";
 
-# Creates a new person with name "Alice" & age 10.
-put $p3 isa person, has name "Alice", has age 10;
+# Creates a new user with name "Alice" & age 10.
+put $p3 isa user, has name "Alice", has age 10;
+#!---
 ----
-The statement `put $p3...` creates a new person because the **whole** pattern fails to match,
-as there is no existing person with name "Alice" **AND** age 10.
+The statement `put $p3...` creates a new user because the **whole** pattern fails to match,
+as there is no existing user with name "Alice" **AND** age 10.
 
-To achieve the desired result of not re-creating the person if only the age attribute is missing,
+To achieve the desired result of not re-creating the user if only the age attribute is missing,
 `put` stages can be pipelined.
 
 [,typeql]
 ----
-put $p4 isa person, has name "Bob"; # Matches the person with name "Bob", since it exists
-put $p4 isa person, has age 11;     # Adds an attribute to the same person
+#!test[write]
+put $p4 isa user, has name "Bob"; # Matches the user with name "Bob", since it exists
+put $p4 has age 11;     # Adds an attribute to the same user
+#!---
 ----
 
 === Isolation from concurrent transactions

--- a/reference/modules/ROOT/pages/typeql/pipelines/put.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/put.adoc
@@ -14,23 +14,28 @@ put <insert-statement> [ <insert-statement> ... ]
 
 == Example
 
+.Schema for the following examples
+[%collapsible]
+====
+[,typeql]
+----
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
+attribute age, value integer;
+user owns age;
+----
+====
+
 The following query creates a friendship relation between two users, if one does not already exist.
 
 [,typeql]
 ----
-#!test[schema, commit]
-#{{
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
-attribute age, value integer;
-user owns age;
-#}}
 #!test[write]
 match
   $user-1 isa user, has username "Alice";
   $user-2 isa user, has username "Bob";
 put
   friendship (friend: $user-1, friend: $user-2);
-#!---
 ----
 
 == Behavior
@@ -63,7 +68,6 @@ and we run the following query:
 #!test[write]
 match $john isa user, has username "John";
 put $jane isa user, has username "Jane";
-#!---
 ----
 
 What happens in this case is:
@@ -95,7 +99,6 @@ put $p2 isa user, has name "Bob";
 
 # Creates a new user with name "Alice" & age 10.
 put $p3 isa user, has name "Alice", has age 10;
-#!---
 ----
 The statement `put $p3...` creates a new user because the **whole** pattern fails to match,
 as there is no existing user with name "Alice" **AND** age 10.
@@ -108,7 +111,6 @@ To achieve the desired result of not re-creating the user if only the age attrib
 #!test[write]
 put $p4 isa user, has name "Bob"; # Matches the user with name "Bob", since it exists
 put $p4 has age 11;     # Adds an attribute to the same user
-#!---
 ----
 
 === Isolation from concurrent transactions

--- a/reference/modules/ROOT/pages/typeql/pipelines/reduce.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/reduce.adoc
@@ -1,5 +1,6 @@
 = Reduce operator
 :page-aliases: {page-version}@reference::typeql/modifiers/aggregation.adoc, {page-version}@reference::typeql/modifiers/grouping.adoc
+:test-typeql: linear
 
 == Reduce
 
@@ -22,22 +23,38 @@ TypeQL supports the following reduce operators:
 
 === Examples
 
-Count the number of logins since `<datetime>`:
+Count the number of logins since `2025-01-01`:
 
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
+attribute last-login, value date;
+user owns last-login;
+#}}
+#!test[read]
 match
-  $user isa user, has last-login >= <datetime>;
+  $user isa user, has last-login >= 2025-01-01;
 reduce $logins = count;
+#!---
 ----
 
 Get disk usage statistics of the files:
 
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+define
+attribute size-kb, value double;
+entity file, owns size-kb;
+#}}
+#!test[read]
 match
   $file isa file, has size-kb $s;
 reduce $total = sum($s), $mean = mean($s), $max = max($s);
+#!---
 ----
 
 == Grouping
@@ -59,6 +76,14 @@ Get the number of users per country:
 
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+define
+  relation located, relates country, relates user;
+  entity country, plays located:country;
+user plays located:user;
+#}}
+#!test[read]
 match
   $user isa user;
   $country isa country;
@@ -68,5 +93,6 @@ match
     located($user, $place);
     located($place, $country);
   };
-reduce $logins = count groupby $country;
+reduce $user-count = count groupby $country;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/pipelines/reduce.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/reduce.adoc
@@ -23,38 +23,43 @@ TypeQL supports the following reduce operators:
 
 === Examples
 
+.Schema for the following examples
+[%collapsible]
+====
+[,typeql]
+----
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
+  attribute last-login, value date;
+  user owns last-login;
+
+  attribute size-kb, value double;
+  entity file, owns size-kb;
+
+  relation located, relates country, relates user;
+  entity country, plays located:country;
+  user plays located:user;
+----
+====
+
 Count the number of logins since `2025-01-01`:
 
 [,typeql]
 ----
-#!test[schema, commit]
-#{{
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
-attribute last-login, value date;
-user owns last-login;
-#}}
 #!test[read]
 match
   $user isa user, has last-login >= 2025-01-01;
 reduce $logins = count;
-#!---
 ----
 
 Get disk usage statistics of the files:
 
 [,typeql]
 ----
-#!test[schema, commit]
-#{{
-define
-attribute size-kb, value double;
-entity file, owns size-kb;
-#}}
 #!test[read]
 match
   $file isa file, has size-kb $s;
 reduce $total = sum($s), $mean = mean($s), $max = max($s);
-#!---
 ----
 
 == Grouping
@@ -76,13 +81,6 @@ Get the number of users per country:
 
 [,typeql]
 ----
-#!test[schema, commit]
-#{{
-define
-  relation located, relates country, relates user;
-  entity country, plays located:country;
-user plays located:user;
-#}}
 #!test[read]
 match
   $user isa user;
@@ -94,5 +92,4 @@ match
     located($place, $country);
   };
 reduce $user-count = count groupby $country;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/pipelines/select.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/select.adoc
@@ -1,5 +1,6 @@
 = Select operator
 :page-aliases: {page-version}@reference::typeql/queries/get.adoc
+:test-typeql: linear
 
 The select operator restricts the stream of rows to only contain the variables specified.
 
@@ -14,8 +15,14 @@ select <var> [ , <var> ... ];
 
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;extended-attributes;relation-group]
+#}}
+#!test[read]
 match
   $group isa group, has group-id "<group id>";
   group-membership (group: $group, member: $member), has rank "member";
 select $member;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/pipelines/select.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/select.adoc
@@ -13,16 +13,21 @@ select <var> [ , <var> ... ];
 
 == Example
 
+.Schema for the following examples
+[%collapsible]
+====
 [,typeql]
 ----
 #!test[schema, commit]
-#{{
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-group]
-#}}
+----
+====
+
+[,typeql]
+----
 #!test[read]
 match
   $group isa group, has group-id "<group id>";
   group-membership (group: $group, member: $member), has rank "member";
 select $member;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/pipelines/select.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/select.adoc
@@ -17,7 +17,7 @@ select <var> [ , <var> ... ];
 ----
 #!test[schema, commit]
 #{{
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;extended-attributes;relation-group]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-group]
 #}}
 #!test[read]
 match

--- a/reference/modules/ROOT/pages/typeql/pipelines/sort.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/sort.adoc
@@ -1,5 +1,6 @@
 = Sort operator
 :page-aliases: {page-version}@reference::typeql/modifiers/sorting.adoc
+:test-typeql: linear
 
 The sort operator sorts the input stream based on the variables and their sort order.
 
@@ -22,9 +23,15 @@ Retrieve all posts on a given page, sorted from newest to oldest.
 
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+include::{page-version}@reference::partial$2_to_3/schema-3x.tql[tags=full-query]
+#}}
+#!test[read]
 match
-  $page isa page, has page-id "<page id>";
+  $page isa page, has id "<page id>";
   $post isa post, has creation-timestamp $created;
   posting (page: $page, post: $post);
 sort $created desc;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/pipelines/sort.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/sort.adoc
@@ -19,19 +19,24 @@ sort <var> [asc|desc] [ , <var> [asc|desc] ... ];
 
 == Example
 
+.Schema for the following examples
+[%collapsible]
+====
+[,typeql]
+----
+#!test[schema, commit]
+include::{page-version}@reference::partial$2_to_3/schema-3x.tql[tags=full-query]
+----
+====
+
 Retrieve all posts on a given page, sorted from newest to oldest.
 
 [,typeql]
 ----
-#!test[schema, commit]
-#{{
-include::{page-version}@reference::partial$2_to_3/schema-3x.tql[tags=full-query]
-#}}
 #!test[read]
 match
   $page isa page, has id "<page id>";
   $post isa post, has creation-timestamp $created;
   posting (page: $page, post: $post);
 sort $created desc;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/pipelines/update.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/update.adoc
@@ -1,5 +1,6 @@
 = Update stage
 :page-aliases: {page-version}@reference::typeql/queries/update.adoc
+:test-typeql: linear
 
 An update stage updates data in the database. Updatable data includes ownerships of attributes and role players of
 relations.
@@ -38,6 +39,11 @@ The modified concepts are validated the same way as in xref:{page-version}@refer
 
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;extended-attributes;relation-group]
+#}}
+#!test[write]
 match
   $group isa group, has group-id "<group id>";
   $user isa user, has username "<username>";
@@ -45,4 +51,5 @@ match
 update
   $group-membership has rank "member";
   $group-membership links (group: $group);
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/pipelines/update.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/update.adoc
@@ -41,7 +41,7 @@ The modified concepts are validated the same way as in xref:{page-version}@refer
 ----
 #!test[schema, commit]
 #{{
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;extended-attributes;relation-group]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-group]
 #}}
 #!test[write]
 match

--- a/reference/modules/ROOT/pages/typeql/pipelines/update.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/update.adoc
@@ -37,12 +37,18 @@ The modified concepts are validated the same way as in xref:{page-version}@refer
 
 == Example
 
+.Schema for the following examples
+[%collapsible]
+====
 [,typeql]
 ----
 #!test[schema, commit]
-#{{
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-group]
-#}}
+----
+====
+
+[,typeql]
+----
 #!test[write]
 match
   $group isa group, has group-id "<group id>";
@@ -51,5 +57,4 @@ match
 update
   $group-membership has rank "member";
   $group-membership links (group: $group);
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/pipelines/with.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/with.adoc
@@ -1,4 +1,5 @@
 = Preamble
+:test-typeql: linear
 
 The preamble of a pipeline allows the local declaration of functions using `with` statements.
 These functions can be called from the pipeline, and from other premable functions.
@@ -33,14 +34,20 @@ The usual function validation applies to the function declaration in a with clau
 +
 [,typeql]
 ----
+#!test[schema, commit]
+#{{
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
+#}}
+#!test[read]
 with fun friend_count($user: user) -> integer:
-  match friendship($user, $x)
+  match friendship($user, $x);
   return count;
 match
   $user1 isa user, has username "<name>";
   $user2 isa user, has username $name;
   friend_count($user1) < friend_count($user2);
 select $name;
+#!---
 ----
 
 
@@ -48,18 +55,22 @@ select $name;
 +
 [,typeql]
 ----
+#!test[read]
 with fun friend_count($user: user) -> integer:
-  match friendship($user, $x)
+  match friendship($user, $x);
   return count;
+
 with fun popular_users() -> { user }:
   match
     $x isa user;
     friend_count($x) > 500;
   return { $x };
+
 match
   let $y in popular_users();
   $y has username $pop_name;
 select $pop_name;
+#!---
 ----
 
 

--- a/reference/modules/ROOT/pages/typeql/pipelines/with.adoc
+++ b/reference/modules/ROOT/pages/typeql/pipelines/with.adoc
@@ -29,15 +29,20 @@ The usual function validation applies to the function declaration in a with clau
 
 == Examples
 
+.Schema for the following examples
+[%collapsible]
+====
+[,typeql]
+----
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
+----
+====
 
 1. Find users with more friends than a specific user and return their usernames
 +
 [,typeql]
 ----
-#!test[schema, commit]
-#{{
-include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
-#}}
 #!test[read]
 with fun friend_count($user: user) -> integer:
   match friendship($user, $x);
@@ -47,7 +52,6 @@ match
   $user2 isa user, has username $name;
   friend_count($user1) < friend_count($user2);
 select $name;
-#!---
 ----
 
 
@@ -70,7 +74,6 @@ match
   let $y in popular_users();
   $y has username $pop_name;
 select $pop_name;
-#!---
 ----
 
 

--- a/reference/modules/ROOT/pages/typeql/schema/define.adoc
+++ b/reference/modules/ROOT/pages/typeql/schema/define.adoc
@@ -1,5 +1,6 @@
 = Define query
 :page-aliases: {page-version}@typeql::schema/define.adoc
+:test-typeql: linear
 
 Define queries are used
 // tag::overview[]
@@ -54,19 +55,25 @@ An error is returned (on execution or on commit), and no changes are preserved, 
 .Defining entity types
 [,typeql]
 ----
+#!test[schema, commit]
 define entity user;
+#!---
 ----
 
 .Defining relation types
 [,typeql]
 ----
+#!test[schema, fail_at=commit]
 define relation parentship;
+#!---
 ----
 
 .Defining attribute types
 [,typeql]
 ----
+#!test[schema, fail_at=commit]
 define attribute email;
+#!---
 ----
 
 === Defining interfaces
@@ -74,37 +81,55 @@ define attribute email;
 .Defining relation type's relates
 [,typeql]
 ----
+#!test[schema]
+#{{
+define relation parentship, relates unused-role;
+#}}
+#!test[schema]
 define parentship relates parent, relates child;
+#!---
 ----
 
 .Defining relation types with subtyping
 [,typeql]
 ----
+#!test[schema, commit]
 define relation fathership sub parentship;
+#!---
 ----
 
 .Defining relates with role type specializing
 [,typeql]
 ----
+#!test[schema]
 define fathership relates father as parent;
+#!---
 ----
 
 .Defining roleplaying for multiple roles
 [,typeql]
 ----
+#!test[schema]
 define user plays parentship:parent, plays parentship:child;
+#!---
 ----
 
 .Defining attribute type's value type
 [,typeql]
 ----
+#!test[schema]
+define attribute email @abstract; # cheat.
+#!test[schema]
 define email value string;
+#!---
 ----
 
 .Defining type's ownership
 [,typeql]
 ----
+#!test[schema]
 define user owns email;
+#!---
 ----
 
 === Defining annotations
@@ -112,25 +137,42 @@ define user owns email;
 .Defining type's annotation without arguments
 [,typeql]
 ----
+#!test[schema]
 define parentship @abstract;
+#!---
 ----
 
 .Defining attribute type's annotation and value type's annotation with arguments
 [,typeql]
 ----
+#!test[schema]
 define email @independent, value string @regex("^.*@\w+\.\w+$");
+#!---
 ----
 
 .Defining type's ownership's annotation with arguments
 [,typeql]
 ----
+#!test[schema]
 define user owns email @card(0..2);
+#!---
+----
+
+
+.Defining annotations for relates
+[,typeql]
+----
+#!test[schema]
+define parentship relates parent @abstract;
+#!---
 ----
 
 .Defining annotations for specializing relates
 [,typeql]
 ----
+#!test[schema]
 define fathership relates father as parent @abstract;
+#!---
 ----
 
 === Defining functions

--- a/reference/modules/ROOT/pages/typeql/schema/define.adoc
+++ b/reference/modules/ROOT/pages/typeql/schema/define.adoc
@@ -57,7 +57,6 @@ An error is returned (on execution or on commit), and no changes are preserved, 
 ----
 #!test[schema, commit]
 define entity user;
-#!---
 ----
 
 .Defining relation types
@@ -65,7 +64,6 @@ define entity user;
 ----
 #!test[schema, fail_at=commit]
 define relation parentship;
-#!---
 ----
 
 .Defining attribute types
@@ -73,7 +71,6 @@ define relation parentship;
 ----
 #!test[schema, fail_at=commit]
 define attribute email;
-#!---
 ----
 
 === Defining interfaces
@@ -87,7 +84,6 @@ define relation parentship, relates unused-role;
 #}}
 #!test[schema]
 define parentship relates parent, relates child;
-#!---
 ----
 
 .Defining relation types with subtyping
@@ -95,7 +91,6 @@ define parentship relates parent, relates child;
 ----
 #!test[schema, commit]
 define relation fathership sub parentship;
-#!---
 ----
 
 .Defining relates with role type specializing
@@ -103,7 +98,6 @@ define relation fathership sub parentship;
 ----
 #!test[schema]
 define fathership relates father as parent;
-#!---
 ----
 
 .Defining roleplaying for multiple roles
@@ -111,7 +105,6 @@ define fathership relates father as parent;
 ----
 #!test[schema]
 define user plays parentship:parent, plays parentship:child;
-#!---
 ----
 
 .Defining attribute type's value type
@@ -121,7 +114,6 @@ define user plays parentship:parent, plays parentship:child;
 define attribute email @abstract; # cheat.
 #!test[schema]
 define email value string;
-#!---
 ----
 
 .Defining type's ownership
@@ -129,7 +121,6 @@ define email value string;
 ----
 #!test[schema]
 define user owns email;
-#!---
 ----
 
 === Defining annotations
@@ -139,7 +130,6 @@ define user owns email;
 ----
 #!test[schema]
 define parentship @abstract;
-#!---
 ----
 
 .Defining attribute type's annotation and value type's annotation with arguments
@@ -147,7 +137,6 @@ define parentship @abstract;
 ----
 #!test[schema]
 define email @independent, value string @regex("^.*@\w+\.\w+$");
-#!---
 ----
 
 .Defining type's ownership's annotation with arguments
@@ -155,7 +144,6 @@ define email @independent, value string @regex("^.*@\w+\.\w+$");
 ----
 #!test[schema]
 define user owns email @card(0..2);
-#!---
 ----
 
 
@@ -164,7 +152,6 @@ define user owns email @card(0..2);
 ----
 #!test[schema]
 define parentship relates parent @abstract;
-#!---
 ----
 
 .Defining annotations for specializing relates
@@ -172,7 +159,6 @@ define parentship relates parent @abstract;
 ----
 #!test[schema]
 define fathership relates father as parent @abstract;
-#!---
 ----
 
 === Defining functions

--- a/reference/modules/ROOT/pages/typeql/schema/redefine.adoc
+++ b/reference/modules/ROOT/pages/typeql/schema/redefine.adoc
@@ -1,4 +1,5 @@
 = Redefine query
+:test-typeql: linear
 
 Redefine queries are used
 // tag::overview[]
@@ -44,7 +45,9 @@ An error is returned (on execution or on commit), and no changes are preserved, 
 .Redefining type's sub
 [,typeql]
 ----
+#!test[schema]
 redefine user sub page;
+#!---
 ----
 
 .Redefining attribute type's value type

--- a/reference/modules/ROOT/pages/typeql/schema/redefine.adoc
+++ b/reference/modules/ROOT/pages/typeql/schema/redefine.adoc
@@ -39,7 +39,10 @@ An error is returned (on execution or on commit), and no changes are preserved, 
 * xref:{page-version}@reference::typeql/statements/fun.adoc[`fun` statements] redefine functions, replacing their interfaces and bodies.
 
 == Examples
-////
+
+.Schema for the following examples
+[%collapsible]
+====
 [,typeql]
 ----
 #!test[schema, commit]
@@ -48,10 +51,9 @@ attribute tag value string;
 entity post owns tag @card(0..);
 relation parentship relates parent, relates child;
 relation fathership sub parentship, relates father as child;
-#!---
 ----
+====
 
-////
 === Redefining types' interfaces and annotations
 
 .Redefining type's sub
@@ -59,7 +61,6 @@ relation fathership sub parentship, relates father as child;
 ----
 #!test[schema]
 redefine user sub page;
-#!---
 ----
 
 .Redefining attribute type's value type
@@ -67,7 +68,6 @@ redefine user sub page;
 ----
 #!test[schema]
 redefine karma value integer;
-#!---
 ----
 
 .Redefining value type's annotation with arguments
@@ -75,7 +75,6 @@ redefine karma value integer;
 ----
 #!test[schema]
 redefine email value string @regex("^.*@typedb\.com$");
-#!---
 ----
 
 .Redefining type interface's annotation with arguments
@@ -83,7 +82,6 @@ redefine email value string @regex("^.*@typedb\.com$");
 ----
 #!test[schema]
 redefine post owns tag @card(0..5);
-#!---
 ----
 
 .Redefining relates specialization
@@ -91,7 +89,6 @@ redefine post owns tag @card(0..5);
 ----
 #!test[schema]
 redefine fathership relates father as parent;
-#!---
 ----
 
 === Redefining functions

--- a/reference/modules/ROOT/pages/typeql/schema/redefine.adoc
+++ b/reference/modules/ROOT/pages/typeql/schema/redefine.adoc
@@ -46,8 +46,8 @@ An error is returned (on execution or on commit), and no changes are preserved, 
 include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;extended-attributes]
 attribute tag value string;
 entity post owns tag @card(0..);
-relation parentship relates parent, relates other-role;
-relation fathership sub parentship, relates father as other-role;
+relation parentship relates parent, relates child;
+relation fathership sub parentship, relates father as child;
 #!---
 ----
 

--- a/reference/modules/ROOT/pages/typeql/schema/redefine.adoc
+++ b/reference/modules/ROOT/pages/typeql/schema/redefine.adoc
@@ -39,7 +39,19 @@ An error is returned (on execution or on commit), and no changes are preserved, 
 * xref:{page-version}@reference::typeql/statements/fun.adoc[`fun` statements] redefine functions, replacing their interfaces and bodies.
 
 == Examples
+////
+[,typeql]
+----
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;extended-attributes]
+attribute tag value string;
+entity post owns tag @card(0..);
+relation parentship relates parent, relates other-role;
+relation fathership sub parentship, relates father as other-role;
+#!---
+----
 
+////
 === Redefining types' interfaces and annotations
 
 .Redefining type's sub
@@ -53,25 +65,33 @@ redefine user sub page;
 .Redefining attribute type's value type
 [,typeql]
 ----
+#!test[schema]
 redefine karma value integer;
+#!---
 ----
 
 .Redefining value type's annotation with arguments
 [,typeql]
 ----
+#!test[schema]
 redefine email value string @regex("^.*@typedb\.com$");
+#!---
 ----
 
 .Redefining type interface's annotation with arguments
 [,typeql]
 ----
+#!test[schema]
 redefine post owns tag @card(0..5);
+#!---
 ----
 
 .Redefining relates specialization
 [,typeql]
 ----
+#!test[schema]
 redefine fathership relates father as parent;
+#!---
 ----
 
 === Redefining functions

--- a/reference/modules/ROOT/pages/typeql/schema/undefine.adoc
+++ b/reference/modules/ROOT/pages/typeql/schema/undefine.adoc
@@ -156,7 +156,6 @@ undefine owns email from user;
 ----
 #!test[schema]
 undefine @abstract from parentship;
-#!---
 ----
 
 .Undefining value type's annotation with arguments
@@ -164,7 +163,6 @@ undefine @abstract from parentship;
 ----
 #!test[schema]
 undefine @regex from email value string;
-#!---
 ----
 
 .Undefining type's and type's ownership's annotations
@@ -174,7 +172,6 @@ undefine @regex from email value string;
 undefine
   @card from user owns email;
   @independent from email;
-#!---
 ----
 
 === Undefining functions

--- a/reference/modules/ROOT/pages/typeql/schema/undefine.adoc
+++ b/reference/modules/ROOT/pages/typeql/schema/undefine.adoc
@@ -71,7 +71,10 @@ Only the type of the annotation is required, so annotations with arguments can b
 * xref:{page-version}@reference::typeql/statements/fun.adoc[`fun ...` statements] undefine existing functions.
 
 == Examples
-////
+
+.Schema for the following examples
+[%collapsible]
+====
 [,typeql]
 ----
 #!test[schema, commit]
@@ -83,7 +86,7 @@ relation fathership sub parentship, relates father as parent;
 user plays parentship:parent;
 user owns email @card(0..1);
 ----
-////
+====
 
 === Undefining types
 
@@ -92,7 +95,6 @@ user owns email @card(0..1);
 ----
 #!test[schema, rollback]
 undefine user;
-#!---
 ----
 
 .Undefining types
@@ -100,7 +102,6 @@ undefine user;
 ----
 #!test[schema, rollback]
 undefine fathership; email;
-#!---
 ----
 
 === Undefining interfaces
@@ -110,7 +111,6 @@ undefine fathership; email;
 ----
 #!test[schema]
 undefine relates child from parentship;
-#!---
 ----
 
 .Undefining relates specialization
@@ -118,7 +118,6 @@ undefine relates child from parentship;
 ----
 #!test[schema]
 undefine as parent from fathership relates father;
-#!---
 ----
 
 .Undefining relation type's subtyping
@@ -127,7 +126,6 @@ undefine as parent from fathership relates father;
 #!test[schema]
 # Note, this requires the specialisation to have been undefined first.
 undefine sub parentship from fathership;
-#!---
 ----
 
 .Undefining type's roleplaying
@@ -135,7 +133,6 @@ undefine sub parentship from fathership;
 ----
 #!test[schema]
 undefine plays parentship:parent from user;
-#!---
 ----
 
 .Undefining attribute type's value type
@@ -143,7 +140,6 @@ undefine plays parentship:parent from user;
 ----
 #!test[schema, fail_at=runtime]
 undefine value string from email;
-#!---
 ----
 
 .Undefining type's ownership
@@ -151,7 +147,6 @@ undefine value string from email;
 ----
 #!test[schema, rollback]
 undefine owns email from user;
-#!---
 ----
 
 === Undefining annotations

--- a/reference/modules/ROOT/pages/typeql/schema/undefine.adoc
+++ b/reference/modules/ROOT/pages/typeql/schema/undefine.adoc
@@ -1,5 +1,6 @@
 = Undefine query
 :page-aliases: {page-version}@reference::typeql/queries/undefine.adoc
+:test-typeql: linear
 
 Undefine queries are used
 // tag::overview[]
@@ -70,19 +71,36 @@ Only the type of the annotation is required, so annotations with arguments can b
 * xref:{page-version}@reference::typeql/statements/fun.adoc[`fun ...` statements] undefine existing functions.
 
 == Examples
+////
+[,typeql]
+----
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;extended-attributes]
+attribute tag value string;
+entity post owns tag @card(0..);
+relation parentship @abstract, relates parent, relates child;
+relation fathership sub parentship, relates father as parent;
+user plays parentship:parent;
+user owns email @card(0..1);
+----
+////
 
 === Undefining types
 
 .Undefining a type
 [,typeql]
 ----
+#!test[schema, rollback]
 undefine user;
+#!---
 ----
 
 .Undefining types
 [,typeql]
 ----
-undefine parentship; email;
+#!test[schema, rollback]
+undefine fathership; email;
+#!---
 ----
 
 === Undefining interfaces
@@ -90,37 +108,50 @@ undefine parentship; email;
 .Undefining relation type's relates
 [,typeql]
 ----
+#!test[schema]
 undefine relates child from parentship;
-----
-
-.Undefining relation type's subtyping
-[,typeql]
-----
-undefine sub parentship from fathership;
+#!---
 ----
 
 .Undefining relates specialization
 [,typeql]
 ----
+#!test[schema]
 undefine as parent from fathership relates father;
+#!---
+----
+
+.Undefining relation type's subtyping
+[,typeql]
+----
+#!test[schema]
+# Note, this requires the specialisation to have been undefined first.
+undefine sub parentship from fathership;
+#!---
 ----
 
 .Undefining type's roleplaying
 [,typeql]
 ----
+#!test[schema]
 undefine plays parentship:parent from user;
+#!---
 ----
 
 .Undefining attribute type's value type
 [,typeql]
 ----
+#!test[schema, fail_at=runtime]
 undefine value string from email;
+#!---
 ----
 
 .Undefining type's ownership
 [,typeql]
 ----
+#!test[schema, rollback]
 undefine owns email from user;
+#!---
 ----
 
 === Undefining annotations
@@ -128,21 +159,27 @@ undefine owns email from user;
 .Undefining type's annotation without arguments
 [,typeql]
 ----
+#!test[schema]
 undefine @abstract from parentship;
+#!---
 ----
 
 .Undefining value type's annotation with arguments
 [,typeql]
 ----
+#!test[schema]
 undefine @regex from email value string;
+#!---
 ----
 
 .Undefining type's and type's ownership's annotations
 [,typeql]
 ----
+#!test[schema]
 undefine
   @card from user owns email;
   @independent from email;
+#!---
 ----
 
 === Undefining functions

--- a/reference/modules/ROOT/pages/typeql/statements/attribute.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/attribute.adoc
@@ -11,7 +11,6 @@ The `attribute` keyword can be used to define a type of kind `attribute`.
 ----
 #!test[schema, fail_at=commit]
 define attribute name;
-#!---
 ----
 
 == Matching attributes
@@ -22,5 +21,4 @@ The `attribute` keyword can be used to match all types of kind `attribute`.
 ----
 #!test[read]
 match attribute $a;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/attribute.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/attribute.adoc
@@ -1,4 +1,5 @@
 = `attribute` statement
+:test-typeql: linear
 
 The statement `attribute <LABEL>` is used to identify the `<LABEL>` as a type of kind `attribute`.
 
@@ -8,7 +9,9 @@ The `attribute` keyword can be used to define a type of kind `attribute`.
 
 [,typeql]
 ----
+#!test[schema, fail_at=commit]
 define attribute name;
+#!---
 ----
 
 == Matching attributes
@@ -17,5 +20,7 @@ The `attribute` keyword can be used to match all types of kind `attribute`.
 
 [,typeql]
 ----
+#!test[read]
 match attribute $a;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/entity.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/entity.adoc
@@ -11,7 +11,6 @@ The `entity` keyword can be used to define a type of kind `entity`.
 ----
 #!test[schema]
 define entity user;
-#!---
 ----
 
 == Matching entities
@@ -22,5 +21,4 @@ The `entity` keyword can be used to match all types of kind `entity`.
 ----
 #!test[read]
 match entity $e;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/entity.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/entity.adoc
@@ -1,4 +1,5 @@
 = `entity` statement
+:test-typeql: linear
 
 The statement `entity <LABEL>` is used to identify the `<LABEL>` as a type of kind `entity`.
 
@@ -8,7 +9,9 @@ The `entity` keyword can be used to define a type of kind `entity`.
 
 [,typeql]
 ----
+#!test[schema, fail_at=commit]
 define entity user;
+#!---
 ----
 
 == Matching entities
@@ -17,5 +20,7 @@ The `entity` keyword can be used to match all types of kind `entity`.
 
 [,typeql]
 ----
+#!test[read]
 match entity $e;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/entity.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/entity.adoc
@@ -9,7 +9,7 @@ The `entity` keyword can be used to define a type of kind `entity`.
 
 [,typeql]
 ----
-#!test[schema, fail_at=commit]
+#!test[schema]
 define entity user;
 #!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/has.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/has.adoc
@@ -3,7 +3,9 @@
 
 The statement `<OWNER VAR> has <ATTRIBUTE VAR>` is used to identify the `<OWNER VAR>` as owning the `<ATTRIBUTE VAR>`.
 
-////
+.Schema for the following examples
+[%collapsible]
+====
 [,typeql]
 ----
 #!test[schema]
@@ -11,7 +13,7 @@ define
 attribute name, value string;
 entity person, owns name;
 ----
-////
+====
 
 == Inserting attribute ownership
 
@@ -19,26 +21,22 @@ The `has` keyword can be used to attach an attribute to an object.
 
 [,typeql]
 ----
-insert $person has $name;
-
 #!test[write]
 #{{
 match $person isa person; $name isa name;
-insert $person has $name;
 #}}
+insert $person has $name;
 ----
 
 An attribute can be created in-place by providing its type and value.
 
 [,typeql]
 ----
-insert $person has name "Alice";
-
 #!test[write]
 #{{
 match $person isa person;
-insert $person has name "Alice";
 #}}
+insert $person has name "Alice";
 ----
 
 == Deleting attribute ownership
@@ -47,13 +45,11 @@ The `has` keyword is used to remove an attribute from its owner.
 
 [,typeql]
 ----
-delete has $name of $person;
-
 #!test[write]
 #{{
 match $person isa person, has name $name;
-delete has $name of $person;
 #}}
+delete has $name of $person;
 ----
 
 == Matching attributes

--- a/reference/modules/ROOT/pages/typeql/statements/has.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/has.adoc
@@ -1,6 +1,18 @@
 = `has` statement
+:test-typeql: linear
 
 The statement `<OWNER VAR> has <ATTRIBUTE VAR>` is used to identify the `<OWNER VAR>` as owning the `<ATTRIBUTE VAR>`.
+
+////
+[,typeql]
+----
+#!test[schema]
+define
+attribute name, value string;
+entity person, owns name;
+#!---
+----
+////
 
 == Inserting attribute ownership
 
@@ -9,6 +21,12 @@ The `has` keyword can be used to attach an attribute to an object.
 [,typeql]
 ----
 insert $person has $name;
+
+#!test[write]
+#{{
+match $person isa person; $name isa name;
+insert $person has $name;
+#}}
 ----
 
 An attribute can be created in-place by providing its type and value.
@@ -16,6 +34,12 @@ An attribute can be created in-place by providing its type and value.
 [,typeql]
 ----
 insert $person has name "Alice";
+
+#!test[write]
+#{{
+match $person isa person;
+insert $person has name "Alice";
+#}}
 ----
 
 == Deleting attribute ownership
@@ -25,6 +49,12 @@ The `has` keyword is used to remove an attribute from its owner.
 [,typeql]
 ----
 delete has $name of $person;
+
+#!test[write]
+#{{
+match $person isa person, has name $name;
+delete has $name of $person;
+#}}
 ----
 
 == Matching attributes
@@ -33,27 +63,35 @@ The `has` keyword can be used to match attributes of an object.
 
 [,typeql]
 ----
+#!test[read]
 match $person has $name;
+#!---
 ----
 
 The attribute type may be provided.
 
 [,typeql]
 ----
+#!test[read]
 match $person has name $name;
+#!---
 ----
 
 The attribute can be matched by attribute type and value instead of binding it to a variable.
 
 [,typeql]
 ----
+#!test[read]
 match $person has name "Alice";
+#!---
 ----
 
 Alternatively, a comparison can be used to constrain the attribute value.
 
 [,typeql]
 ----
+#!test[read]
 match $person has name < "Bob";
+#!---
 ----
 

--- a/reference/modules/ROOT/pages/typeql/statements/has.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/has.adoc
@@ -10,7 +10,6 @@ The statement `<OWNER VAR> has <ATTRIBUTE VAR>` is used to identify the `<OWNER 
 define
 attribute name, value string;
 entity person, owns name;
-#!---
 ----
 ////
 
@@ -65,7 +64,6 @@ The `has` keyword can be used to match attributes of an object.
 ----
 #!test[read]
 match $person has $name;
-#!---
 ----
 
 The attribute type may be provided.
@@ -74,7 +72,6 @@ The attribute type may be provided.
 ----
 #!test[read]
 match $person has name $name;
-#!---
 ----
 
 The attribute can be matched by attribute type and value instead of binding it to a variable.
@@ -83,7 +80,6 @@ The attribute can be matched by attribute type and value instead of binding it t
 ----
 #!test[read]
 match $person has name "Alice";
-#!---
 ----
 
 Alternatively, a comparison can be used to constrain the attribute value.
@@ -92,6 +88,5 @@ Alternatively, a comparison can be used to constrain the attribute value.
 ----
 #!test[read]
 match $person has name < "Bob";
-#!---
 ----
 

--- a/reference/modules/ROOT/pages/typeql/statements/iid.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/iid.adoc
@@ -3,7 +3,9 @@
 
 The constraint `$c iid <IID>` matches the stored concept with the provided internal ID (IID).
 
-////
+.Schema for the following examples
+[%collapsible]
+====
 [,typeql]
 ----
 #!test[schema]
@@ -11,7 +13,7 @@ define
 attribute name, value string;
 entity person, owns name;
 ----
-////
+====
 
 == Inserting IIDs
 

--- a/reference/modules/ROOT/pages/typeql/statements/iid.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/iid.adoc
@@ -1,6 +1,18 @@
 = `iid` statement
+:test-typeql: linear
 
 The constraint `$c iid <IID>` matches the stored concept with the provided internal ID (IID).
+
+////
+[,typeql]
+----
+#!test[schema]
+define
+attribute name, value string;
+entity person, owns name;
+#!---
+----
+////
 
 == Inserting IIDs
 
@@ -8,7 +20,9 @@ When a concept is inserted, it is assigned an IID automatically.
 
 [,typeql]
 ----
-insert $user isa user;
+#!test[write]
+insert $user isa person;
+#!---
 ----
 
 .Example TypeDB Console output
@@ -25,5 +39,7 @@ insert $user isa user;
 
 [,typeql]
 ----
+#!test[read]
 match $x iid 0x1f0005000000000000012f;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/iid.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/iid.adoc
@@ -10,7 +10,6 @@ The constraint `$c iid <IID>` matches the stored concept with the provided inter
 define
 attribute name, value string;
 entity person, owns name;
-#!---
 ----
 ////
 
@@ -22,7 +21,6 @@ When a concept is inserted, it is assigned an IID automatically.
 ----
 #!test[write]
 insert $user isa person;
-#!---
 ----
 
 .Example TypeDB Console output
@@ -41,5 +39,4 @@ insert $user isa person;
 ----
 #!test[read]
 match $x iid 0x1f0005000000000000012f;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/isa.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/isa.adoc
@@ -3,7 +3,9 @@
 
 The statement `<VAR> isa <TYPE>` is used to identify the `<VAR>` as an instance of `<TYPE>`.
 
-////
+.Schema for the following examples
+[%collapsible]
+====
 [,typeql]
 ----
 #!test[schema]
@@ -11,7 +13,7 @@ define
 attribute name, value string;
 entity person, owns name;
 ----
-////
+====
 
 == Inserting instance of type
 
@@ -30,13 +32,11 @@ Simply delete the variable that is bound to the instance.
 
 [,typeql]
 ----
-delete $person;
-
 #!test[write]
 #{{
 match $person isa person;
-delete $person;
 #}}
+delete $person;
 ----
 
 == Matching

--- a/reference/modules/ROOT/pages/typeql/statements/isa.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/isa.adoc
@@ -1,6 +1,18 @@
 = `isa` statement
+:test-typeql: linear
 
 The statement `<VAR> isa <TYPE>` is used to identify the `<VAR>` as an instance of `<TYPE>`.
+
+////
+[,typeql]
+----
+#!test[schema]
+define
+attribute name, value string;
+entity person, owns name;
+#!---
+----
+////
 
 == Inserting instance of type
 
@@ -8,16 +20,25 @@ The `isa` keyword can be used to create a new instance of a given type.
 
 [,typeql]
 ----
+#!test[write]
 insert $person isa person;
+#!---
 ----
 
 == Deleting instance of type
 
-The `isa` keyword is not used to delete an instance of type. Simply delete the variable that is bound to the instance.
+Unlike in TypeDB 2, the `isa` keyword is no longer used to delete an instance of type.
+Simply delete the variable that is bound to the instance.
 
 [,typeql]
 ----
 delete $person;
+
+#!test[write]
+#{{
+match $person isa person;
+delete $person;
+#}}
 ----
 
 == Matching
@@ -28,14 +49,18 @@ The `isa` keyword can be used to match all instances of a given type and its sub
 
 [,typeql]
 ----
+#!test[read]
 match $person isa person;
+#!---
 ----
 
 The `isa!` keyword can be used to match all instances of a type _excluding subtypes._
 
 [,typeql]
 ----
+#!test[read]
 match $person isa! person;
+#!---
 ----
 
 === Matching types of an instance
@@ -44,12 +69,16 @@ The `isa` keyword can be used to match all types of an instance.
 
 [,typeql]
 ----
+#!test[read]
 match $person isa $type;
+#!---
 ----
 
 The `isa!` keyword can be used to match the exact type of an instance.
 
 [,typeql]
 ----
+#!test[read]
 match $person isa! $type;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/isa.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/isa.adoc
@@ -10,7 +10,6 @@ The statement `<VAR> isa <TYPE>` is used to identify the `<VAR>` as an instance 
 define
 attribute name, value string;
 entity person, owns name;
-#!---
 ----
 ////
 
@@ -22,7 +21,6 @@ The `isa` keyword can be used to create a new instance of a given type.
 ----
 #!test[write]
 insert $person isa person;
-#!---
 ----
 
 == Deleting instance of type
@@ -51,7 +49,6 @@ The `isa` keyword can be used to match all instances of a given type and its sub
 ----
 #!test[read]
 match $person isa person;
-#!---
 ----
 
 The `isa!` keyword can be used to match all instances of a type _excluding subtypes._
@@ -60,7 +57,6 @@ The `isa!` keyword can be used to match all instances of a type _excluding subty
 ----
 #!test[read]
 match $person isa! person;
-#!---
 ----
 
 === Matching types of an instance
@@ -71,7 +67,6 @@ The `isa` keyword can be used to match all types of an instance.
 ----
 #!test[read]
 match $person isa $type;
-#!---
 ----
 
 The `isa!` keyword can be used to match the exact type of an instance.
@@ -80,5 +75,4 @@ The `isa!` keyword can be used to match the exact type of an instance.
 ----
 #!test[read]
 match $person isa! $type;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/label.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/label.adoc
@@ -1,5 +1,6 @@
 = `label` statement
 :page-aliases: {page-version}@reference::typeql/statements/type.adoc
+:test-typeql: linear
 
 The constraint `$t label <LABEL>` matches all types `$t` that have the label (name) `<LABEL>`.
 
@@ -9,12 +10,16 @@ The `label` keyword is only used when matching on a type label. The type label i
 
 [,typeql]
 ----
+#!test[schema]
 define entity user;
+#!---
 ----
 
 == Matching type labels
 
 [,typeql]
 ----
+#!test[schema]
 match $t label user;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/label.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/label.adoc
@@ -12,7 +12,6 @@ The `label` keyword is only used when matching on a type label. The type label i
 ----
 #!test[schema]
 define entity user;
-#!---
 ----
 
 == Matching type labels
@@ -21,5 +20,4 @@ define entity user;
 ----
 #!test[schema]
 match $t label user;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/let-eq.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/let-eq.adoc
@@ -8,7 +8,9 @@ The expression can be a literal, an arithmetic expression, or a single valued fu
 
 If the function returns a tuple, multiple variables must be specified on the left hand side of the assignment.
 
-////
+.Schema for the following examples
+[%collapsible]
+====
 [,typeql]
 ----
 #!test[schema, commit]
@@ -19,7 +21,7 @@ match
 { $a > $b; let $min = $b; let $max = $a; };
 return first $min, $max;
 ----
-////
+====
 
 [,typeql]
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/let-eq.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/let-eq.adoc
@@ -1,5 +1,6 @@
 = `let ... =` statement
 :page-aliases: {page-version}@reference::typeql/statements/value-assignment.adoc, {page-version}@reference::typeql/values/value-variables.adoc
+:test-typeql: linear
 
 The statement `let <VAR> = <EXPRESSION>` assigns the result of a single valued expression `<EXPRESSION>` to the variable `<VAR>`.
 
@@ -7,7 +8,24 @@ The expression can be a literal, an arithmetic expression, or a single valued fu
 
 If the function returns a tuple, multiple variables must be specified on the left hand side of the assignment.
 
+////
 [,typeql]
 ----
-let $x, $y = minmax($a, $b);
+#!test[schema, commit]
+define
+fun minmax($a: integer, $b: integer) -> integer, integer:
+match
+{ $a <= $b; let $min = $a; let $max = $b; } or
+{ $a > $b; let $min = $b; let $max = $a; };
+return first $min, $max;
+#!---
+----
+////
+
+[,typeql]
+----
+#!test[read]
+match
+  let $x, $y = minmax(3 * 5, 4 * 4);
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/let-eq.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/let-eq.adoc
@@ -18,7 +18,6 @@ match
 { $a <= $b; let $min = $a; let $max = $b; } or
 { $a > $b; let $min = $b; let $max = $a; };
 return first $min, $max;
-#!---
 ----
 ////
 
@@ -27,5 +26,4 @@ return first $min, $max;
 #!test[read]
 match
   let $x, $y = minmax(3 * 5, 4 * 4);
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/let-in.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/let-in.adoc
@@ -7,7 +7,26 @@ The expression can only be a call to a function that returns a stream of answers
 
 If each tuple in the stream contains more than one value, multiple variables must be specified of the left hand side of the assignment.
 
+.Schema for the following examples
+[%collapsible]
+====
 [,typeql]
 ----
+#!test[schema, commit]
+define
+entity person;
+entity company;
+# Dummy definition
+fun past-employments($person: person) -> { integer, company }:
+match
+  let $year = 2000;
+  $company isa company;
+return {$year, $company};
+----
+====
+
+[,typeql]
+----
+#!test[read]
 let $year, $company in past-employments($person);
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/links.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/links.adoc
@@ -5,7 +5,9 @@
 The statement `<RELATION VAR> links (<ROLE>: <PLAYER VAR> [ , ... ])` is used to identify the `<PLAYER VAR>` as playing `<ROLE>` in the `<RELATION
 VAR>`.
 
-////
+.Schema for the following examples
+[%collapsible]
+====
 [,typeql]
 ----
 #!test[schema, commit]
@@ -13,7 +15,7 @@ define
 relation friendship, relates friend @card(0..2);
 entity user, plays friendship:friend;
 ----
-////
+====
 
 == Inserting a role player
 
@@ -21,26 +23,22 @@ The `links` keyword can be used to attach a role player to a relation instance.
 
 [,typeql]
 ----
-insert $friendship links (friend: $person);
-
 #!test[write]
 #{{
 match $person isa user; $friendship isa friendship;
-insert $friendship links (friend: $person);
 #}}
+insert $friendship links (friend: $person);
 ----
 
 Multiple role players can be attached in the same statement.
 
 [,typeql]
 ----
-insert $friendship links (friend: $alice, friend: $bob);
-
 #!test[write]
 #{{
 match $alice isa user; $bob isa user; $friendship isa friendship;
-insert $friendship links (friend: $alice, friend: $bob);
 #}}
+insert $friendship links (friend: $alice, friend: $bob);
 ----
 
 == Deleting a role player
@@ -49,26 +47,22 @@ The `links` keyword is used to remove a role player from a relation instance.
 
 [,typeql]
 ----
-delete links ($person) of $friendship;
-
 #!test[write]
 #{{
 match $friendship isa friendship, links ($person);
-delete links ($person) of $friendship;
 #}}
+delete links ($person) of $friendship;
 ----
 
 Multiple role players can be removed in the same statement.
 
 [,typeql]
 ----
-delete links ($alice, $bob) of $friendship;
-
 #!test[write]
 #{{
 match $friendship isa friendship, links (friend: $alice, friend: $bob);
-delete links ($alice, $bob) of $friendship;
 #}}
+delete links ($alice, $bob) of $friendship;
 ----
 
 == Matching role players

--- a/reference/modules/ROOT/pages/typeql/statements/links.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/links.adoc
@@ -1,8 +1,20 @@
 = `links` statement
 :page-aliases: {page-version}@reference::typeql/statements/role-assignment.adoc
+:test-typeql: linear
 
 The statement `<RELATION VAR> links (<ROLE>: <PLAYER VAR> [ , ... ])` is used to identify the `<PLAYER VAR>` as playing `<ROLE>` in the `<RELATION
 VAR>`.
+
+////
+[,typeql]
+----
+#!test[schema, commit]
+define
+relation friendship, relates friend @card(0..2);
+entity user, plays friendship:friend;
+#!---
+----
+////
 
 == Inserting a role player
 
@@ -11,6 +23,12 @@ The `links` keyword can be used to attach a role player to a relation instance.
 [,typeql]
 ----
 insert $friendship links (friend: $person);
+
+#!test[write]
+#{{
+match $person isa user; $friendship isa friendship;
+insert $friendship links (friend: $person);
+#}}
 ----
 
 Multiple role players can be attached in the same statement.
@@ -18,6 +36,12 @@ Multiple role players can be attached in the same statement.
 [,typeql]
 ----
 insert $friendship links (friend: $alice, friend: $bob);
+
+#!test[write]
+#{{
+match $alice isa user; $bob isa user; $friendship isa friendship;
+insert $friendship links (friend: $alice, friend: $bob);
+#}}
 ----
 
 == Deleting a role player
@@ -27,6 +51,12 @@ The `links` keyword is used to remove a role player from a relation instance.
 [,typeql]
 ----
 delete links ($person) of $friendship;
+
+#!test[write]
+#{{
+match $friendship isa friendship, links ($person);
+delete links ($person) of $friendship;
+#}}
 ----
 
 Multiple role players can be removed in the same statement.
@@ -34,6 +64,12 @@ Multiple role players can be removed in the same statement.
 [,typeql]
 ----
 delete links ($alice, $bob) of $friendship;
+
+#!test[write]
+#{{
+match $friendship isa friendship, links (friend: $alice, friend: $bob);
+delete links ($alice, $bob) of $friendship;
+#}}
 ----
 
 == Matching role players
@@ -42,27 +78,35 @@ The `links` keyword can be used to match relations along with their role players
 
 [,typeql]
 ----
+#!test[read]
 match $friendship links (friend: $person);
+#!---
 ----
 
 The role specifiers may be variables as well.
 
 [,typeql]
 ----
+#!test[read]
 match $friendship links ($role: $person);
+#!---
 ----
 
 Note that the role label is not required.
 
 [,typeql]
 ----
+#!test[read]
 match $friendship links ($person);
+#!---
 ----
 
 If a relation binding is not required, the relation type shorthand can be used directly instead.
 
 [,typeql]
 ----
+#!test[read]
 match friendship ($alice, $bob);
+#!---
 ----
 

--- a/reference/modules/ROOT/pages/typeql/statements/links.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/links.adoc
@@ -12,7 +12,6 @@ VAR>`.
 define
 relation friendship, relates friend @card(0..2);
 entity user, plays friendship:friend;
-#!---
 ----
 ////
 
@@ -80,7 +79,6 @@ The `links` keyword can be used to match relations along with their role players
 ----
 #!test[read]
 match $friendship links (friend: $person);
-#!---
 ----
 
 The role specifiers may be variables as well.
@@ -89,7 +87,6 @@ The role specifiers may be variables as well.
 ----
 #!test[read]
 match $friendship links ($role: $person);
-#!---
 ----
 
 Note that the role label is not required.
@@ -98,7 +95,6 @@ Note that the role label is not required.
 ----
 #!test[read]
 match $friendship links ($person);
-#!---
 ----
 
 If a relation binding is not required, the relation type shorthand can be used directly instead.
@@ -107,6 +103,5 @@ If a relation binding is not required, the relation type shorthand can be used d
 ----
 #!test[read]
 match friendship ($alice, $bob);
-#!---
 ----
 

--- a/reference/modules/ROOT/pages/typeql/statements/owns.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/owns.adoc
@@ -3,7 +3,9 @@
 
 The statement `<LABEL> owns <ATTRIBUTE LABEL>` is used to identify the `<LABEL>` type as an owner of `<ATTRIBUTE LABEL>`.
 
-////
+.Schema for the following examples
+[%collapsible]
+====
 [,typeql]
 ----
 #!test[schema, commit]
@@ -11,7 +13,7 @@ define
 entity user;
 attribute email value string;
 ----
-////
+====
 
 == Defining ownership
 

--- a/reference/modules/ROOT/pages/typeql/statements/owns.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/owns.adoc
@@ -10,7 +10,6 @@ The statement `<LABEL> owns <ATTRIBUTE LABEL>` is used to identify the `<LABEL>`
 define
 entity user;
 attribute email value string;
-#!---
 ----
 ////
 
@@ -22,7 +21,6 @@ The `owns` keyword can be used to define a type as an owner of an attribute type
 ----
 #!test[schema]
 define user owns email;
-#!---
 ----
 
 // TODO: Redefining when ordering is introduced
@@ -35,7 +33,6 @@ The `owns` keyword can be used to undefine a type's ownership of an attribute ty
 ----
 #!test[schema]
 undefine owns email from user;
-#!---
 ----
 
 == Matching
@@ -48,7 +45,6 @@ The `owns` keyword can be used to match all attribute types a type owns.
 ----
 #!test[read]
 match user owns $a;
-#!---
 ----
 
 === Matching owner types
@@ -59,5 +55,4 @@ The `owns` keyword can be used to match all owner types for an attribute type.
 ----
 #!test[read]
 match $o owns email;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/owns.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/owns.adoc
@@ -1,6 +1,18 @@
 = `owns` statement
+:test-typeql: linear
 
 The statement `<LABEL> owns <ATTRIBUTE LABEL>` is used to identify the `<LABEL>` type as an owner of `<ATTRIBUTE LABEL>`.
+
+////
+[,typeql]
+----
+#!test[schema, commit]
+define
+entity user;
+attribute email value string;
+#!---
+----
+////
 
 == Defining ownership
 
@@ -8,7 +20,9 @@ The `owns` keyword can be used to define a type as an owner of an attribute type
 
 [,typeql]
 ----
+#!test[schema]
 define user owns email;
+#!---
 ----
 
 // TODO: Redefining when ordering is introduced
@@ -19,7 +33,9 @@ The `owns` keyword can be used to undefine a type's ownership of an attribute ty
 
 [,typeql]
 ----
+#!test[schema]
 undefine owns email from user;
+#!---
 ----
 
 == Matching
@@ -30,7 +46,9 @@ The `owns` keyword can be used to match all attribute types a type owns.
 
 [,typeql]
 ----
+#!test[read]
 match user owns $a;
+#!---
 ----
 
 === Matching owner types
@@ -39,5 +57,7 @@ The `owns` keyword can be used to match all owner types for an attribute type.
 
 [,typeql]
 ----
+#!test[read]
 match $o owns email;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/plays.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/plays.adoc
@@ -10,7 +10,6 @@ The statement `<LABEL> plays <SCOPED ROLE LABEL>` is used to identify the `<LABE
 define
 relation parentship, relates parent, relates child;
 entity user, plays parentship:child;
-#!---
 ----
 ////
 
@@ -23,7 +22,6 @@ Note that a scope is required to resolve role type names ambiguity.
 ----
 #!test[schema]
 define user plays parentship:parent;
-#!---
 ----
 
 == Undefining role players
@@ -34,7 +32,6 @@ The `plays` keyword can be used to undefine a type's role.
 ----
 #!test[schema]
 undefine plays parentship:parent from user;
-#!---
 ----
 
 == Matching
@@ -47,7 +44,6 @@ The `plays` keyword can be used to match all role types a type plays.
 ----
 #!test[schema]
 match user plays $r;
-#!---
 ----
 
 === Matching role player types
@@ -67,5 +63,4 @@ The previous query can return results for different role types with the same `<L
 ----
 #!test[schema]
 match $rp plays parentship:parent;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/plays.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/plays.adoc
@@ -1,6 +1,18 @@
 = `plays` statement
+:test-typeql: linear
 
 The statement `<LABEL> plays <SCOPED ROLE LABEL>` is used to identify the `<LABEL>` type as a role player of `<SCOPED ROLE LABEL>`.
+
+////
+[,typeql]
+----
+#!test[schema, commit]
+define
+relation parentship, relates parent, relates child;
+entity user, plays parentship:child;
+#!---
+----
+////
 
 == Defining role players
 
@@ -9,7 +21,9 @@ Note that a scope is required to resolve role type names ambiguity.
 
 [,typeql]
 ----
+#!test[schema]
 define user plays parentship:parent;
+#!---
 ----
 
 == Undefining role players
@@ -18,7 +32,9 @@ The `plays` keyword can be used to undefine a type's role.
 
 [,typeql]
 ----
+#!test[schema]
 undefine plays parentship:parent from user;
+#!---
 ----
 
 == Matching
@@ -29,7 +45,9 @@ The `plays` keyword can be used to match all role types a type plays.
 
 [,typeql]
 ----
+#!test[schema]
 match user plays $r;
+#!---
 ----
 
 === Matching role player types
@@ -38,6 +56,7 @@ The `plays` keyword can be used to match all role player types for a role type w
 
 [,typeql]
 ----
+#!test[schema]
 match $rp plays parent;
 ----
 
@@ -46,5 +65,7 @@ The previous query can return results for different role types with the same `<L
 
 [,typeql]
 ----
+#!test[schema]
 match $rp plays parentship:parent;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/plays.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/plays.adoc
@@ -3,7 +3,9 @@
 
 The statement `<LABEL> plays <SCOPED ROLE LABEL>` is used to identify the `<LABEL>` type as a role player of `<SCOPED ROLE LABEL>`.
 
-////
+.Schema for the following examples
+[%collapsible]
+====
 [,typeql]
 ----
 #!test[schema, commit]
@@ -11,7 +13,7 @@ define
 relation parentship, relates parent, relates child;
 entity user, plays parentship:child;
 ----
-////
+====
 
 == Defining role players
 

--- a/reference/modules/ROOT/pages/typeql/statements/relates.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/relates.adoc
@@ -5,18 +5,24 @@ The statement `<RELATION LABEL> relates <LABEL>` is used to identify the `<LABEL
 
 It can be extended to `<RELATION LABEL> relates <LABEL> as <SPECIALIZED LABEL>` to specify specialization between two role types. `SPECIALIZED LABEL>` should be inherited by `<RELATION LABEL>` from a supertype. `<LABEL>` becomes a subtype of `<SPECIALIZED LABEL>`, and the `<RELATION LABEL>` instances do no longer accept role players of `<SPECIALIZED LABEL>`. `<LABEL>` is called **specializing relates**, and `<SPECIALIZED LABEL>` is called **specialized relates**.
 
+.Schema for the following examples
+[%collapsible]
+====
+[,typeql]
+----
+#!test[schema, commit]
+define
+  relation parentship, relates child;
+  relation fathership sub parentship;
+----
+====
+
 == Defining role types
 
 The `relates` keyword can be used to define a role type for a relation type.
 
 [,typeql]
 ----
-#!test[schema]
-#{{
-define
-  relation parentship, relates child;
-  relation fathership sub parentship;
-#}}
 #!test[schema]
 define parentship relates parent;
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/relates.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/relates.adoc
@@ -1,4 +1,5 @@
 = `relates` statement
+:test-typeql: linear
 
 The statement `<RELATION LABEL> relates <LABEL>` is used to identify the `<LABEL>` as a role type related by `<RELATION LABEL>`.
 
@@ -10,7 +11,15 @@ The `relates` keyword can be used to define a role type for a relation type.
 
 [,typeql]
 ----
+#!test[schema]
+#{{
+define
+  relation parentship, relates child;
+  relation fathership sub parentship;
+#}}
+#!test[schema]
 define parentship relates parent;
+#!---
 ----
 
 === Defining specializing role types
@@ -19,7 +28,9 @@ The `relates ... as` construction can be used to define a role type specializing
 
 [,typeql]
 ----
+#!test[schema, commit]
 define fathership relates father as parent;
+#!---
 ----
 
 // TODO: Redefining when ordering is introduced
@@ -30,7 +41,9 @@ The `relates ... as` construction can be used to define a role type specializing
 
 [,typeql]
 ----
+#!test[schema, rollback]
 redefine fathership relates father as child;
+#!---
 ----
 
 == Undefining role types
@@ -39,7 +52,13 @@ The `relates` keyword can be used to undefine a role type from a relation.
 
 [,typeql]
 ----
+#!test[schema]
+#{{
+undefine as parent from fathership relates father;
+#}}
+#!test[schema, rollback]
 undefine relates parent from parentship;
+#!---
 ----
 
 === Undefining role types specialization
@@ -48,7 +67,13 @@ The `relates ... as` construction can be used to undefine a role type specializa
 
 [,typeql]
 ----
+#!test[schema]
+#{{
+define fathership relates father as parent;
+#}}
+#!test[schema]
 undefine as parent from fathership relates father;
+#!---
 ----
 
 == Matching
@@ -59,7 +84,9 @@ The `relates` keyword can be used to match all role types related by a relation 
 
 [,typeql]
 ----
+#!test[schema]
 match parentship relates $r;
+#!---
 ----
 
 === Matching relation types
@@ -68,7 +95,9 @@ The `relates` keyword can be used to match all relation types for a role type wi
 
 [,typeql]
 ----
+#!test[schema]
 match $r relates parent;
+#!---
 ----
 
 Note that a scope can be used to have more specific results.
@@ -76,5 +105,7 @@ The previous query can return results for different role types with the same `<L
 
 [,typeql]
 ----
+#!test[schema]
 match $r relates parentship:parent;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/relates.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/relates.adoc
@@ -19,7 +19,6 @@ define
 #}}
 #!test[schema]
 define parentship relates parent;
-#!---
 ----
 
 === Defining specializing role types
@@ -30,7 +29,6 @@ The `relates ... as` construction can be used to define a role type specializing
 ----
 #!test[schema, commit]
 define fathership relates father as parent;
-#!---
 ----
 
 // TODO: Redefining when ordering is introduced
@@ -43,7 +41,6 @@ The `relates ... as` construction can be used to define a role type specializing
 ----
 #!test[schema, rollback]
 redefine fathership relates father as child;
-#!---
 ----
 
 == Undefining role types
@@ -58,7 +55,6 @@ undefine as parent from fathership relates father;
 #}}
 #!test[schema, rollback]
 undefine relates parent from parentship;
-#!---
 ----
 
 === Undefining role types specialization
@@ -73,7 +69,6 @@ define fathership relates father as parent;
 #}}
 #!test[schema]
 undefine as parent from fathership relates father;
-#!---
 ----
 
 == Matching
@@ -86,7 +81,6 @@ The `relates` keyword can be used to match all role types related by a relation 
 ----
 #!test[schema]
 match parentship relates $r;
-#!---
 ----
 
 === Matching relation types
@@ -97,7 +91,6 @@ The `relates` keyword can be used to match all relation types for a role type wi
 ----
 #!test[schema]
 match $r relates parent;
-#!---
 ----
 
 Note that a scope can be used to have more specific results.
@@ -107,5 +100,4 @@ The previous query can return results for different role types with the same `<L
 ----
 #!test[schema]
 match $r relates parentship:parent;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/relation.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/relation.adoc
@@ -1,4 +1,5 @@
 = `relation` statement
+:test-typeql: linear
 
 The statement `relation <LABEL>` is used to identify the `<LABEL>` as a type of kind `relation`.
 
@@ -8,7 +9,9 @@ The `relation` keyword can be used to define a type of kind `relation`.
 
 [,typeql]
 ----
+#!test[schema, fail_at=commit]
 define relation parentship;
+#!---
 ----
 
 == Matching relations
@@ -17,5 +20,7 @@ The `relation` keyword can be used to match all types of kind `relation`.
 
 [,typeql]
 ----
+#!test[schema]
 match relation $r;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/relation.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/relation.adoc
@@ -11,7 +11,6 @@ The `relation` keyword can be used to define a type of kind `relation`.
 ----
 #!test[schema, fail_at=commit]
 define relation parentship;
-#!---
 ----
 
 == Matching relations
@@ -22,5 +21,4 @@ The `relation` keyword can be used to match all types of kind `relation`.
 ----
 #!test[schema]
 match relation $r;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/sub.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/sub.adoc
@@ -3,13 +3,15 @@
 
 The statement `<LABEL> sub <SUPERTYPE LABEL>` is used to identify the `<LABEL>` type as a subtype of `<SUPERTYPE LABEL>`.
 
-////
+.Schema for the following examples
+[%collapsible]
+====
 [,typeql]
 ----
 #!test[schema]
 define entity profile; entity user;
 ----
-////
+====
 
 == Defining subtyping
 

--- a/reference/modules/ROOT/pages/typeql/statements/sub.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/sub.adoc
@@ -8,7 +8,6 @@ The statement `<LABEL> sub <SUPERTYPE LABEL>` is used to identify the `<LABEL>` 
 ----
 #!test[schema]
 define entity profile; entity user;
-#!---
 ----
 ////
 
@@ -20,7 +19,6 @@ The `sub` keyword can be used to define a type as a subtype of another type.
 ----
 #!test[schema]
 define user sub profile;
-#!---
 ----
 
 == Undefining subtyping
@@ -31,7 +29,6 @@ The `sub` keyword can be used to undefine a type's subtyping of a type.
 ----
 #!test[schema]
 undefine sub profile from user;
-#!---
 ----
 
 == Matching
@@ -45,7 +42,6 @@ This will result in all the transitive supertypes, including supertypes of its s
 ----
 #!test[read]
 match user sub $t;
-#!---
 ----
 
 .Example TypeDB Console output
@@ -73,7 +69,6 @@ This will result in only the types with defined `sub` statements, excluding the 
 ----
 #!test[read]
 match user sub! $t;
-#!---
 ----
 
 .Example TypeDB Console output
@@ -95,7 +90,6 @@ This will result in all the transitive subtypes, including subtypes of its subty
 ----
 #!test[read]
 match $t sub profile;
-#!---
 ----
 
 .Example TypeDB Console output
@@ -133,7 +127,6 @@ This will result in only the types with defined `sub` statements, excluding the 
 ----
 #!test[read]
 match $t sub! profile;
-#!---
 ----
 
 .Example TypeDB Console output

--- a/reference/modules/ROOT/pages/typeql/statements/sub.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/sub.adoc
@@ -1,6 +1,16 @@
 = `sub` statement
+:test-typeql: linear
 
 The statement `<LABEL> sub <SUPERTYPE LABEL>` is used to identify the `<LABEL>` type as a subtype of `<SUPERTYPE LABEL>`.
+
+////
+[,typeql]
+----
+#!test[schema]
+define entity profile; entity user;
+#!---
+----
+////
 
 == Defining subtyping
 
@@ -8,7 +18,9 @@ The `sub` keyword can be used to define a type as a subtype of another type.
 
 [,typeql]
 ----
+#!test[schema]
 define user sub profile;
+#!---
 ----
 
 == Undefining subtyping
@@ -17,7 +29,9 @@ The `sub` keyword can be used to undefine a type's subtyping of a type.
 
 [,typeql]
 ----
+#!test[schema]
 undefine sub profile from user;
+#!---
 ----
 
 == Matching
@@ -29,7 +43,9 @@ This will result in all the transitive supertypes, including supertypes of its s
 
 [,typeql]
 ----
+#!test[read]
 match user sub $t;
+#!---
 ----
 
 .Example TypeDB Console output
@@ -55,7 +71,9 @@ This will result in only the types with defined `sub` statements, excluding the 
 
 [,typeql]
 ----
+#!test[read]
 match user sub! $t;
+#!---
 ----
 
 .Example TypeDB Console output
@@ -75,7 +93,9 @@ This will result in all the transitive subtypes, including subtypes of its subty
 
 [,typeql]
 ----
+#!test[read]
 match $t sub profile;
+#!---
 ----
 
 .Example TypeDB Console output
@@ -111,7 +131,9 @@ This will result in only the types with defined `sub` statements, excluding the 
 
 [,typeql]
 ----
+#!test[read]
 match $t sub! profile;
+#!---
 ----
 
 .Example TypeDB Console output

--- a/reference/modules/ROOT/pages/typeql/statements/value.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/value.adoc
@@ -10,7 +10,6 @@ The statement `<LABEL> value <VALUE TYPE>` is used to identify `<VALUE TYPE>` as
 ----
 #!test[schema]
 define attribute name @abstract;
-#!---
 ----
 ////
 
@@ -22,7 +21,6 @@ The `value` keyword can be used to define a value type of an attribute type.
 ----
 #!test[schema]
 define name value string;
-#!---
 ----
 
 == Undefining attribute type's value type
@@ -33,7 +31,6 @@ The `value` keyword can be used to undefine an attribute type's value type.
 ----
 #!test[schema]
 undefine value string from name;
-#!---
 ----
 
 == Matching
@@ -44,5 +41,4 @@ The `value` keyword can be used to match all attribute types with a value type.
 ----
 #!test[read]
 match $a value string;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/value.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/value.adoc
@@ -1,8 +1,18 @@
 = `value` statement
+:test-typeql: linear
 
 The statement `<LABEL> value <VALUE TYPE>` is used to identify `<VALUE TYPE>` as the value type of the `<LABEL>` attribute type.
 
 `<VALUE TYPE>` should be a built-in or a user-defined xref:{page-version}@reference::typeql/values/index.adoc[value type].
+
+////
+[,typeql]
+----
+#!test[schema]
+define attribute name @abstract;
+#!---
+----
+////
 
 == Defining attribute type's value types
 
@@ -10,7 +20,9 @@ The `value` keyword can be used to define a value type of an attribute type.
 
 [,typeql]
 ----
+#!test[schema]
 define name value string;
+#!---
 ----
 
 == Undefining attribute type's value type
@@ -19,7 +31,9 @@ The `value` keyword can be used to undefine an attribute type's value type.
 
 [,typeql]
 ----
+#!test[schema]
 undefine value string from name;
+#!---
 ----
 
 == Matching
@@ -28,5 +42,7 @@ The `value` keyword can be used to match all attribute types with a value type.
 
 [,typeql]
 ----
+#!test[read]
 match $a value string;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/statements/value.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/value.adoc
@@ -5,13 +5,15 @@ The statement `<LABEL> value <VALUE TYPE>` is used to identify `<VALUE TYPE>` as
 
 `<VALUE TYPE>` should be a built-in or a user-defined xref:{page-version}@reference::typeql/values/index.adoc[value type].
 
-////
+.Schema for the following examples
+[%collapsible]
+====
 [,typeql]
 ----
 #!test[schema]
 define attribute name @abstract;
 ----
-////
+====
 
 == Defining attribute type's value types
 

--- a/reference/modules/ROOT/pages/typeql/values/boolean.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/boolean.adoc
@@ -1,4 +1,5 @@
 = Boolean
+:test-typeql: linear
 
 A logical boolean (`true` / `false`).
 
@@ -6,15 +7,19 @@ A logical boolean (`true` / `false`).
 
 [,typeql]
 ----
+#!test[schema]
 define
   attribute shipped value boolean;
+#!---
 ----
 
 == Inserting a boolean valued attribute
 
 [,typeql]
 ----
+#!test[write]
 insert
   $_ isa shipped false;
+#!---
 ----
 

--- a/reference/modules/ROOT/pages/typeql/values/boolean.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/boolean.adoc
@@ -10,7 +10,6 @@ A logical boolean (`true` / `false`).
 #!test[schema]
 define
   attribute shipped value boolean;
-#!---
 ----
 
 == Inserting a boolean valued attribute
@@ -20,6 +19,5 @@ define
 #!test[write]
 insert
   $_ isa shipped false;
-#!---
 ----
 

--- a/reference/modules/ROOT/pages/typeql/values/date.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/date.adoc
@@ -37,7 +37,6 @@ and the maximum supported date is December 31, 262142 CE.
 #!test[schema]
 define
   attribute publish-date value date;
-#!---
 ----
 
 == Inserting a date valued attribute
@@ -47,5 +46,4 @@ define
 #!test[write]
 insert
   $_ isa publish-date 2025-01-10;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/values/date.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/date.adoc
@@ -1,4 +1,5 @@
 = Date
+:test-typeql: linear
 
 An ISO 8601 compliant date type. 
 
@@ -14,21 +15,37 @@ The date literal consists of the following values, separated by a `-`:
 .Example date literals
 ----
 2024-03-30
-+802701-09-21
++12345-09-21
+#!test[read]
+#{{
+match
+  let $x = 2024-03-30;
+  let $y = +12345-09-21;
+#}}
 ----
+
+[NOTE]
+====
+The minimum supported date is January 1, 262144 BCE,
+and the maximum supported date is December 31, 262142 CE.
+====
 
 == Defining a date valued attribute
 
 [,typeql]
 ----
+#!test[schema]
 define
   attribute publish-date value date;
+#!---
 ----
 
 == Inserting a date valued attribute
 
 [,typeql]
 ----
+#!test[write]
 insert
   $_ isa publish-date 2025-01-10;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/values/datetime.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/datetime.adoc
@@ -40,7 +40,6 @@ match
 #!test[schema]
 define
   attribute local-sunset value datetime;
-#!---
 ----
 
 == Inserting a datetime valued attribute

--- a/reference/modules/ROOT/pages/typeql/values/datetime.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/datetime.adoc
@@ -49,5 +49,4 @@ define
 #!test[write]
 insert
   $_ isa local-sunset 2025-01-10T16:13;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/values/datetime.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/datetime.adoc
@@ -1,4 +1,5 @@
 = Datetime
+:test-typeql: linear
 
 An ISO 8601 compliant date and time type. 
 
@@ -22,21 +23,32 @@ The time fragment consists of the following values, separated by `:`:
 .Example datetime literals
 ----
 2024-03-30T12:00:00
-+802701-09-21T12:34:56.789
++12345-09-21T12:34:56.789
+
+#!test[read]
+#{{
+match
+    let $x = 2024-03-30T12:00:00;
+    let $y = +12345-09-21T12:34:56.789;
+#}}
 ----
 
 == Defining a datetime valued attribute
 
 [,typeql]
 ----
+#!test[schema]
 define
   attribute local-sunset value datetime;
+#!---
 ----
 
 == Inserting a datetime valued attribute
 
 [,typeql]
 ----
+#!test[write]
 insert
   $_ isa local-sunset 2025-01-10T16:13;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/values/datetimetz.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/datetimetz.adoc
@@ -40,7 +40,6 @@ match
 #!test[schema]
 define
   attribute scheduled-meeting-time value datetime-tz;
-#!---
 ----
 
 == Inserting a datetime-tz valued attribute

--- a/reference/modules/ROOT/pages/typeql/values/datetimetz.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/datetimetz.adoc
@@ -1,4 +1,5 @@
 = DatetimeTZ
+:test-typeql: linear
 
 An ISO 8601 compliant date and time type with time zone information.
 
@@ -18,23 +19,36 @@ The IANA TZ identifier is separated from the datetime by a space character.
 .Example datetime-tz literals
 ----
 2024-03-30T12:00:00Z
-+802701-09-21T12:34:56.789+01
++12345-09-21T12:34:56.789+0100
 1887-12-22T17:29 Asia/Kolkata
-1920-04-26T16:30+01
+1920-04-26T16:30-09:30
+
+#!test[read]
+#{{
+match
+  let $w = 2024-03-30T12:00:00Z;
+  let $x = +12345-09-21T12:34:56.789+0100;
+  let $y = 1887-12-22T17:29 Asia/Kolkata;
+  let $z = 1920-04-26T16:30-09:30;
+#}}
 ----
 
 == Defining a datetime-tz valued attribute
 
 [,typeql]
 ----
+#!test[schema]
 define
   attribute scheduled-meeting-time value datetime-tz;
+#!---
 ----
 
 == Inserting a datetime-tz valued attribute
 
 [,typeql]
 ----
+#!test[write]
 insert
   $_ isa scheduled-meeting-time 2025-01-10T12:34:56 Europe/London;
+#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/values/datetimetz.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/datetimetz.adoc
@@ -49,5 +49,4 @@ define
 #!test[write]
 insert
   $_ isa scheduled-meeting-time 2025-01-10T12:34:56 Europe/London;
-#!---
 ----

--- a/reference/modules/ROOT/pages/typeql/values/decimal.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/decimal.adoc
@@ -1,4 +1,5 @@
 = Decimal
+:test-typeql: linear
 
 A fixed point signed decimal number with 64 bits to the left of the decimal point and 19 decimal digits of precision after the point.
 
@@ -11,15 +12,19 @@ for decimal is from &minus;2^63^ to 2^63^ &minus; 10^&minus;19^ (inclusive).
 
 [,typeql]
 ----
+#!test[schema]
 define
   attribute account-balance value decimal;
+#!---
 ----
 
 == Inserting a decimal valued attribute
 
 [,typeql]
 ----
+#!test[write]
 insert
   $_ isa account-balance 0.02dec;
+#!---
 ----
 

--- a/reference/modules/ROOT/pages/typeql/values/decimal.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/decimal.adoc
@@ -15,7 +15,6 @@ for decimal is from &minus;2^63^ to 2^63^ &minus; 10^&minus;19^ (inclusive).
 #!test[schema]
 define
   attribute account-balance value decimal;
-#!---
 ----
 
 == Inserting a decimal valued attribute

--- a/reference/modules/ROOT/pages/typeql/values/decimal.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/decimal.adoc
@@ -24,6 +24,5 @@ define
 #!test[write]
 insert
   $_ isa account-balance 0.02dec;
-#!---
 ----
 

--- a/reference/modules/ROOT/pages/typeql/values/double.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/double.adoc
@@ -11,7 +11,6 @@ A finite double precision IEEE 754 floating point number.
 define
 attribute latitude @independent, value double;
 attribute longitude @independent, value double;
-#!---
 ----
 
 == Inserting a double valued attribute
@@ -22,6 +21,5 @@ attribute longitude @independent, value double;
 insert
   $_ isa latitude 11.373333;
   $_ isa longitude 142.591667;
-#!---
 ----
 

--- a/reference/modules/ROOT/pages/typeql/values/double.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/double.adoc
@@ -7,17 +7,21 @@ A finite double precision IEEE 754 floating point number.
 
 [,typeql]
 ----
+#!test[schema]
 define
 attribute latitude @independent, value double;
 attribute longitude @independent, value double;
+#!---
 ----
 
 == Inserting a double valued attribute
 
 [,typeql]
 ----
+#!test[write]
 insert
   $_ isa latitude 11.373333;
   $_ isa longitude 142.591667;
+#!---
 ----
 

--- a/reference/modules/ROOT/pages/typeql/values/double.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/double.adoc
@@ -1,4 +1,5 @@
 = Double
+:test-typeql: linear
 
 A finite double precision IEEE 754 floating point number.
 

--- a/reference/modules/ROOT/pages/typeql/values/duration.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/duration.adoc
@@ -144,6 +144,5 @@ define
 #!test[write]
 insert
   $_ isa event-cadence P1M; # same local time on the same day of every month
-#!---
 ----
 

--- a/reference/modules/ROOT/pages/typeql/values/duration.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/duration.adoc
@@ -135,7 +135,6 @@ The nanosecond part of the duration is added directly to the underlying UTC time
 #!test[schema]
 define
   attribute event-cadence value duration;
-#!---
 ----
 
 == Inserting a duration valued attribute

--- a/reference/modules/ROOT/pages/typeql/values/duration.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/duration.adoc
@@ -42,6 +42,18 @@ P1Y2M3DT4H5M6.789S
 # they are disambiguated by the time designator `T`
 P1M # one month
 PT1M # one minute
+#!test[read]
+#{{
+match
+  let $d1 = P12W;
+  let $d2 = P1Y2M3DT4H5M6.789S;
+  let $d3 = P1M;
+  let $d4 = PT1M;
+#}}
+#!test[read, fail_at=runtime]
+#{{
+match let $d5 = P1W1D;
+#}}
 ----
 
 == Storage representation
@@ -58,7 +70,7 @@ nanoseconds. These operations respect daylight saving changes, and other timezon
 [WARNING]
 ====
 This means that addition of durations to datetimes is not commutative.
-
+// TODO: Add tests
 [,typeql]
 ----
 # 29th of Februrary + 1 month and 1 day = 29th of March + 1 day = 30th of March
@@ -120,15 +132,19 @@ The nanosecond part of the duration is added directly to the underlying UTC time
 
 [,typeql]
 ----
+#!test[schema]
 define
   attribute event-cadence value duration;
+#!---
 ----
 
 == Inserting a duration valued attribute
 
 [,typeql]
 ----
+#!test[write]
 insert
   $_ isa event-cadence P1M; # same local time on the same day of every month
+#!---
 ----
 

--- a/reference/modules/ROOT/pages/typeql/values/duration.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/duration.adoc
@@ -1,4 +1,5 @@
 = Duration
+:test-typeql: linear
 
 An ISO 8601 compliant duration type. 
 

--- a/reference/modules/ROOT/pages/typeql/values/integer.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/integer.adoc
@@ -1,4 +1,5 @@
 = Integer
+:test-typeql: linear
 
 A 64-bit signed integer.
 
@@ -6,15 +7,19 @@ A 64-bit signed integer.
 
 [,typeql]
 ----
+#!test[schema]
 define
   attribute total-likes value integer;
+#!---
 ----
 
 == Inserting an integer valued attribute
 
 [,typeql]
 ----
+#!test[write]
 insert
   $_ isa total-likes 42;
+#!---
 ----
 

--- a/reference/modules/ROOT/pages/typeql/values/integer.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/integer.adoc
@@ -10,7 +10,6 @@ A 64-bit signed integer.
 #!test[schema]
 define
   attribute total-likes value integer;
-#!---
 ----
 
 == Inserting an integer valued attribute
@@ -20,6 +19,5 @@ define
 #!test[write]
 insert
   $_ isa total-likes 42;
-#!---
 ----
 

--- a/reference/modules/ROOT/pages/typeql/values/string.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/string.adoc
@@ -10,7 +10,6 @@ A UTF-8 character string type.
 #!test[schema]
 define
   attribute name value string;
-#!---
 ----
 
 == Inserting a string valued attribute
@@ -20,7 +19,6 @@ define
 #!test[write]
 insert
   $_ isa name "John";
-#!---
 ----
 
 

--- a/reference/modules/ROOT/pages/typeql/values/string.adoc
+++ b/reference/modules/ROOT/pages/typeql/values/string.adoc
@@ -1,4 +1,5 @@
 = String
+:test-typeql: linear
 
 A UTF-8 character string type.
 
@@ -6,16 +7,20 @@ A UTF-8 character string type.
 
 [,typeql]
 ----
+#!test[schema]
 define
   attribute name value string;
+#!---
 ----
 
 == Inserting a string valued attribute
 
 [,typeql]
 ----
+#!test[write]
 insert
   $_ isa name "John";
+#!---
 ----
 
 


### PR DESCRIPTION
## Goal
Add tests to TypeQL reference to notice if we ever break any syntax.

## Implementation
Adds tests as far as possible.
Notably misses `data-model.adoc`. Also skips some which are quite hand-wavy.

Points of improvement (Maybe todo in this PR)
* Add pre-conditions to a dedicated typeql block that's block-commented out.
* Add counts to read queries I may have forgotten.