### PR TITLE
Document round ties to even behaviour

### DIFF
--- a/typeql-reference/modules/ROOT/pages/expressions/operators.adoc
+++ b/typeql-reference/modules/ROOT/pages/expressions/operators.adoc
@@ -35,12 +35,15 @@ TypeQL provides several built-in functions for common mathematical and list oper
 
 `round(x)`::
 Returns the provided numeric argument rounded to the nearest integer.
+If the value is half-way between two integers, rounds to the number with an even least significant digit.
 
 [,typeql]
 ----
 round(3.7) == 4
 round(3.2) == 3
 round(-3.7) == -4
+round(3.5) == 4
+round(4.5) == 4
 ----
 
 `ceil(x)`::

--- a/typeql-reference/modules/ROOT/pages/expressions/operators.adoc
+++ b/typeql-reference/modules/ROOT/pages/expressions/operators.adoc
@@ -35,7 +35,7 @@ TypeQL provides several built-in functions for common mathematical and list oper
 
 `round(x)`::
 Returns the provided numeric argument rounded to the nearest integer.
-If the value is half-way between two integers, rounds to the number with an even least significant digit.
+If the value is half-way between two integers, rounds to the nearest even integer.
 
 [,typeql]
 ----


### PR DESCRIPTION
## Goal

We add the clarification that if the input is halfway between two integers, `round()` rounds to the nearest even integer.

## Implementation
