### PR TITLE
Add graph and hypergraph use case pages

### DIFF
--- a/use-cases/modules/ROOT/pages/graph.adoc
+++ b/use-cases/modules/ROOT/pages/graph.adoc
@@ -1,0 +1,234 @@
+= Graph database
+:Summary: How TypeDB works as a more advanced graph database
+:keywords: typedb, graph database, property graph, neo4j, cypher, labeled property graph
+:test-typeql: linear
+
+If you've worked with graphs or graph databases like Neo4j, you already think in terms of nodes and edges. TypeDB shares the core intuition that relationships are first-class citizens, but its model goes further: entities and relations are fully typed, relationships carry named roles, and a strict schema validates every write.
+
+This page maps graph concepts to TypeDB, and shows you how TypeDB goes above and beyond property graph models. We'll work through a concrete example — a companies ledger tracking companies, their directors, and ownership stakes.
+
+== Mapping property graph concepts to TypeDB
+
+[cols="1,1,2"]
+|===
+| Property graph | TypeDB | Notes
+
+| Node
+| Entity
+| Typed instances with attributes. **No labels** - the type _is_ the classification.
+
+| Label
+| Type
+| Instead of attaching labels, you define types in the schema. Types can be organized in hierarchies, eg. `organization` (abstract) -> [`company`, `nonprofit`]. There are 3 groups of types: Entity types, Relation types, and Attribute types.
+
+| Property
+| Attribute
+| Owned by entity or relation types. Value-typed (`string`, `long`, `double`, `datetime`, ...).
+
+| Edge
+| Relation with roles
+| A relation connects players through named roles, not just source -> target. Relation types declare which role(s) they `relates`, which are in turn added to other types using `plays`.
+
+| Edge property
+| Relation-owned attribute
+| Relations own attributes directly.
+
+| Traversal
+| Pattern matching
+| TypeQL `match` clauses describe the subgraph you want; the engine finds all matches.
+|===
+
+In TypeDB, entity, relation, and attribute types make up the schema, while entity, relation, and attribute _instances_ make up the data.
+
+=== Example: a companies ledger
+
+Let's model companies, people who direct them, and the ownership stakes between them.
+
+**Cypher (property graph)**
+
+In Cypher, you directly insert the data without any schema:
+
+[,cypher]
+----
+CREATE (acme:Company {name: "Acme Corp", jurisdiction: "US", incorporated: date("2019-03-15")})
+CREATE (globex:Company {name: "Globex Inc", jurisdiction: "UK", incorporated: date("2021-07-01")})
+CREATE (initech:Company {name: "Initech Ltd", jurisdiction: "US", incorporated: date("2015-11-20")})
+
+CREATE (alice:Person {name: "Alice Park"})
+CREATE (bob:Person {name: "Bob Rivera"})
+
+CREATE (alice)-[:DIRECTS]->(acme)
+CREATE (alice)-[:DIRECTS]->(globex)
+CREATE (bob)-[:DIRECTS]->(initech)
+
+CREATE (acme)-[:OWNS {stake_percentage: 51.0}]->(globex)
+CREATE (acme)-[:OWNS {stake_percentage: 30.0}]->(initech)
+----
+
+This is simple and readable — but nothing in the database enforces which node types can appear on either end of an edge, or what properties an edge should carry. You could accidentally create `(alice)-[:OWNS]->(bob)` and the database would accept it.
+
+**TypeQL**
+
+In TypeDB, we define a schema first:
+
+[,typeql]
+----
+#!test[schema]
+define
+  attribute name, value string;
+  attribute jurisdiction, value string;
+  attribute incorporation-date, value date;
+  attribute stake-percentage, value double;
+
+  entity company,
+    owns name @key,
+    owns jurisdiction,
+    owns incorporation-date @card(1),  # required
+    # i.e. instances of company can use directorship relations via the directed role
+    plays directorship:directed,
+    plays ownership:owner,
+    plays ownership:subsidiary;
+
+  entity person,
+    owns name,
+    plays directorship:director;
+
+  relation directorship,
+    relates director,
+    relates directed;
+
+  relation ownership,
+    relates owner,
+    relates subsidiary,
+    owns stake-percentage;
+----
+
+Then, insert data:
+
+[,typeql]
+----
+#!test[write, commit]
+insert
+  $acme isa company,
+    has name "Acme Corp",
+    has jurisdiction "US",
+    has incorporation-date 2019-03-15;
+  $globex isa company,
+    has name "Globex Inc",
+    has jurisdiction "UK",
+    has incorporation-date 2021-07-01;
+  $initech isa company,
+    has name "Initech Ltd",
+    has jurisdiction "US",
+    has incorporation-date 2015-11-20;
+
+  $alice isa person, has name "Alice Park";
+  $bob isa person, has name "Bob Rivera";
+
+  $d1 isa directorship (director: $alice, directed: $acme);
+  $d2 isa directorship (director: $alice, directed: $globex);
+  $d3 isa directorship (director: $bob, directed: $initech);
+
+  $o1 isa ownership (owner: $acme, subsidiary: $globex),
+    has stake-percentage 51.0;
+  $o2 isa ownership (owner: $acme, subsidiary: $initech),
+    has stake-percentage 30.0;
+----
+
+The schema validates that only a `person` can be a `director` and only a `company` can be an `owner` or `subsidiary`. The mistake `(owner: $alice, subsidiary: $bob)` would be rejected at write time.
+
+_TypeDB enforces the structure of your graph, so your application doesn't have to._
+
+=== Querying: find a company's directors
+
+**Cypher:**
+[,cypher]
+----
+MATCH (person)-[:DIRECTS]->(company:Company {name: "Acme Corp"})
+RETURN person.name
+----
+
+**TypeQL:**
+[,typeql]
+----
+#!test[read, count=1]
+match
+  $company isa company, has name "Acme Corp";
+  $dir isa directorship (director: $person, directed: $company);
+  $person has name $name;
+----
+
+The queries look similar — both follow edges from a company to its directors.
+
+== What TypeDB adds beyond property graphs
+
+=== Type inheritance and polymorphism
+
+In a property graph, you might give a node multiple labels — `:Company:Public` or `:Company:Private` — but there's no enforced hierarchy. In TypeDB, types form a tree. You could extend the ledger schema with subtypes:
+
+[,typeql]
+----
+define
+  entity company @abstract;
+  entity public-company sub company;
+  entity private-company sub company;
+----
+
+Now querying `company` returns all public and private companies — without listing subtypes!
+
+This works for relations too. You could subtype `ownership` into `majority-ownership` and `minority-ownership`, and a query matching `ownership` would find both. This extensibility is enabled by structuring your graph using a schema.
+
+=== Roles give semantics
+
+In a property graph, `(acme)-[:OWNS]->(globex)` relies on convention to determine which end is the parent and which is the subsidiary. In TypeDB, the roles `owner` and `subsidiary` make the semantics explicit and queryable:
+
+[,typeql]
+----
+#!test[read, count=2]
+match
+  $own isa ownership (subsidiary: $sub);
+  $sub has name $name;
+----
+
+This finds all companies that are subsidiaries of some other company, regardless of the owner.
+
+You can think of roles as interfaces that let your data be interpreted from different angles - company is seen as a subsidiary, or a person is used as a director.
+
+=== Attribute value identity
+
+In TypeDB, attributes with the same value and type are the same instance. In other words – attributes are like their own singleton 'nodes'. If two companies share the jurisdiction `"US"`, they both own the same `jurisdiction` attribute. This provides natural deduplication and enables queries like "find all companies in the same jurisdiction" without self-joins:
+
+[,typeql]
+----
+#!test[read, count=2]
+match
+  $a isa company, has jurisdiction $j;
+  $b isa company, has jurisdiction $j;
+  not { $a is $b; };
+----
+
+=== Relations can do more
+
+The examples above use binary relations — each connecting two players — which map directly to the property graph model. But TypeDB relations can:
+
+- **Own attributes** directly (like `stake-percentage` on `ownership`)
+- **Connect any number of participants** in a single relation with distinct roles
+- **Play roles in other relations** — an ownership relation can itself be reviewed, amended, or disputed
+
+These last two capabilities are what make TypeDB a full hypergraph database. See the xref:{page-version}@use-cases::hypergraph.adoc[Hypergraph page] for how the companies ledger extends into acquisition deal modeling.
+
+== Tradeoffs
+
+TypeDB's stricter model is not always the right choice. Property graphs have advantages in several areas:
+
+**Schemaless exploration.** Property graphs let you ingest data immediately and evolve structure over time. Even though TypeDB schemas are designed easily refactored, TypeDB requires some schema before any data is written. This is a strength for production systems but adds friction during early exploration.
+
+**Graph algorithm ecosystems.** Neo4j's Graph Data Science library provides PageRank, community detection, shortest path, and other algorithms out of the box. TypeDB does not currently ship with graph analytics.
+
+**Ecosystem size.** Property graph databases have broader tool integration (visualization, ETL, monitoring,) and larger communities.
+
+== Next steps
+
+* xref:{page-version}@use-cases::hypergraph.adoc[Hypergraphs] — extending the companies ledger into acquisition deal modeling
+* xref:{page-version}@guides::typeql/sql-vs-typeql.adoc[SQL vs TypeQL] — mapping relational database concepts to TypeDB
+* xref:{page-version}@home::get-started/setup.adoc[Get started] — install TypeDB and try it yourself

