### PR TITLE
Add driver logging documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,122 @@
+# TypeDB Documentation Repository
+
+This repository contains all content for the TypeDB Documentation Portal at https://typedb.com/docs.
+
+## Git Configuration
+
+- **Base branch**: `3.x-development`
+
+## Branches
+
+- **`3.x-development`**: Main development branch (staging at development.typedb.com/docs)
+- **`3.x-master`**: Production branch (published at typedb.com/docs)
+
+Feature branches should fork from `3.x-development`.
+
+## Technology Stack
+
+- **Antora**: Documentation site generator
+- **AsciiDoc**: Content markup language
+- **Node.js/pnpm**: Build tooling
+
+## Repository Structure
+
+| Directory | Description |
+|-----------|-------------|
+| `home/` | Landing pages and installation guides |
+| `core-concepts/` | Conceptual documentation (drivers, TypeQL basics) |
+| `academy/` | Tutorial-style learning content |
+| `guides/` | How-to guides |
+| `reference/` | API reference documentation |
+| `typeql-reference/` | TypeQL language reference |
+| `maintenance-operation/` | Server configuration and operations |
+| `examples/` | Code examples included in docs |
+| `test/` | Documentation testing infrastructure |
+
+## Content Modules
+
+Each directory is an Antora module with this structure:
+```
+module-name/
+  modules/
+    ROOT/
+      pages/        # AsciiDoc content pages
+      partials/     # Reusable content fragments
+      examples/     # Code examples
+      images/       # Module-specific images
+      nav.adoc      # Navigation structure
+```
+
+## Build Commands
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build documentation locally
+pnpm run build
+
+# Initialize submodules (for external content)
+git submodule update --init
+```
+
+## Writing Guidelines
+
+### AsciiDoc Conventions
+
+- Use sentence case for headings
+- Maximum one h1 (`=`) per page at the top
+- Heading hierarchy: `==` → `===` → `====`
+- Use American English spelling
+
+### Code Examples
+
+Code examples can be:
+1. Inline in AsciiDoc files
+2. Included from `examples/` directories using `include::` directive
+3. Tagged for partial inclusion: `include::file.py[tag=example_name]`
+
+### Cross-References
+
+Use Antora xref syntax for links between pages:
+```asciidoc
+xref:{page-version}@module::path/to/page.adoc[Link Text]
+xref:{page-version}@reference::typedb-grpc-drivers/rust.adoc#_anchor[Rust Driver]
+```
+
+## External Content
+
+The `reference/` module includes API documentation generated from other repositories:
+- Driver API docs are included from `typedb-driver` via `external-typedb-driver` reference
+- These are pulled as submodules or during build
+
+## Testing
+
+Documentation code examples can be tested:
+```bash
+# Test code snippets for a specific language
+python3 -m test.code.main <language> <directory>
+```
+
+## Common Tasks
+
+### Adding a New Page
+
+1. Create `.adoc` file in appropriate `pages/` directory
+2. Add entry to `nav.adoc` for navigation
+3. Include required front matter (title, summary, keywords)
+
+### Updating Driver Documentation
+
+Driver API reference is generated from `typedb-driver` repository partials. To update:
+1. Modify partials in `typedb-driver/docs/modules/ROOT/partials/`
+2. Ensure submodule is updated in this repo
+
+### Page Front Matter
+
+```asciidoc
+= Page Title
+:pageTitle: Page Title
+:Summary: Brief description for search/SEO.
+:keywords: typedb, keyword1, keyword2
+```

--- a/core-concepts/modules/ROOT/pages/drivers/best-practices.adoc
+++ b/core-concepts/modules/ROOT/pages/drivers/best-practices.adoc
@@ -1,7 +1,7 @@
 = Best Practices
 :pageTitle: Best Practices
 :Summary: Best practices for building robust applications with TypeDB drivers.
-:keywords: typedb, driver, best practices, connection management, error handling, performance
+:keywords: typedb, driver, best practices, connection management, error handling, performance, debugging, logging
 
 This guide covers essential best practices for building robust, performant applications with TypeDB drivers. Following these practices will help you avoid common pitfalls and create maintainable database code.
 
@@ -259,12 +259,96 @@ If you know that all your queries are valid, the `resolve()` call can be omitted
 * **Never hardcode credentials**: Use environment variables or secure configuration management
 * **Use encryption**: Always enable TLS network encryption for production or publicly accessible deployments
 
+== Debugging
+
+=== Driver logging
+
+TypeDB drivers support logging via environment variables. Set these before running your application:
+
+[cols="1,2"]
+|===
+| Variable | Description
+
+| `TYPEDB_DRIVER_LOG`
+| Log level for the driver core (e.g., `debug`, `info`, `warn`, `error`, `trace`)
+
+| `TYPEDB_DRIVER_CLIB_LOG`
+| Log level for the C FFI layer (useful for debugging memory and binding issues)
+
+| `RUST_LOG`
+| Standard Rust logging variable (lower priority than `TYPEDB_DRIVER_LOG`)
+|===
+
+**Example:**
+[source,bash]
+----
+# Enable debug logging
+export TYPEDB_DRIVER_LOG=debug
+python my_app.py
+----
+
+=== Enabling logging in your application
+
+[tabs]
+====
+Python::
++
+--
+Logging is available automatically when environment variables are set. You can also explicitly initialize logging:
+
+[,python]
+----
+from typedb.driver import TypeDB
+
+# Initialize driver logging
+TypeDB.init_logging()
+----
+--
+
+Java::
++
+--
+Logging is available automatically when environment variables are set. You can also explicitly initialize logging:
+
+[,java]
+----
+import com.typedb.driver.TypeDB;
+
+// Initialize driver logging
+TypeDB.initLogging();
+----
+--
+
+Rust::
++
+--
+The Rust driver uses the `tracing` crate. Configure your own subscriber to capture driver logs:
+
+[,rust]
+----
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+// Initialize tracing with environment filter
+tracing_subscriber::registry()
+    .with(EnvFilter::from_default_env())
+    .with(fmt::layer())
+    .init();
+
+// Driver logs will now be captured
+let driver = TypeDBDriver::new(address, credential).await?;
+----
+
+Set `RUST_LOG=typedb_driver=debug` to enable debug-level driver logs.
+--
+====
+
 == Summary
 
 Following these best practices will help you build robust TypeDB applications:
 
 1. **Use automatic resource management** whenever possible
-2. **Reuse connections** and handle errors gracefully  
+2. **Reuse connections** and handle errors gracefully
 3. **Choose appropriate transaction types** and keep transactions short-lived
 4. **Batch operations** for better performance
 5. **Secure your credentials** and use encryption in production
+6. **Enable logging** with environment variables when debugging issues

--- a/core-concepts/modules/ROOT/pages/drivers/best-practices.adoc
+++ b/core-concepts/modules/ROOT/pages/drivers/best-practices.adoc
@@ -269,21 +269,22 @@ TypeDB drivers support logging via environment variables. Set these before runni
 |===
 | Variable | Description
 
+| `TYPEDB_DRIVER_LOG_LEVEL`
+| Simple log level (`debug`, `info`, `warn`, `error`, `trace`) applied to all driver components. This is the easiest way to enable logging.
+
 | `TYPEDB_DRIVER_LOG`
-| Log level for the driver core (e.g., `debug`, `info`, `warn`, `error`, `trace`)
-
-| `TYPEDB_DRIVER_CLIB_LOG`
-| Log level for the C FFI layer (useful for debugging memory and binding issues)
-
-| `RUST_LOG`
-| Standard Rust logging variable (lower priority than `TYPEDB_DRIVER_LOG`)
+| Fine-grained control using the same syntax as `RUST_LOG`. Allows setting different levels for different components. `TYPEDB_DRIVER_LOG_LEVEL` takes precedence if both are set.
 |===
 
-**Example:**
+**Examples:**
 [source,bash]
 ----
-# Enable debug logging
-export TYPEDB_DRIVER_LOG=debug
+# Simple: Enable debug logging for all driver components
+export TYPEDB_DRIVER_LOG_LEVEL=debug
+python my_app.py
+
+# Advanced: Fine-grained control per component
+export TYPEDB_DRIVER_LOG=typedb_driver=debug,typedb_driver_clib=trace
 python my_app.py
 ----
 
@@ -294,35 +295,39 @@ python my_app.py
 Python::
 +
 --
-Logging is available automatically when environment variables are set. You can also explicitly initialize logging:
+Logging is automatically initialized when the driver module is imported. If you want logging enabled before importing the driver (e.g., to capture import-time logs), you can explicitly initialize it first:
 
 [,python]
 ----
-from typedb.driver import TypeDB
+from typedb.native_driver_wrapper import init_logging
+init_logging()
 
-# Initialize driver logging
-TypeDB.init_logging()
+# Now import and use the driver
+from typedb.driver import TypeDB
 ----
 --
 
 Java::
 +
 --
-Logging is available automatically when environment variables are set. You can also explicitly initialize logging:
+Logging is automatically initialized when driver classes are loaded. If you want logging enabled before creating a driver (e.g., to capture class-loading logs), you can explicitly initialize it first:
 
 [,java]
 ----
 import com.typedb.driver.TypeDB;
 
-// Initialize driver logging
+// Explicitly initialize logging before driver creation
 TypeDB.initLogging();
+
+// Now create and use the driver
+Driver driver = TypeDB.driver(address, credentials, options);
 ----
 --
 
 Rust::
 +
 --
-The Rust driver uses the `tracing` crate. Configure your own subscriber to capture driver logs:
+The Rust driver uses the `tracing` crate and does **not** use the `TYPEDB_DRIVER_LOG*` environment variables. Configure your own tracing subscriber using standard Rust logging conventions:
 
 [,rust]
 ----


### PR DESCRIPTION
## Goal

Document using TypeDB driver logging

- Eextend best-practices.adoc with environment variables (TYPEDB_DRIVER_LOG, TYPEDB_DRIVER_LOG_LEVEL) language-specific logging initialization examples

## Implementation

Additionally: Add CLAUDE.md with repo structure, branches, and writing guidelines