### PR TITLE
Docs updates: links

### DIFF
--- a/home/modules/ROOT/pages/install/drivers.adoc
+++ b/home/modules/ROOT/pages/install/drivers.adoc
@@ -58,10 +58,11 @@ from typedb.driver import *
 driver = TypeDB.driver(address=TypeDB.DEFAULT_ADDRESS, ...)
 ----
 
-=== Python driver example
+=== Python driver resources
 
 * https://github.com/typedb/typedb-driver/blob/master/python/example.py[example.py on GitHub] - View the TypeDB Python driver example
 * https://pypi.org/project/typedb-driver/[PyPI]
+* xref:{page-version}@reference::typedb-grpc-drivers/python.adoc[Python Driver API Reference]
 
 
 == TypeScript (HTTP)
@@ -88,10 +89,11 @@ const driver = new TypeDBHttpDriver({
 });
 ----
 
-=== TypeScript HTTP driver example
+=== TypeScript HTTP driver resources
 
 * https://github.com/typedb/typedb-examples/tree/master/webapp[TypeSpace: Social Network Webapp Example] - Explore the TypeScript HTTP driver example on GitHub
 * https://www.npmjs.com/package/typedb-driver-http[NPM registry]
+* xref:{page-version}@reference::typedb-http-drivers/typescript.adoc[TypeScript Driver API Reference]
 
 
 == Rust
@@ -114,10 +116,11 @@ use typedb_driver::TypeDBDriver;
 let driver = TypeDBDriver::new_core(TypeDBDriver::DEFAULT_ADDRESS).await.unwrap();
 ----
 
-=== Rust driver example
+=== Rust driver resources
 
 * https://github.com/typedb/typedb-driver/blob/master/rust/example.rs[example.rs on GitHub] - View the TypeDB Rust driver example
 * https://crates.io/crates/typedb-driver[Crates.io]
+* xref:{page-version}@reference::typedb-grpc-drivers/rust.adoc[Rust Driver API Reference]
 
 
 == Java