--- a/use-cases/modules/ROOT/pages/hypergraph.adoc
+++ b/use-cases/modules/ROOT/pages/hypergraph.adoc
@@ -1,0 +1,211 @@
+= Hypergraph database
+:Summary: How TypeDB's hypergraph model handles n-ary relations, nested relations, and layered context and metadata structuresg
+:keywords: typedb, hypergraph, n-ary relations, nested relations, knowledge graph, data modeling
+:test-typeql: linear
+
+Binary edges work well for simple connections: a person directs a company, a company owns a subsidiary. But real domains involve relationships that connect multiple parties in specific roles, carry rich context, and themselves participate in other relationships.
+
+This page explains why TypeDB is an excellent hypergraph store — a paradigm not widely implemented in production databases. To illustrate, we'll extend the companies ledger from the xref:{page-version}@use-cases::graph.adoc[Graph] page into acquisition deal modeling — showing where binary edges break down and how a hypergraph model handles the complexity directly.
+
+== The limits of binary edges
+
+Starting from our companies ledger, suppose Acme Corp acquires Globex Inc. In a property graph, you'd model this with a simple edge:
+
+[,cypher]
+----
+CREATE (acme)-[:ACQUIRES {stake: 67.5, value: 2500000000}]->(globex)
+----
+
+Simple enough. But real acquisitions involve more than two parties. Bank A leads the financing, Advisory Firm B advises the acquirer, Legal Firm C handles representation. Now you're forced to reify the acquisition into a node:
+
+[,cypher]
+----
+CREATE (bankA:Bank {name: "Bank A"})
+CREATE (advB:AdvisoryFirm {name: "Advisory Firm B"})
+CREATE (legalC:LegalFirm {name: "Legal Firm C"})
+
+CREATE (acq:Acquisition {name: "Project Atlas", value: 2500000000})
+CREATE (acme)-[:ACQUIRES {stake: 67.5}]->(acq)
+CREATE (globex)-[:TARGET_OF]->(acq)
+CREATE (bankA)-[:FINANCES {facility_size: 1800000000}]->(acq)
+CREATE (advB)-[:ADVISES]->(acq)
+CREATE (legalC)-[:REPRESENTS]->(acq)
+----
+
+Notice the problems:
+
+* **The acquisition is not an edge.** It's a relationship between parties, but you've been forced to model it as a node. The database treats it the same as a company — there's no structural distinction.
+* **Roles are edge labels.** The fact that Acme is the _acquirer_ and Bank A is the _lender_ is encoded in edge type names, not in a schema-enforced structure. Nothing prevents attaching a `:FINANCES` edge from an advisory firm.
+* **Context is scattered.** The stake percentage lives on one edge, the facility size on another, the value on the node. A single question — "what are the financial terms of this acquisition?" — requires collecting properties from multiple edges and the node.
+* **No composability.** If a compliance officer reviews the acquisition, there's no way to create that review _about_ the `Acquisition` node in a way that's structurally distinct from any other edge. You'd need yet another node and more edges.
+
+== N-ary relations (hyperedges)
+
+TypeDB models multi-party relationships directly. Here's the full schema for the acquisition domain — building on the same concepts from the companies ledger (entities, relations, attributes, roles) but redesigned with an `organization` type hierarchy and an n-ary `acquisition` relation:
+
+[,typeql]
+----
+#!test[schema]
+define
+
+  attribute name, value string;
+  attribute incorporation-date, value date;
+  attribute stake-percentage, value double;
+  attribute deal-value, value integer;
+  attribute facility-size, value integer;
+  attribute fee, value integer;
+
+  entity organization @abstract,
+    owns name;
+
+  entity company sub organization,
+    owns incorporation-date,
+    plays directorship:directed,
+    plays ownership:owner,
+    plays ownership:subsidiary,
+    plays acquisition:acquirer,
+    plays acquisition:target;
+
+  entity bank sub organization,
+    plays acquisition:lender;
+
+  entity advisory-firm sub organization,
+    plays acquisition:advisor;
+
+  entity legal-firm sub organization,
+    plays acquisition:counsel;
+
+  entity person @abstract,
+    owns name;
+
+  entity officer sub person,
+    plays directorship:director;
+
+  relation directorship,
+    relates director,
+    relates directed;
+
+  relation ownership,
+    relates owner,
+    relates subsidiary,
+    owns stake-percentage;
+
+  relation acquisition,
+    relates acquirer,
+    relates target,
+    relates lender,
+    relates advisor,
+    relates counsel,
+    owns name,
+    owns deal-value,
+    owns stake-percentage,
+    owns facility-size,
+    owns fee;
+----
+
+One relation, five roles, five owned attributes. The schema enforces that only a `company` can be an `acquirer` or `target`, only a `bank` can be a `lender`, and so on.
+
+Inserting the acquisition:
+
+[,typeql]
+----
+#!test[write, commit]
+insert
+  $acme isa company,
+    has name "Acme Corp",
+    has incorporation-date 2019-03-15;
+  $globex isa company,
+    has name "Globex Inc",
+    has incorporation-date 2021-07-01;
+  $bankA isa bank, has name "Bank A";
+  $advB isa advisory-firm, has name "Advisory Firm B";
+  $legalC isa legal-firm, has name "Legal Firm C";
+
+  $acq isa acquisition (acquirer: $acme,
+        target: $globex, lender: $bankA,
+        advisor: $advB, counsel: $legalC),
+    has name "Project Atlas",
+    has deal-value 2500000000,
+    has stake-percentage 67.5,
+    has facility-size 1800000000,
+    has fee 15000000;
+----
+
+Everything about the deal — parties and financial terms — lives in one relation. Querying is straightforward:
+
+[,typeql]
+----
+#!test[read, count=1]
+match
+  $acq isa acquisition (lender: $bank), has name "Project Atlas";
+  $bank has name $bank-name;
+----
+
+The acquisition remains a relationship — not a node masquerading as one.
+
+== Nested relations: relations playing roles
+
+N-ary relations handle multiple parties. Nested relations handle relationships _about_ relationships.
+
+=== Compliance review of an acquisition
+
+Suppose a compliance officer reviews the acquisition and flags a conflict — Advisory Firm B also advises a portfolio company of the target.
+
+The compliance review is _about_ the acquisition (a relation), not about any individual party. In TypeDB, a relation can play a role in another relation:
+
+[,typeql]
+----
+#!test[schema]
+define
+  attribute finding, value string;
+  attribute timestamp, value datetime;
+
+  entity officer, plays compliance-review:reviewer;
+  relation acquisition, plays compliance-review:reviewed-acquisition;
+
+  relation compliance-review,
+    relates reviewer,
+    relates reviewed-acquisition,
+    owns finding,
+    owns timestamp;
+----
+
+Now you can insert a review that directly references the acquisition:
+
+[,typeql]
+----
+#!test[write, commit]
+match
+  $acq isa acquisition, has name "Project Atlas";
+insert
+  $carol isa officer, has name "Carol Chen";
+  $review isa compliance-review (reviewer: $carol, reviewed-acquisition: $acq),
+    has finding "Conflict: Advisory Firm B also advises target portfolio company",
+    has timestamp 2025-11-15T09:30:00;
+----
+
+And query it:
+
+[,typeql]
+----
+#!test[read, count=1]
+match
+  $review isa compliance-review (reviewer: $reviewer, reviewed-acquisition: $acq),
+    has finding $finding;
+  $reviewer has name $reviewer-name;
+  $acq has name $acq-name;
+----
+
+In TypeDB, this is encoded in the schema: only a relation of type `acquisition` can fill the `reviewed-acquisition` role.
+
+Nesting is recursive — the compliance review is itself a relation, so it too can play a role in another relation (e.g., a senior officer signing off on the review). Each layer is a genuine relation with its own attributes, roles, and schema constraints.
+
+== Design space
+
+TypeDB scales from binary relations (like the xref:{page-version}@use-cases::graph.adoc[companies ledger]) to hyperedges to nested hypergraph structures seamlessly. Use the simplest model that fits your domain — the richer capabilities are there when you need them.
+
+== Next steps
+
+* xref:{page-version}@use-cases::graph.adoc[Graph database] — understanding TypeDB as a more advanced graph database
+* xref:{page-version}@core-concepts::typeql/entities-relations-attributes.adoc[Entities, relations, and attributes] — core type system concepts
+* xref:{page-version}@home::get-started/setup.adoc[Get started] — install TypeDB and try it yourself

