### PR TITLE
Revert changes to TypeQL runner to support multiple queries

### DIFF
--- a/reference/modules/ROOT/pages/typeql/statements/relates.adoc
+++ b/reference/modules/ROOT/pages/typeql/statements/relates.adoc
@@ -55,11 +55,11 @@ The `relates` keyword can be used to undefine a role type from a relation.
 
 [,typeql]
 ----
-#!test[schema]
+#!test[schema, rollback]
 #{{
 undefine as parent from fathership relates father;
 #}}
-#!test[schema, rollback]
+#---
 undefine relates parent from parentship;
 ----
 
@@ -69,11 +69,7 @@ The `relates ... as` construction can be used to undefine a role type specializa
 
 [,typeql]
 ----
-#!test[schema]
-#{{
-define fathership relates father as parent;
-#}}
-#!test[schema]
+#!test[schema, rollback]
 undefine as parent from fathership relates father;
 ----
 

--- a/test/parser/parser.py
+++ b/test/parser/parser.py
@@ -229,14 +229,12 @@ class Parser:
                     logger.debug(f"line {self.line_number}: found hidden segment start")
                     if self.in_segment:
                         self.error("Nested hidden segment found.")
-                    self.finalize_current_segment()
                     self.in_segment = True
 
                 elif line.startswith(MARKERS[self.language]['hidden_segment_end']):
                     logger.debug(f"line {self.line_number}: found hidden segment end")
                     if not self.in_segment:
                         self.error("No hidden segment to end found.")
-                    self.finalize_current_segment()
                     self.in_segment = False
 
                 elif line.startswith(MARKERS[self.language]['segment_separator']):

--- a/test/parser/parser.py
+++ b/test/parser/parser.py
@@ -10,20 +10,20 @@ logger = logging.getLogger('main')
 MARKERS = {
     "typeql": {
         "test_start": "#!test",  # may have options, e.g. '#!test[write, reset, count=3]', see README.md
-        "hidden_segment_start": "#{{",
-        "hidden_segment_end": "#}}",
+        "hidden_section_start": "#{{",
+        "hidden_section_end": "#}}",
         "segment_separator": "#---",  # used to separate non-hidden queries
     },
     "python": {
         "test_start": "#!test",
-        "hidden_segment_start": "#{{",
-        "hidden_segment_end": "#}}",
+        "hidden_section_start": "#{{",
+        "hidden_section_end": "#}}",
         "segment_separator": "#---",
     },
     "rust": {
         "test_start": "//!test",
-        "hidden_segment_start": "//{{",
-        "hidden_segment_end": "//}}",
+        "hidden_section_start": "//{{",
+        "hidden_section_end": "//}}",
         "segment_separator": "//---",
     }
 }
@@ -225,22 +225,22 @@ class Parser:
                 continue
 
             if self.in_language_block and self.in_test:
-                if line.startswith(MARKERS[self.language]['hidden_segment_start']):
-                    logger.debug(f"line {self.line_number}: found hidden segment start")
+                if line.startswith(MARKERS[self.language]['hidden_section_start']):
+                    logger.debug(f"line {self.line_number}: found hidden section start")
                     if self.in_segment:
-                        self.error("Nested hidden segment found.")
+                        self.error("Nested hidden section found.")
                     self.in_segment = True
 
-                elif line.startswith(MARKERS[self.language]['hidden_segment_end']):
-                    logger.debug(f"line {self.line_number}: found hidden segment end")
+                elif line.startswith(MARKERS[self.language]['hidden_section_end']):
+                    logger.debug(f"line {self.line_number}: found hidden section end")
                     if not self.in_segment:
-                        self.error("No hidden segment to end found.")
+                        self.error("No hidden section to end found.")
                     self.in_segment = False
 
                 elif line.startswith(MARKERS[self.language]['segment_separator']):
                     logger.debug(f"line {self.line_number}: found segment separator")
                     if self.in_segment:
-                        self.error("Cannot separate in a hidden segment")
+                        self.error("Cannot separate in a hidden section")
                     self.finalize_current_segment()
 
                 elif line.startswith("include::"):

--- a/test/runners/typeql_runner.py
+++ b/test/runners/typeql_runner.py
@@ -129,6 +129,15 @@ class TypeqlRunner(BaseRunner):
             except Exception as e:
                 raise Exception(f"{e}") from e
 
+    def before_run_test(self, parsed_test):
+        if TEST_CONFIG_KEY_RESET in parsed_test.config:
+            self.setup_db(True)
+
+
+    def after_run_test(self, parsed_test):
+        if TEST_CONFIG_KEY_RESET in parsed_test.config:
+            self.setup_db(True)
+
     def run_test(self, parsed_test: ParsedTest, adoc_path: str):
         self.before_run_test(parsed_test)
 

--- a/test/runners/typeql_runner.py
+++ b/test/runners/typeql_runner.py
@@ -1,5 +1,5 @@
 from typedb.driver import TypeDB, Driver, TransactionType, Credentials, DriverOptions
