### PR TITLE
Reference correct GitHub URLs for driver repositories

### DIFF
--- a/home/modules/ROOT/pages/install/drivers.adoc
+++ b/home/modules/ROOT/pages/install/drivers.adoc
@@ -55,7 +55,7 @@ driver = TypeDB.driver(address=TypeDB.DEFAULT_ADDRESS, ...)
 
 === Python driver tutorial
 
-* https://github.com/typedb/typedb-driver/python[typedb-driver/python on GitHub] - Read the TypeDB Python driver tutorial
+* https://github.com/typedb/typedb-driver/tree/master/python[typedb-driver/python on GitHub] - Read the TypeDB Python driver tutorial
 
 
 == TypeScript (HTTP)
@@ -109,7 +109,7 @@ let driver = TypeDBDriver::new_core(TypeDBDriver::DEFAULT_ADDRESS).await.unwrap(
 
 === Rust driver tutorial
 
-* https://github.com/typedb/typedb-driver/rust[typedb-driver/rust on GitHub] - Read the TypeDB Rust driver tutorial
+* https://github.com/typedb/typedb-driver/tree/master/rust[typedb-driver/rust on GitHub] - Read the TypeDB Rust driver tutorial
 
 
 == Java
@@ -152,7 +152,7 @@ try (Driver driver = TypeDB.driver(TypeDB.DEFAULT_ADDRESS, new Credentials("admi
 
 === Java driver tutorial
 
-* https://github.com/typedb/typedb-driver/java[typedb-driver/java on GitHub] - Read the TypeDB Java driver tutorial
+* https://github.com/typedb/typedb-driver/tree/master/java[typedb-driver/java on GitHub] - Read the TypeDB Java driver tutorial
 
 
 == Other languages


### PR DESCRIPTION
## Goal
Fix broken driver GitHub URLs.

## Implementation
Add `tree/master` to the paths to make them correct GitHub URLs.