--- a/use-cases/modules/ROOT/pages/index.adoc
+++ b/use-cases/modules/ROOT/pages/index.adoc
@@ -28,6 +28,18 @@ Cybersecurity solutions using TypeDB.
 ****
 AI and machine learning applications with TypeDB.
 ****
+
+.xref:{page-version}@use-cases::graph.adoc[Graph database]
+[.clickable]
+****
+How TypeDB works as a more advanced graph database.
+****
+
+.xref:{page-version}@use-cases::hypergraph.adoc[Hypergraph database]
+[.clickable]
+****
+How TypeDB works as a hypergraph database with N-ary relations, nested relations, and layered structures.
+****
 --
 
 Got other use cases you'd like to see?

--- a/use-cases/modules/ROOT/partials/nav.adoc
+++ b/use-cases/modules/ROOT/partials/nav.adoc
@@ -4,3 +4,5 @@
 * xref:{page-version}@use-cases::iam.adoc[]
 * xref:{page-version}@use-cases::cybersecurity.adoc[]
 * xref:{page-version}@use-cases::ai.adoc[]
+* xref:{page-version}@use-cases::graph.adoc[]
+* xref:{page-version}@use-cases::hypergraph.adoc[]


### PR DESCRIPTION
## Goal

We outline two major new sections, which correspond to two horizontal use cases instead of the existing vertical ones: graph and hypergraph modeling. These are intended to capture the understanding of those looking for graph or hypergraph database concepts, and help them see how they exist in TypeDB.