### PR TITLE
Update 3.1-fetching-simple-data.adoc - Syntax mistakes

### DIFF
--- a/academy/modules/ROOT/pages/3-reading-data/3.1-fetching-simple-data.adoc
+++ b/academy/modules/ROOT/pages/3-reading-data/3.1-fetching-simple-data.adoc
@@ -279,8 +279,8 @@ match
 $book isa paperback, has isbn-13 "9780446310789";
 $line isa order-line (order: $order, item: $book);
 fetch {
-  "id": $order.id;
-  "quantity": $line.quantity;
+  "id": $order.id,
+  "quantity": $line.quantity
 };
 ----
 
@@ -352,7 +352,7 @@ $book isa paperback, has isbn-13 "9780446310789";
 $line isa order-line (order: $order, item: $book);
 delivery (deliverer: $courier, delivered: $order, destination: $address);
 fetch {
-  "id": $order.id;
+  "id": $order.id,
   "quantity": $line.quantity,
   "name": $courier.name,
   "street": $address.street


### PR DESCRIPTION
## Goal
Have the queries be correct and run without syntax errors.

## Implementation
Fixed minor syntax errors in two query examples by replacing incorrect semicolons with commas and removing unnecessary semicolons where required.

These changes are purely syntactical and ensure the queries execute successfully on version 3.8. No logical changes were made.