### PR TITLE
Add more readable datetime literal examples

### DIFF
--- a/typeql-reference/modules/ROOT/pages/values/date.adoc
+++ b/typeql-reference/modules/ROOT/pages/values/date.adoc
@@ -1,7 +1,7 @@
 = Date
 :test-typeql: linear
 
-An ISO 8601 compliant date type. 
+An https://www.iso.org/iso-8601-date-and-time-format.html[ISO 8601,window=_blank] compliant date type. 
 
 == Syntax
 
@@ -15,12 +15,25 @@ The date literal consists of the following values, separated by a `-`:
 .Example date literals
 ----
 2024-03-30
-+12345-09-21
+1920-09-21
 #!test[read]
 #{{
 match
   let $x = 2024-03-30;
-  let $y = +12345-09-21;
+  let $y = 1920-09-21;
+#}}
+----
+
+[,typeql]
+.Example date literals (non-4-digit year)
+----
++20000-01-01
++900-09-21
+#!test[read]
+#{{
+match
+  let $x = +20000-01-01;
+  let $y = +900-09-21;
 #}}
 ----
 

--- a/typeql-reference/modules/ROOT/pages/values/datetime.adoc
+++ b/typeql-reference/modules/ROOT/pages/values/datetime.adoc
@@ -24,14 +24,12 @@ The time fragment consists of the following values, separated by `:`:
 ----
 2024-03-30T12:00:00
 1920-09-21T09:00:00
-+12345-09-21T12:34:56.789
 
 #!test[read]
 #{{
 match
     let $x = 2024-03-30T12:00:00;
     let $y = 1920-09-21T09:00:00;
-    let $y = +12345-09-21T12:34:56.789;
 #}}
 ----
 

--- a/typeql-reference/modules/ROOT/pages/values/datetime.adoc
+++ b/typeql-reference/modules/ROOT/pages/values/datetime.adoc
@@ -1,7 +1,7 @@
 = Datetime
 :test-typeql: linear
 
-An ISO 8601 compliant date and time type. 
+An https://www.iso.org/iso-8601-date-and-time-format.html[ISO 8601,window=_blank] compliant date and time type. 
 
 == Syntax
 
@@ -23,13 +23,29 @@ The time fragment consists of the following values, separated by `:`:
 .Example datetime literals
 ----
 2024-03-30T12:00:00
+1920-09-21T09:00:00
 +12345-09-21T12:34:56.789
 
 #!test[read]
 #{{
 match
     let $x = 2024-03-30T12:00:00;
+    let $y = 1920-09-21T09:00:00;
     let $y = +12345-09-21T12:34:56.789;
+#}}
+----
+
+[,typeql]
+.Example datetime literals (non-4-digit year)
+----
++20000-01-01T10:30:00.000
++900-09-21T19:59:59.358
+
+#!test[read]
+#{{
+match
+    let $x = +20000-01-01T10:30:00.000;
+    let $y = +900-09-21T19:59:59.358;
 #}}
 ----
 

--- a/typeql-reference/modules/ROOT/pages/values/datetimetz.adoc
+++ b/typeql-reference/modules/ROOT/pages/values/datetimetz.adoc
@@ -1,7 +1,7 @@
 = DatetimeTZ
 :test-typeql: linear
 
-An ISO 8601 compliant date and time type with time zone information.
+An https://www.iso.org/iso-8601-date-and-time-format.html[ISO 8601,window=_blank] compliant date and time type with time zone information.
 
 == Syntax
 
@@ -19,17 +19,27 @@ The IANA TZ identifier is separated from the datetime by a space character.
 .Example datetime-tz literals
 ----
 2024-03-30T12:00:00Z
-+12345-09-21T12:34:56.789+0100
-1887-12-22T17:29 Asia/Kolkata
+1987-12-22T17:29 Asia/Kolkata
 1920-04-26T16:30-09:30
 
 #!test[read]
 #{{
 match
   let $w = 2024-03-30T12:00:00Z;
-  let $x = +12345-09-21T12:34:56.789+0100;
   let $y = 1887-12-22T17:29 Asia/Kolkata;
   let $z = 1920-04-26T16:30-09:30;
+#}}
+----
+
+[,typeql]
+.Example datetime-tz literal (non-4-digit year)
+----
++20000-01-01T10:30:00.000
+
+#!test[read]
+#{{
+match
+    let $x = +20000-01-01T10:30:00.000+0100;
 #}}
 ----
 
@@ -48,5 +58,5 @@ define
 ----
 #!test[write]
 insert
-  $_ isa scheduled-meeting-time 2025-01-10T12:34:56 Europe/London;
+  $_ isa scheduled-meeting-time 2025-01-10T12:30:00 Europe/London;
 ----

--- a/typeql-reference/modules/ROOT/pages/values/duration.adoc
+++ b/typeql-reference/modules/ROOT/pages/values/duration.adoc
@@ -1,7 +1,7 @@
 = Duration
 :test-typeql: linear
 
-An ISO 8601 compliant duration type. 
+An https://www.iso.org/iso-8601-date-and-time-format.html[ISO 8601,window=_blank] compliant duration type. 
 
 == Syntax
 


### PR DESCRIPTION
## Goal

We've done a pass over our date & time literal examples to keep them as intuitive as possible

## Implementation

Split date & datetime examples into two blocks - one block for literals without the leading + symbol to denote a non-four-digit year - this is the default that everyone should expect & be used to - and we separate out the examples with a leading + into a separate clearly indicated block

For example:

```
Example date literals
2024-03-30
1920-09-21
#!test[read]
#{{
match
  let $x = 2024-03-30;
  let $y = 1920-09-21;
#}}

Example date literals (non-4-digit year)
+20000-01-01
+900-09-21
#!test[read]
#{{
match
  let $x = +20000-01-01;
  let $y = +900-09-21;
#}}
```