### PR TITLE
`isbn-10` and `isbn-13` should be a sub-type of `isbn`

### DIFF
--- a/academy/modules/ROOT/pages/9-modeling-schemas/9.8-abstract-contracts.adoc
+++ b/academy/modules/ROOT/pages/9-modeling-schemas/9.8-abstract-contracts.adoc
@@ -40,8 +40,8 @@ However, if you make `book` abstract, now you've created a simple contract of wh
 ----
 define
 attribute isbn @abstract, value string;
-attribute isbn-10;
-attribute isbn-13;
+attribute isbn-10, sub isbn;
+attribute isbn-13, sub isbn;
 attribute price, value double;
 
 entity book,


### PR DESCRIPTION
`isbn-10` and `isbn-13` should be a sub-type of `isbn`

## Goal


## Implementation