-from test.runners.base_runner import BaseRunner, TEST_CONFIG_KEY_RESET
+from test.runners.base_runner import BaseRunner
 from enum import Enum
 from typing import List, Dict, Tuple, Union
 from test.parser.parser import ParsedTest
@@ -77,11 +77,14 @@ class TypeqlRunner(BaseRunner):
             return False
         return True
 
-    def run_failing_queries(self, parsed_test: ParsedTest, type: TransactionType) -> str:
-        query = "\n".join(parsed_test.segments)
+    def run_failing_queries(self, queries: List[str], type: TransactionType) -> str:
         with self.driver.transaction(self.db, type) as tx:
             try:
-                tx.query(query).resolve()
+                promises = []
+                for q in queries:
+                    promises += [tx.query(q)]
+                for p in promises:
+                    p.resolve()
             except:
                 return FailureMode.Runtime
             try:
@@ -90,22 +93,27 @@ class TypeqlRunner(BaseRunner):
                 return FailureMode.Commit
         return FailureMode.NoFailure
 
-    def run_transaction(self, parsed_test: ParsedTest, type: TransactionType, counted=False, rollback=False, documents=False) -> Union[int, None]:
+    def run_transaction(self, queries: List[str], type: TransactionType, counted=False, rollback=False, documents=False) -> Union[int, None]:
         count_var_name = "automatic_test_count"
-        query = "\n".join(parsed_test.segments)
         if counted:
-            query += f"\nreduce ${count_var_name} = count;"
+            queries[-1] = queries[-1] + f"\nreduce ${count_var_name} = count;"
         with self.driver.transaction(self.db, type) as tx:
             try:
-                result = tx.query(query).resolve()
+                promises = []
+                results = []
+                for q in queries:
+                    promises.append(tx.query(q))
+                for p in promises:
+                    results.append(p.resolve())
                 if rollback:
                     tx.rollback()
                     tx.close()
                 elif type == TransactionType.READ:
-                    if documents:
-                        consumed_iterator = list(result.as_concept_documents())
-                    else:
-                        consumed_iterator = list(result.as_concept_rows())
+                    for r in results:
+                        if documents:
+                            consumed_iterator = list(r.as_concept_documents())
+                        else:
+                            consumed_iterator = list(r.as_concept_rows())
                     tx.close()
                 else:
                     tx.commit()
@@ -115,20 +123,11 @@ class TypeqlRunner(BaseRunner):
                     if type == TransactionType.READ:
                         count = consumed_iterator[0].get(count_var_name).get_integer()
                     else:
-                        rows = list(result.as_concept_rows())
-                        count = rows[0].get(count_var_name).get_integer()
+                        last_result = list(results[-1].as_concept_rows())
+                        count = last_result[0].get(count_var_name).get_integer()
                     return count
             except Exception as e:
                 raise Exception(f"{e}") from e
-
-    def before_run_test(self, parsed_test):
-        if TEST_CONFIG_KEY_RESET in parsed_test.config:
-            self.setup_db(True)
-
-
-    def after_run_test(self, parsed_test):
-        if TEST_CONFIG_KEY_RESET in parsed_test.config:
-            self.setup_db(True)
 
     def run_test(self, parsed_test: ParsedTest, adoc_path: str):
         self.before_run_test(parsed_test)
@@ -165,15 +164,15 @@ class TypeqlRunner(BaseRunner):
                     ref_failure_mode = FailureMode.Runtime
                 case x if x == TEST_FAIL_COMMIT_VAL:
                     ref_failure_mode = FailureMode.Commit
-            failure_mode = self.run_failing_queries(parsed_test, type)
+            failure_mode = self.run_failing_queries(parsed_test.segments, type)
             if failure_mode != ref_failure_mode:
                 raise RuntimeError(f"[{adoc_path}]: Failure mode: expected {ref_failure_mode} but got {failure_mode}")
         elif counted == True:
-            count = self.run_transaction(parsed_test, type, counted, rollback, documents)
+            count = self.run_transaction(parsed_test.segments, type, counted, rollback, documents)
             if count != reference_count:
                 raise RuntimeError(f"[{adoc_path}]: Query count: expected {reference_count} but got {count}")
         else:
-            self.run_transaction(parsed_test, type, counted, rollback, documents)
+            self.run_transaction(parsed_test.segments, type, counted, rollback, documents)
 
         self.after_run_test(parsed_test)
 

--- a/test/runners/typeql_runner.py
+++ b/test/runners/typeql_runner.py
@@ -1,5 +1,5 @@
 from typedb.driver import TypeDB, Driver, TransactionType, Credentials, DriverOptions
-from test.runners.base_runner import BaseRunner
+from test.runners.base_runner import BaseRunner, TEST_CONFIG_KEY_RESET
 from enum import Enum
 from typing import List, Dict, Tuple, Union
 from test.parser.parser import ParsedTest


### PR DESCRIPTION
## Goal
Reverts changes to TypeQL runner to support multiple queries so we can run multiple queries in a single transaction. 
"Hidden segments" are now called "hidden sections", and are simply joined to the existing segment without starting a new one.
