### PR TITLE
Add C# gRPC driver documentation

### DIFF
--- a/home/modules/ROOT/pages/install/drivers.adoc
+++ b/home/modules/ROOT/pages/install/drivers.adoc
@@ -205,8 +205,8 @@ TypeDBDriver* driver = driver_open("127.0.0.1:1729", credentials, options);
 +
 [source,xml]
 ----
-<PackageReference Include="TypeDB.Driver" Version={VERSION} />
-<PackageReference Include="TypeDB.Driver.Pinvoke.osx-arm64" Version={VERSION} />
+<PackageReference Include="TypeDB.Driver" Version="{version}" />
+<PackageReference Include="TypeDB.Driver.Pinvoke.osx-arm64" Version="{version}" />
 ----
 +
 Replace `osx-arm64` with the appropriate platform for your system: `osx-x64`, `linux-x64`, `linux-arm64`, or `win-x64`.
@@ -215,11 +215,11 @@ For platform-independent distribution, include all Pinvoke runtimes:
 +
 [source,xml]
 ----
-<PackageReference Include="TypeDB.Driver.Pinvoke.osx-x64" Version={VERSION} />
-<PackageReference Include="TypeDB.Driver.Pinvoke.osx-arm64" Version={VERSION} />
-<PackageReference Include="TypeDB.Driver.Pinvoke.linux-x64" Version={VERSION} />
-<PackageReference Include="TypeDB.Driver.Pinvoke.linux-arm64" Version={VERSION} />
-<PackageReference Include="TypeDB.Driver.Pinvoke.win-x64" Version={VERSION} />
+<PackageReference Include="TypeDB.Driver.Pinvoke.osx-x64" Version="{version}" />
+<PackageReference Include="TypeDB.Driver.Pinvoke.osx-arm64" Version="{version}" />
+<PackageReference Include="TypeDB.Driver.Pinvoke.linux-x64" Version="{version}" />
+<PackageReference Include="TypeDB.Driver.Pinvoke.linux-arm64" Version="{version}" />
+<PackageReference Include="TypeDB.Driver.Pinvoke.win-x64" Version="{version}" />
 ----
 
 . Use TypeDB Driver in your program:
@@ -229,11 +229,12 @@ For platform-independent distribution, include all Pinvoke runtimes:
 using TypeDB.Driver;
 using TypeDB.Driver.Api;
 
-using var driver = TypeDB.Driver("127.0.0.1:1729", new Credentials("admin", "password"), new DriverOptions(false, null));
+using var driver = TypeDB.Driver(TypeDB.DefaultAddress, new Credentials("admin", "password"), new DriverOptions(false, null));
 ----
 
 === C# driver resources
 
+* https://github.com/typedb/typedb-driver/blob/master/csharp/TypeDBExample.cs[TypeDBExample.cs on GitHub] - View the TypeDB C# driver example
 * https://www.nuget.org/packages/TypeDB.Driver[NuGet]
 * xref:{page-version}@reference::typedb-grpc-drivers/csharp.adoc[C# Driver API Reference]
 

--- a/home/modules/ROOT/pages/install/drivers.adoc
+++ b/home/modules/ROOT/pages/install/drivers.adoc
@@ -32,6 +32,11 @@ TypeDB drivers are client libraries that enable applications to communicate with
 ****
 ****
 
+.xref:#_csharp[]
+[.clickable]
+****
+****
+
 .xref:#_other_languages[]
 [.clickable]
 ****
@@ -189,6 +194,48 @@ TypeDBDriver* driver = driver_open("127.0.0.1:1729", credentials, options);
 
 * https://github.com/typedb/typedb-driver/blob/master/c/example.c[example.c on GitHub] - View the TypeDB C driver example
 * xref:{page-version}@reference::typedb-grpc-drivers/c.adoc[C Driver API Reference]
+
+
+[#_csharp]
+== C#
+
+=== Install TypeDB C# Driver through NuGet
+
+. Add `TypeDB.Driver` and the platform-specific native runtime to your `.csproj`:
++
+[source,xml]
+----
+<PackageReference Include="TypeDB.Driver" Version={VERSION} />
+<PackageReference Include="TypeDB.Driver.Pinvoke.osx-arm64" Version={VERSION} />
+----
++
+Replace `osx-arm64` with the appropriate platform for your system: `osx-x64`, `linux-x64`, `linux-arm64`, or `win-x64`.
++
+For platform-independent distribution, include all Pinvoke runtimes:
++
+[source,xml]
+----
+<PackageReference Include="TypeDB.Driver.Pinvoke.osx-x64" Version={VERSION} />
+<PackageReference Include="TypeDB.Driver.Pinvoke.osx-arm64" Version={VERSION} />
+<PackageReference Include="TypeDB.Driver.Pinvoke.linux-x64" Version={VERSION} />
+<PackageReference Include="TypeDB.Driver.Pinvoke.linux-arm64" Version={VERSION} />
+<PackageReference Include="TypeDB.Driver.Pinvoke.win-x64" Version={VERSION} />
+----
+
+. Use TypeDB Driver in your program:
++
+[source,csharp]
+----
+using TypeDB.Driver;
+using TypeDB.Driver.Api;
+
+using var driver = TypeDB.Driver("127.0.0.1:1729", new Credentials("admin", "password"), new DriverOptions(false, null));
+----
+
+=== C# driver resources
+
+* https://www.nuget.org/packages/TypeDB.Driver[NuGet]
+* xref:{page-version}@reference::typedb-grpc-drivers/csharp.adoc[C# Driver API Reference]
 
 
 == Other languages

--- a/reference/modules/ROOT/pages/typedb-grpc-drivers/csharp.adoc
+++ b/reference/modules/ROOT/pages/typedb-grpc-drivers/csharp.adoc
@@ -1,0 +1,8 @@
+= C# gRPC driver
+:pageTitle: C# gRPC driver
+:Summary: API Reference of TypeDB gRPC driver for C#.
+:keywords: typedb, client, driver, csharp, grpc, api, reference
+:page-toclevels: 2
+:page-aliases: {page-version}@drivers::csharp/api-reference.adoc
+
+include::{page-version}@external-typedb-driver::partial$csharp/api-reference.adoc[]

--- a/reference/modules/ROOT/pages/typedb-grpc-drivers/index.adoc
+++ b/reference/modules/ROOT/pages/typedb-grpc-drivers/index.adoc
@@ -27,4 +27,10 @@ Rust GRPC driver for TypeDB.
 ****
 C GRPC driver for TypeDB.
 ****
+
+.xref:{page-version}@reference::typedb-grpc-drivers/csharp.adoc[]
+[.clickable]
+****
+C# GRPC driver for TypeDB.
+****
 --

--- a/reference/modules/ROOT/partials/nav.adoc
+++ b/reference/modules/ROOT/partials/nav.adoc
@@ -5,6 +5,7 @@
 ** xref:{page-version}@reference::typedb-grpc-drivers/java.adoc[]
 ** xref:{page-version}@reference::typedb-grpc-drivers/rust.adoc[]
 ** xref:{page-version}@reference::typedb-grpc-drivers/c.adoc[]
+** xref:{page-version}@reference::typedb-grpc-drivers/csharp.adoc[]
 
 * xref:{page-version}@reference::typedb-http-api.adoc[]
 


### PR DESCRIPTION
## Goal

Add C# driver to the reference pages, navigation sidebar, gRPC drivers index, and installation guide with NuGet setup instructions.
