### PR TITLE
Top-level sidenav links, cloud API tutorial rename

### DIFF
--- a/academy/modules/ROOT/partials/nav.adoc
+++ b/academy/modules/ROOT/partials/nav.adoc
@@ -1,4 +1,4 @@
-.TypeDB Academy
+.xref:{page-version}@academy::index.adoc[]
 
 * xref:{page-version}@academy::index.adoc[Course overview]
 

--- a/core-concepts/modules/ROOT/partials/nav.adoc
+++ b/core-concepts/modules/ROOT/partials/nav.adoc
@@ -1,4 +1,4 @@
-.Core Concepts
+.xref:{page-version}@core-concepts::index.adoc[]
 
 
 * xref:{page-version}@core-concepts::typedb/index.adoc[]

--- a/examples/modules/ROOT/partials/nav.adoc
+++ b/examples/modules/ROOT/partials/nav.adoc
@@ -1,4 +1,4 @@
-.Examples
+.xref:{page-version}@examples::index.adoc[]
 
 * xref:{page-version}@examples::social-network.adoc[]
 

--- a/home/modules/ROOT/pages/learning-journey.adoc
+++ b/home/modules/ROOT/pages/learning-journey.adoc
@@ -35,7 +35,12 @@ As you go through those examples, we recommend having the Core Concepts open (se
 Some developers like to start with Concepts first, then look at examples, in which case
 skip to the next section and come back to the examples afterward!
 
-== Step 5: Core concepts
+== Step 5: Tutorials
+
+Look at our xref:{page-version}@tutorials::index.adoc[tutorials] for accomplishing specific TypeDB tasks,
+such as using TypeDB in CI, or deploying TypeDB through our Cloud API.
+
+== Step 6: Core concepts
 
 There are approximately 3 major parts to understanding TypeDB:
 
@@ -64,7 +69,7 @@ TypeDB can be accessed through either high-performance gRPC drivers or its built
 TypeDB's gRPC drivers come with their own set of APIs and recommended usage patterns that 
 are described at the xref:{page-version}@core-concepts::drivers/overview.adoc[Driver Overview].
 
-== Step 6: Building your application
+== Step 7: Building your application
 
 At this point you should have enough conceptual and practical knowledge of TypeDB to build
 your proof-of-concept, or even start building a production application!
@@ -73,7 +78,7 @@ In this building phase you will probably need to refer to any of the xref:{page-
 which are descriptions of all the different features of TypeDB, TypeQL, the protocol and drivers,
 and libraries.
 
-== Step 7: Operations
+== Step 8: Operations
 
 The xref:{page-version}@maintenance-operation::index.adoc[Operations] pages are for learning about backups, upgrades, configurations, and much more.
 

--- a/home/modules/ROOT/partials/nav.adoc
+++ b/home/modules/ROOT/partials/nav.adoc
@@ -1,4 +1,4 @@
-.Home
+.xref:{page-version}@home::index.adoc[]
 
 * xref:{page-version}@home::what-is-typedb.adoc[]
 

--- a/maintenance-operation/modules/ROOT/partials/nav.adoc
+++ b/maintenance-operation/modules/ROOT/partials/nav.adoc
@@ -1,4 +1,4 @@
-.Maintenance & Operation
+.xref:{page-version}@maintenance-operation::index.adoc[]
 
 * xref:{page-version}@maintenance-operation::typedb-upgrades.adoc[]
 

--- a/reference/modules/ROOT/partials/nav.adoc
+++ b/reference/modules/ROOT/partials/nav.adoc
@@ -1,4 +1,4 @@
-.Reference
+.xref:{page-version}@reference::index.adoc[]
 
 * xref:{page-version}@reference::typedb-grpc-drivers/index.adoc[]
 ** xref:{page-version}@reference::typedb-grpc-drivers/python.adoc[]

--- a/tools/modules/ROOT/partials/nav.adoc
+++ b/tools/modules/ROOT/partials/nav.adoc
@@ -1,4 +1,4 @@
-.Tools
+.xref:{page-version}@tools::index.adoc[]
 
 * xref:{page-version}@tools::studio.adoc[]
 

--- a/tutorials/modules/ROOT/pages/deploy-through-api.adoc
+++ b/tutorials/modules/ROOT/pages/deploy-through-api.adoc
@@ -1,6 +1,6 @@
-= Deploy TypeDB through the API
+= Deploy TypeDB via the Cloud API
 :keywords: typedb, typeql, tutorial, api, cloud, cluster, deploy
-:pageTitle: Deploy TypeDB through the API
+:pageTitle: Deploy TypeDB via the Cloud API
 :summary: A tutorial on deploying TypeDB through the API
 :page-toclevels: 2
 :tabs-sync-option:
@@ -653,7 +653,7 @@ If successful, TypeDB Cloud will deploy your cluster, and the script will poll i
 
 == Conclusion
 
-This tutorial has shown you how to set up a script to deploy TypeDB through the API.
+This tutorial has shown you how to set up a script to deploy TypeDB through the Cloud API.
 
 Similar approaches can be used for other common actions,
 such as pausing or resuming your clusters when not in use.

--- a/tutorials/modules/ROOT/partials/nav.adoc
+++ b/tutorials/modules/ROOT/partials/nav.adoc
@@ -1,4 +1,4 @@
-.Tutorials
+.xref:{page-version}@tutorials::index.adoc[]
 
 * xref:{page-version}@tutorials::deploy-through-api.adoc[]
 * xref:{page-version}@tutorials::use-github-actions.adoc[]

--- a/typeql-reference/modules/ROOT/partials/nav.adoc
+++ b/typeql-reference/modules/ROOT/partials/nav.adoc
@@ -1,4 +1,4 @@
-.TypeQL Reference
+.xref:{page-version}@typeql-reference::index.adoc[TypeQL Reference]
 
 * xref:{page-version}@typeql-reference::index.adoc[]
 ** xref:{page-version}@typeql-reference::data-model.adoc[]


### PR DESCRIPTION
## Goal

- Make all top-level sidenav items links to their respective index pages
- Rename the Cloud API tutorial to clarify its connection to Cloud

## Implementation

- Change the names to links
- Update the title to "Deploy TypeDB via the Cloud API"
