### PR TITLE
Remove redundant segment separators

### DIFF
--- a/core-concepts/modules/ROOT/pages/typeql/entities-relations-attributes.adoc
+++ b/core-concepts/modules/ROOT/pages/typeql/entities-relations-attributes.adoc
@@ -16,7 +16,6 @@ E.g., a `person` exists, regardless of whether they are involved in friendships 
 define
 entity person;
 entity company;
-#!---
 ----
 
 == Relation
@@ -34,7 +33,6 @@ define
 relation employment,
   relates employer,
   relates employee;
-#!---
 ----
 
 Role type names exist scoped within their relation types, allowing you to re-use role labels in different relation types:
@@ -51,7 +49,6 @@ relation insurance-obligation,
   relates employer,
   relates employee,
   relates insurance;
-#!---
 ----
 
 You can refer to a role distinctly by scoping the role name with the relation name: `employment:employer`.
@@ -74,7 +71,6 @@ A type can be defined to implement this interface using the `owns` keyword.
 #!test[schema]
 define
 attribute age, value integer;
-#!---
 ----
 
 == Owning attributes & playing roles
@@ -89,7 +85,6 @@ E.g., a `person` may own an attribute `birth-date`, or an `employment` may own a
 #!test[schema]
 define
 person owns age;
-#!---
 ----
 
 Entity & relation types may be defined to "play" a role defined by a relation.
@@ -101,7 +96,6 @@ E.g., the entity type `company` may play the  `employer` role of an `employment`
 #!test[schema, rollback]
 define
 company plays employment:employer;
-#!---
 ----
 
 == Inheritance

--- a/core-concepts/modules/ROOT/pages/typeql/queries-as-functions.adoc
+++ b/core-concepts/modules/ROOT/pages/typeql/queries-as-functions.adoc
@@ -67,7 +67,6 @@ fun post_count($page: page) -> integer:
 match
   $posting isa posting, links (posted: $page);
 return count($posting);
-#!---
 ----
 
 [NOTE]
@@ -98,7 +97,6 @@ match
         $_ isa edge, links (from_: $mid, to: $to);
     };
 return { $to };
-#!---
 ----
 
 This will return `node`s in a breadth-first fashion.

--- a/core-concepts/modules/ROOT/pages/typeql/query-variables-patterns.adoc
+++ b/core-concepts/modules/ROOT/pages/typeql/query-variables-patterns.adoc
@@ -74,7 +74,6 @@ match
 
   ## $e is an 'employment', where $p plays the 'employee' role
   $e isa employment; $e links (employee: $p);
-#!---
 ----
 
 [NOTE]
@@ -88,7 +87,6 @@ match
   $p isa person,      # Combine the constraints on $p using a comma
     has name "James";  # Directly specify type & value of owned attribute.
   $e isa employment (employee: $p);  # Omit 'links' using the relation shorthand.
-#!---
 ----
 We will continue writing out the constraints for illustrative purposes.
 ====
@@ -138,7 +136,6 @@ insert
 
   ## $e is an 'employment', where $p plays the 'employee' role
   $e isa employment; $e links (employee: $p);
-#!---
 ----
 [NOTE]
 ====


### PR DESCRIPTION
## Goal
Remove redundant segment separators from TypeQL core concepts
