### PR TITLE
Add aliases for old driver pages

### DIFF
--- a/reference/modules/ROOT/pages/typedb-http-api.adoc
+++ b/reference/modules/ROOT/pages/typedb-http-api.adoc
@@ -1,6 +1,6 @@
 = TypeDB HTTP API
 :page-toclevels: 2
-:page-aliases: {page-version}@drivers::http/api-reference.adoc
+:page-aliases: {page-version}@drivers::http/api-reference.adoc, {page-version}@reference::http-api.adoc
 
 == Authorization
 

--- a/reference/modules/ROOT/pages/typedb-http-drivers/typescript.adoc
+++ b/reference/modules/ROOT/pages/typedb-http-drivers/typescript.adoc
@@ -3,6 +3,6 @@
 :keywords: typedb, client, driver, typescript, http, api, refernce
 :pageTitle: Typescript HTTP driver API reference
 :page-toclevels: 2
-:page-aliases: {page-version}@drivers::nodejs/api-reference.adoc
+:page-aliases: {page-version}@drivers::nodejs/api-reference.adoc, {page-version}@reference::http-drivers/typescript.adoc
 
 include::{page-version}@external-typedb-driver::partial$http-ts/api-reference.adoc[]


### PR DESCRIPTION
## Goal
Add aliases for outdated URLs referenced from HTTP driver READMEs.

## Implementation
Add aliases where needed. Source of the broken links: https://www.npmjs.com/package/typedb-driver-http