### PR TITLE
Fix glossary errors

### DIFF
--- a/typeql-reference/modules/ROOT/pages/expressions/operators.adoc
+++ b/typeql-reference/modules/ROOT/pages/expressions/operators.adoc
@@ -26,3 +26,49 @@ Parentheses (`()`) may be used to override the precedence. The sub-expressions i
 ----
 (1 + 2) * 3 == 9
 ----
+
+== Built-in functions
+
+TypeQL provides several built-in functions for common mathematical and list operations:
+
+=== Mathematical functions
+
+`round(x)`::
+Returns the provided numeric argument rounded to the nearest integer.
+
+[,typeql]
+----
+round(3.7) == 4
+round(3.2) == 3
+round(-3.7) == -4
+----
+
+`ceil(x)`::
+Returns the provided numeric argument rounded to the nearest greater integer (ceiling).
+
+[,typeql]
+----
+ceil(3.2) == 4
+ceil(3.7) == 4
+ceil(-3.2) == -3
+----
+
+`floor(x)`::
+Returns the provided numeric argument rounded to the nearest lesser integer (floor).
+
+[,typeql]
+----
+floor(3.2) == 3
+floor(3.7) == 3
+floor(-3.2) == -4
+----
+
+`abs(x)`::
+Returns the absolute value of the provided numeric argument.
+
+[,typeql]
+----
+abs(5) == 5
+abs(-5) == 5
+abs(0) == 0
+----

--- a/typeql-reference/modules/ROOT/pages/keywords.adoc
+++ b/typeql-reference/modules/ROOT/pages/keywords.adoc
@@ -39,7 +39,10 @@ Denotes the beginning of a xref:{page-version}@typeql-reference::pipelines/put.a
 Denotes the beginning of a xref:{page-version}@typeql-reference::pipelines/select.adoc[] in a data pipeline, used to keep specified variables for each element of the data stream and remove the rest.
 
 `require`::
-Denotes the beginning of a xref:{page-version}@typeql-reference::pipelines/require.adoc[] in a data pipeline, used to remove elements from the data stream that do not contain specified optional variables.
+Denotes the beginning of a xref:{page-version}@typeql-reference::pipelines/require.adoc[Require operator] in a data pipeline, used to remove elements from the data stream that do not contain specified optional variables.
+
+`distinct`::
+Denotes the beginning of a xref:{page-version}@typeql-reference::pipelines/distinct.adoc[Distinct operator] in a data pipeline, used to remove duplicate elements from the data stream.
 
 `sort`::
 Denotes the beginning of a xref:{page-version}@typeql-reference::pipelines/sort.adoc[] in a data pipeline, used to order the elements of the data stream based on the value of specified variables.
@@ -184,12 +187,6 @@ Describes a xref:{page-version}@typeql-reference::annotations/regex.adoc[], used
 Describes a xref:{page-version}@typeql-reference::annotations/distinct.adoc[], used to restrict an owned list of attributes to distinct values.
 
 == Reductions
-
-`check`::
-Reduces the stream to a boolean value, indicating whether it contains any elements. See xref:{page-version}@typeql-reference::pipelines/reduce.adoc[] for more information.
-
-`first`::
-Reduces the stream to the first occurrence of a specified variable. See xref:{page-version}@typeql-reference::pipelines/reduce.adoc[] for more information.
 
 `count`::
 Reduces the stream to the number of occurrences of a specified variable. See xref:{page-version}@typeql-reference::pipelines/reduce.adoc[] for more information.

--- a/typeql-reference/modules/ROOT/pages/pipelines/distinct.adoc
+++ b/typeql-reference/modules/ROOT/pages/pipelines/distinct.adoc
@@ -1,0 +1,45 @@
+= Distinct operator
+:test-typeql: linear
+
+The distinct operator removes duplicate elements from the data stream. Elements are considered duplicates if all their variables have the same values.
+
+== Syntax
+
+[,typeql]
+----
+distinct;
+----
+
+== Example
+
+.Schema for the following examples
+[%collapsible]
+====
+[,typeql]
+----
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
+----
+====
+
+Find all unique ages of users:
+
+[,typeql]
+----
+#!test[read]
+match
+  $user isa user, has age $age;
+select $age;
+distinct;
+----
+
+Remove duplicate answers that may result from using `or` patterns:
+
+[,typeql]
+----
+#!test[read]
+match
+  { $p isa person; } or { $p has name "John"; };
+distinct; # Make sure that the person with name John is returned at most once.
+----
+

--- a/typeql-reference/modules/ROOT/pages/pipelines/index.adoc
+++ b/typeql-reference/modules/ROOT/pages/pipelines/index.adoc
@@ -69,6 +69,12 @@ Used to keep specified variables for each element of the data stream and remove 
 Used to remove elements from the data stream that do not contain specified optional variables.
 ****
 
+.xref:{page-version}@typeql-reference::pipelines/distinct.adoc[]
+[.clickable]
+****
+Used to remove duplicate elements from the data stream.
+****
+
 .xref:{page-version}@typeql-reference::pipelines/sort.adoc[]
 [.clickable]
 ****

--- a/typeql-reference/modules/ROOT/pages/pipelines/require.adoc
+++ b/typeql-reference/modules/ROOT/pages/pipelines/require.adoc
@@ -1,1 +1,37 @@
-= Require stage
+= Require operator
+:test-typeql: linear
+
+The require operator filters the data stream to only include elements that contain the specified variables. Elements where any of the specified variables are unbound (empty) are removed from the stream.
+
+== Syntax
+
+[,typeql]
+----
+require <var> [ , <var> ... ];
+----
+
+== Example
+
+.Schema for the following examples
+[%collapsible]
+====
+[,typeql]
+----
+#!test[schema, commit]
+include::{page-version}@reference::example$tql/schema_statements_functions.tql[tags=define-keyword;entities;attributes;relation-friendship]
+----
+====
+
+Find users who have both a username and an email address:
+
+[,typeql]
+----
+#!test[read]
+match
+  $user isa user;
+  try { $user has username $username; };
+  try { $user has email $email; };
+require $username, $email;
+----
+
+In this example, the `try` clauses make `$username` and `$email` optional. The `require` operator then filters the stream to only include users who have both attributes bound (note: in this example, it would have been equivalent to not use `try` clauses and skip the `require` clause!)

--- a/typeql-reference/modules/ROOT/partials/nav.adoc
+++ b/typeql-reference/modules/ROOT/partials/nav.adoc
@@ -14,6 +14,7 @@
 ** xref:{page-version}@typeql-reference::pipelines/put.adoc[Put]
 ** xref:{page-version}@typeql-reference::pipelines/select.adoc[Select]
 ** xref:{page-version}@typeql-reference::pipelines/require.adoc[Require]
+** xref:{page-version}@typeql-reference::pipelines/distinct.adoc[Distinct]
 ** xref:{page-version}@typeql-reference::pipelines/sort.adoc[Sort]
 ** xref:{page-version}@typeql-reference::pipelines/limit.adoc[Limit]
 ** xref:{page-version}@typeql-reference::pipelines/offset.adoc[Offset]


### PR DESCRIPTION
## Goal

We fix glossary and corresponding pages with missing and incorrectly documented operators.