@@ -158,10 +161,11 @@ try (Driver driver = TypeDB.driver(TypeDB.DEFAULT_ADDRESS, new Credentials("admi
 }
 ----
 
-=== Java driver example
+=== Java driver resources
 
 * https://github.com/typedb/typedb-driver/blob/master/java/TypeDBExample.java[TypeDBExample.java on GitHub] - View the TypeDB Java driver example
 * https://cloudsmith.io/~typedb/repos/public-release/packages/detail/maven/typedb-driver/[Maven repo]
+* xref:{page-version}@reference::typedb-grpc-drivers/java.adoc[Java Driver API Reference]
 
 
 == C
@@ -181,9 +185,10 @@ DriverOptions* options = driver_options_new(false, NULL);
 TypeDBDriver* driver = driver_open("127.0.0.1:1729", credentials, options);
 ----
 
-=== C driver example
+=== C driver resources
 
 * https://github.com/typedb/typedb-driver/blob/master/c/example.c[example.c on GitHub] - View the TypeDB C driver example
+* xref:{page-version}@reference::typedb-grpc-drivers/c.adoc[C Driver API Reference]
 
 
 == Other languages

--- a/tools/modules/ROOT/pages/mcp-server.adoc
+++ b/tools/modules/ROOT/pages/mcp-server.adoc
@@ -13,7 +13,7 @@ TypeDB MCP Server implements this protocol, enabling AI tools like Cursor IDE to
 
 TypeDB MCP Server is ideal when you want to:
 
-* Enable AI assistants to query and manipulate TypeDB databases using natural language
+* Enable AI assistants to query and manage TypeDB databases
 * Integrate TypeDB with AI-powered IDEs and development tools
 * Prototype and explore TypeDB schemas and data interactively with AI assistance
 * Automate database operations through conversational interfaces

--- a/tools/modules/ROOT/pages/mcp-server.adoc
+++ b/tools/modules/ROOT/pages/mcp-server.adoc
@@ -1,22 +1,22 @@
 = TypeDB MCP Server
 
-TypeDB MCP Server is an MCP (Model Context Protocol) server that enables AI assistants to interact with TypeDB databases.
-This allows Large Language Models (LLMs) to execute TypeQL queries, manage databases, and manage users through natural language,
-making TypeDB accessible to AI-powered development tools.
+TypeDB MCP Server is an MCP (Model Context Protocol) server that enables AI assistant tools and autonomous agents to interact with TypeDB databases.
+It provides structured access to execute TypeQL queries, manage databases, and manage users,
+making TypeDB accessible to AI-powered development tools and agent frameworks.
 
 == What is MCP?
 
-The Model Context Protocol (MCP) is a standardized protocol that allows AI assistants and LLMs to interact with external tools and services.
-TypeDB MCP Server implements this protocol, enabling AI tools like Cursor IDE to communicate with TypeDB databases seamlessly.
+The Model Context Protocol (MCP) is a standardized protocol that allows AI assistant tools and autonomous agents to interact with external tools and services.
+TypeDB MCP Server implements this protocol, enabling tools like Cursor IDE and autonomous agents to communicate with TypeDB databases seamlessly.
 
 == When to use TypeDB MCP Server
 
 TypeDB MCP Server is ideal when you want to:
 
-* Enable AI assistants to query and manage TypeDB databases
+* Enable AI assistant tools and autonomous agents to query and manage TypeDB databases
 * Integrate TypeDB with AI-powered IDEs and development tools
 * Prototype and explore TypeDB schemas and data interactively with AI assistance
-* Automate database operations through conversational interfaces
+* Automate database operations through agent frameworks
 
 == Features
 

--- a/use-cases/modules/ROOT/pages/ai.adoc
+++ b/use-cases/modules/ROOT/pages/ai.adoc
@@ -70,3 +70,7 @@ For a detailed guide on building natural language query interfaces with TypeDB, 
 
 https://typedb.com/blog/building-prompt-guided-stix-knowledge-graph-explorer[Building a Prompt-Guided STIX Knowledge Graph Explorer,window=_blank]
 
+=== AI-Powered Tools
+
+Integrate TypeDB directly into your AI-powered development workflow using the xref:{page-version}@tools::mcp-server.adoc[TypeDB MCP Server]. The MCP Server enables AI assistants and LLMs to query, manage, and interact with TypeDB databases through natural language, making it easy to prototype schemas, explore data, and automate database operations from tools like Cursor IDE.
+

--- a/use-cases/modules/ROOT/pages/ai.adoc
+++ b/use-cases/modules/ROOT/pages/ai.adoc
@@ -72,5 +72,5 @@ https://typedb.com/blog/building-prompt-guided-stix-knowledge-graph-explorer[Bui
 
 === AI-Powered Tools
 
-Integrate TypeDB directly into your AI-powered development workflow using the xref:{page-version}@tools::mcp-server.adoc[TypeDB MCP Server]. The MCP Server enables AI assistants to execute TypeQL queries, manage databases, and manage users directly from AI-powered development tools like Cursor IDE.
+Integrate TypeDB directly into your AI-powered development workflow using the xref:{page-version}@tools::mcp-server.adoc[TypeDB MCP Server]. The MCP Server enables AI assistant tools and autonomous agents to execute TypeQL queries, manage databases, and manage users directly from tools like Cursor IDE and agent frameworks.
 

--- a/use-cases/modules/ROOT/pages/ai.adoc
+++ b/use-cases/modules/ROOT/pages/ai.adoc
@@ -72,5 +72,5 @@ https://typedb.com/blog/building-prompt-guided-stix-knowledge-graph-explorer[Bui
 
 === AI-Powered Tools
 
-Integrate TypeDB directly into your AI-powered development workflow using the xref:{page-version}@tools::mcp-server.adoc[TypeDB MCP Server]. The MCP Server enables AI assistants and LLMs to query, manage, and interact with TypeDB databases through natural language, making it easy to prototype schemas, explore data, and automate database operations from tools like Cursor IDE.
+Integrate TypeDB directly into your AI-powered development workflow using the xref:{page-version}@tools::mcp-server.adoc[TypeDB MCP Server]. The MCP Server enables AI assistants to execute TypeQL queries, manage databases, and manage users directly from AI-powered development tools like Cursor IDE.
 


### PR DESCRIPTION
## Goal

Add more internal linking from drivers install pages to API references, plus link to MCP server from AI use case page and clarify that MCP can be used for agentic systems.

## Implementation
