### PR TITLE
TypeDB Loader docs, typedb-console -> typedb-tools rename

### DIFF
--- a/home/modules/resources/partials/typedb-console-latest-links.adoc
+++ b/home/modules/resources/partials/typedb-console-latest-links.adoc
@@ -1,5 +1,5 @@
 | 
-https://github.com/typedb/typedb-console/releases/latest[latest]
+https://github.com/typedb/typedb-tools/releases?q=console&expanded=true[latest]
 
 | 
 // tag::mac[]

--- a/reference/modules/ROOT/pages/typedb-cluster/console.adoc
+++ b/reference/modules/ROOT/pages/typedb-cluster/console.adoc
@@ -8,7 +8,7 @@ TypeDB Console has been updated to connect to TypeDB clusters and automatically 
 The interface is experimental and may change between releases.
 You'll need an alpha version of TypeDB Console.
 These are published alongside the mainstream versions, starting with `3.7.0`.
-To access the releases, visit the https://github.com/typedb/typedb-console/releases[TypeDB Console GitHub page] and look for the most recent Pre-release item containing the alpha suffix (e.g., `TypeDB Console 3.7.0-alpha-2`).
+To access the releases, visit the https://github.com/typedb/typedb-tools/releases[TypeDB Console GitHub page] and look for the most recent Pre-release item containing the alpha suffix (e.g., `TypeDB Console 3.7.0-alpha-2`).
 
 == What's different in a clustered deployment?
 
@@ -119,5 +119,5 @@ Use `server list` to see up-to-date roles and statuses across all replicas.
 
 - Continue with xref:{page-version}@reference::typedb-cluster/drivers.adoc[Drivers in clustered TypeDB] for programmatic access to TypeDB.
 - Read the full xref:{page-version}@tools::console.adoc[TypeDB Console documentation].
-- Get the latest alpha clustered TypeDB Console from the https://github.com/typedb/typedb-console/releases[Releases page].
+- Get the latest alpha clustered TypeDB Console from the https://github.com/typedb/typedb-tools/releases[Releases page].
 - Join our discussion in https://discord.com/invite/typedb[Discord]!

--- a/tools/modules/ROOT/pages/console.adoc
+++ b/tools/modules/ROOT/pages/console.adoc
@@ -431,15 +431,15 @@ https://cloudsmith.io/~typedb/repos/public-release/packages/?q=name%3A%5Etypedb-
 |===
 | TypeDB Console | TypeDB | TypeDB Community Edition
 
-| https://github.com/typedb/typedb-console/releases/tag/3.0.0[3.0.0] to 3.1.x
+| https://github.com/typedb/typedb-tools/releases/tag/3.0.0[3.0.0] to 3.1.x
 | 3.0.0 to 3.1.x
 | 3.0.0 to 3.1.x
 
-| https://github.com/typedb/typedb-console/releases/tag/3.2.0[3.2.0] to 3.3.x
+| https://github.com/typedb/typedb-tools/releases/tag/3.2.0[3.2.0] to 3.3.x
 | 3.2.0 to 3.3.x
 | 3.2.0 to 3.3.x
 
-| https://github.com/typedb/typedb-console/releases/tag/3.4.0[3.4.0+]
+| https://github.com/typedb/typedb-tools/releases/tag/3.4.0[3.4.0+]
 | 3.4.0+
 | 3.4.0+
 |===

--- a/tools/modules/ROOT/pages/index.adoc
+++ b/tools/modules/ROOT/pages/index.adoc
@@ -17,7 +17,7 @@ TypeDB Studio - the visual web client for TypeDB.
 TypeDB Console - the CLI client for TypeDB.
 ****
 
-.xref:{page-version}@tools::console.adoc[]
+.xref:{page-version}@tools::loader/index.adoc[]
 [.clickable]
 ****
 TypeDB Loader - the CLI tool for loading datasets into TypeDB

--- a/tools/modules/ROOT/pages/index.adoc
+++ b/tools/modules/ROOT/pages/index.adoc
@@ -17,6 +17,12 @@ TypeDB Studio - the visual web client for TypeDB.
 TypeDB Console - the CLI client for TypeDB.
 ****
 
+.xref:{page-version}@tools::console.adoc[]
+[.clickable]
+****
+TypeDB Loader - the CLI tool for loading datasets into TypeDB
+****
+
 .xref:{page-version}@tools::admin.adoc[]
 [.clickable]
 ****

--- a/tools/modules/ROOT/pages/loader/index.adoc
+++ b/tools/modules/ROOT/pages/loader/index.adoc
@@ -1,0 +1,32 @@
+= TypeDB Loader
+
+This section provides information on using the TypeDB Loader.
+It includes reference documentation, as well as specific example walkthroughs of using the loader.
+
+[cols-2]
+--
+.xref:{page-version}@tools::loader/quickstart.adoc[]
+[.clickable]
+****
+Basic usage and general advice
+****
+
+.xref:{page-version}@tools::loader/reference.adoc[]
+[.clickable]
+****
+Reference documentation for the TypeDB Loader command line tool
+****
+
+.xref:{page-version}@tools::loader/sql-example.adoc[]
+[.clickable]
+****
+Migrating an existing SQL database to TypeDB
+****
+
+.xref:{page-version}@tools::loader/json-example.adoc[]
+[.clickable]
+****
+Taking JSON data and loading it into TypeDB
+****
+
+--

--- a/tools/modules/ROOT/pages/loader/json-example.adoc
+++ b/tools/modules/ROOT/pages/loader/json-example.adoc
@@ -1,4 +1,9 @@
 = JSON to TypeDB
+:keywords: typedb, typeql, tutorial, guide, loader
+:pageTitle:
+:summary:
+:page-toclevels: 2
+:tabs-sync-option:
 :test-typeql: linear
 
 This walkthrough takes a nested JSON dataset, designs a schema to fit it, normalizes it into

--- a/tools/modules/ROOT/pages/loader/json-example.adoc
+++ b/tools/modules/ROOT/pages/loader/json-example.adoc
@@ -59,6 +59,7 @@ they happened to review one. The schema recovers that:
 
 [source,typeql]
 ----
+#!test[schema, commit]
 define
 
 attribute isbn, value string;
@@ -250,6 +251,7 @@ Verify:
 
 [source,typeql]
 ----
+#!test[read]
 match
   $b isa book, has title $t;
   $rv (book: $b) isa review;

--- a/tools/modules/ROOT/pages/loader/json-example.adoc
+++ b/tools/modules/ROOT/pages/loader/json-example.adoc
@@ -155,29 +155,43 @@ Pass C must run after A and B because it uses `match` to find the entities it li
 
 [source,typeql]
 ----
-given $isbn: string, $title: string;
+given
+    $isbn: string,
+    $title: string;
 insert
-  $b isa book, has isbn == $isbn, has title == $title;
+  $b isa book,
+    has isbn == $isbn,
+    has title == $title;
 ----
 
 *`load_reviewers.tql`*
 
 [source,typeql]
 ----
-given $reviewer_email: string, $reviewer_name: string;
+given
+    $reviewer_email: string,
+    $reviewer_name: string;
 insert
-  $r isa reviewer, has email == $reviewer_email, has name == $reviewer_name;
+  $r isa reviewer,
+    has email == $reviewer_email,
+    has name == $reviewer_name;
 ----
 
 *`load_reviews.tql`*
 
 [source,typeql]
 ----
-given $isbn: string, $reviewer_email: string,
-      $rating: integer, $review_text: string?, $reviewed_at: datetime;
+given
+    $isbn: string,
+    $reviewer_email: string,
+    $rating: integer,
+    $review_text: string?,
+    $reviewed_at: datetime;
 match
-  $b isa book, has isbn == $isbn;
-  $r isa reviewer, has email == $reviewer_email;
+  $b isa book,
+    has isbn == $isbn;
+  $r isa reviewer,
+    has email == $reviewer_email;
 insert
   $rv isa review, links (book: $b, reviewer: $r),
     has rating == $rating,

--- a/tools/modules/ROOT/pages/loader/json-example.adoc
+++ b/tools/modules/ROOT/pages/loader/json-example.adoc
@@ -1,0 +1,352 @@
+= JSON to TypeDB
+
+This walkthrough takes you end-to-end from a raw dataset to a fully loaded TypeDB database:
+reading the data, designing a schema to fit it, normalizing it into CSV form, writing the
+loader query, and handling the multi-pass patterns most real datasets require.
+
+We start from JSON — the shape data most often arrives in from an API. The loader itself only
+consumes CSV, so the first real engineering step is going from one to the other; we'll use
+`jq` for that.
+
+== Step 1: The source data
+
+`source.json`:
+
+[source,json]
+----
+{
+  "books": [
+    {
+      "isbn": "9780441172719",
+      "title": "Dune",
+      "reviews": [
+        { "reviewer": { "email": "alice@example.com", "name": "Alice" },
+          "rating": 5, "text": "A timeless classic.", "reviewed_at": "2024-03-12" },
+        { "reviewer": { "email": "bob@example.com", "name": "Bob" },
+          "rating": 4, "text": "Long, but rewarding.", "reviewed_at": "2024-04-01" }
+      ]
+    },
+    {
+      "isbn": "9780553213119",
+      "title": "Frankenstein",
+      "reviews": [
+        { "reviewer": { "email": "alice@example.com", "name": "Alice" },
+          "rating": 3, "text": "Gothic and slow.", "reviewed_at": "2024-05-08" }
+      ]
+    },
+    {
+      "isbn": "9780451524935",
+      "title": "1984",
+      "reviews": [
+        { "reviewer": { "email": "carol@example.com", "name": "Carol" },
+          "rating": 5, "text": null, "reviewed_at": "2024-02-20" }
+      ]
+    }
+  ]
+}
+----
+
+Three structural features matter before going further:
+
+* *Nesting* — reviews live inside books; reviewers live inside reviews. The JSON encodes
+  relationships positionally.
+* *Implicit duplication* — the same reviewer (`alice@example.com`) appears under multiple
+  books. The JSON shape repeats them; the schema will not.
+* *Optional fields* — `text` is `null` for the 1984 review. JSON `null` will become an empty
+  CSV cell once normalized.
+
+== Step 2: Identify entities and relations
+
+For each piece of information, ask three questions:
+
+. *Does this identify something?* (`isbn`, `reviewer.email`) → key on an entity
+. *Does it describe a thing?* (`title`, `reviewer.name`, `rating`) → an attribute
+. *Does the connection between two things matter on its own?* (a `review` ties a book and a
+  reviewer, and carries its own rating and date) → a relation
+
+The nesting in the JSON is encoding _relationships_, not ownership. A reviewer doesn't "belong
+to" a book in real life — they happened to review one. The schema recovers that fact:
+
+* `book` (entity, keyed by `isbn`)
+* `reviewer` (entity, keyed by `email`)
+* `review` (relation linking a book and a reviewer, with its own rating/text/date)
+
+== Step 3: Design the schema
+
+`schema.tql`:
+
+[source,typeql]
+----
+define
+
+attribute isbn, value string;
+attribute title, value string;
+attribute name, value string;
+attribute email, value string;
+attribute rating, value integer;
+attribute review_text, value string;
+attribute reviewed_at, value datetime;
+
+entity book,
+  owns isbn @key,
+  owns title;
+
+entity reviewer,
+  owns email @key,
+  owns name;
+
+relation review,
+  relates book,
+  relates reviewer,
+  owns rating,
+  owns review_text,
+  owns reviewed_at;
+
+book plays review:book;
+reviewer plays review:reviewer;
+----
+
+Two choices worth calling out:
+
+* *`@key` on `isbn` and `email`* enforces uniqueness, so duplicate inserts fail cleanly — the
+  exact failure mode you want when deduping is incomplete.
+* *`review` is a relation that owns attributes.* In TypeDB, relations are first-class: they
+  carry their own attributes (rating, text, date) instead of forcing you to invent a synthetic
+  entity.
+
+== Step 4: Normalize JSON into CSVs with jq
+
+The loader consumes one CSV per pass, with one column per `given` input in the query template.
+We need three CSVs: books, reviewers, reviews. `jq` does this in one shot per file.
+
+=== Books
+
+Each book appears once in the JSON, so no dedup is needed:
+
+[source,bash]
+----
+jq -r '
+  ["isbn", "title"],
+  (.books[] | [.isbn, .title])
+  | @csv
+' source.json > books.csv
+----
+
+Output:
+
+[source,csv]
+----
+"isbn","title"
+"9780441172719","Dune"
+"9780553213119","Frankenstein"
+"9780451524935","1984"
+----
+
+=== Reviewers
+
+Reviewers repeat across books — dedupe inside `jq` using `unique_by`:
+
+[source,bash]
+----
+jq -r '
+  [.books[].reviews[].reviewer]
+  | unique_by(.email)
+  | (["reviewer_email", "reviewer_name"]),
+    (.[] | [.email, .name])
+  | @csv
+' source.json > reviewers.csv
+----
+
+Output:
+
+[source,csv]
+----
+"reviewer_email","reviewer_name"
+"alice@example.com","Alice"
+"bob@example.com","Bob"
+"carol@example.com","Carol"
+----
+
+=== Reviews
+
+One row per review, carrying the parent book's `isbn` onto each child:
+
+[source,bash]
+----
+jq -r '
+  ["isbn", "reviewer_email", "rating", "review_text", "reviewed_at"],
+  (.books[] as $b
+   | $b.reviews[]
+   | [$b.isbn, .reviewer.email, .rating, .text, .reviewed_at])
+  | @csv
+' source.json > reviews.csv
+----
+
+Output:
+
+[source,csv]
+----
+"isbn","reviewer_email","rating","review_text","reviewed_at"
+"9780441172719","alice@example.com",5,"A timeless classic.","2024-03-12"
+"9780441172719","bob@example.com",4,"Long, but rewarding.","2024-04-01"
+"9780553213119","alice@example.com",3,"Gothic and slow.","2024-05-08"
+"9780451524935","carol@example.com",5,,"2024-02-20"
+----
+
+Notice the `null` `text` for 1984 became an empty cell (`,,`). The loader will treat it as
+absent with `--null-values ''` — matching the optional `string?` we'll declare in the query
+template.
+
+=== `jq` idioms used here
+
+* *`... as $b | ...`* — bind a parent so you can refer back to it inside nested iteration.
+  This is how the book's `isbn` ends up on every child review row.
+* *`unique_by(.field)`* — dedupe an array by a key. Safer than piping to `sort -u` because it
+  works on JSON values rather than on bytes (no quote/comma issues, no header sorted into the
+  data).
+* *`@csv`* — properly quotes strings, escapes embedded commas and quotes, and emits `null` as
+  an empty cell. Always prefer it over hand-rolled string concatenation.
+* *Concatenated outputs* — in `(["a","b"]), (.x | [...])`, the comma is jq's stream-concat
+  operator; it emits the header array first, then the data arrays in order.
+
+== Step 5: Plan the load passes
+
+`@key` makes the multi-pass pattern necessary: you cannot insert the same key twice. The three
+CSVs from step 4 map directly onto three passes:
+
+. *Pass A* — load `books.csv` (unique books)
+. *Pass B* — load `reviewers.csv` (unique reviewers)
+. *Pass C* — load `reviews.csv` (each row is a relation between an already-loaded book and
+  reviewer)
+
+Pass C must run after A and B because it uses `match` to find the entities it links.
+
+== Step 6: Write the loader queries
+
+*`load_books.tql`*
+
+[source,typeql]
+----
+given $isbn: string, $title: string;
+insert
+  $b isa book, has isbn == $isbn, has title == $title;
+----
+
+*`load_reviewers.tql`*
+
+[source,typeql]
+----
+given $reviewer_email: string, $reviewer_name: string;
+insert
+  $r isa reviewer, has email == $reviewer_email, has name == $reviewer_name;
+----
+
+*`load_reviews.tql`*
+
+[source,typeql]
+----
+given $isbn: string, $reviewer_email: string,
+      $rating: integer, $review_text: string?, $reviewed_at: datetime;
+match
+  $b isa book, has isbn == $isbn;
+  $r isa reviewer, has email == $reviewer_email;
+insert
+  $rv isa review, links (book: $b, reviewer: $r),
+    has rating == $rating,
+    has reviewed_at == $reviewed_at;
+  try { $rv has review_text == $review_text; };
+----
+
+Each `given` variable must match a CSV header exactly. `review_text` is optional, so we mark it
+nullable (`string?`) and wrap its insert in `try { ... };` — empty cells become absent inputs
+and the clause skips.
+
+== Step 7: Run the loads
+
+[source,bash]
+----
+# Pass A — also creates the database and applies the schema
+typedb-loader \
+  --address localhost:1729 --username admin \
+  --database reviews --create-db \
+  --schema-file schema.tql \
+  --query load_books.tql --data books.csv --header
+
+# Pass B — db + schema already exist
+typedb-loader \
+  --address localhost:1729 --username admin \
+  --database reviews \
+  --query load_reviewers.tql --data reviewers.csv --header
+
+# Pass C — relations
+typedb-loader \
+  --address localhost:1729 --username admin \
+  --database reviews \
+  --query load_reviews.tql --data reviews.csv --header \
+  --null-values '' \
+  --batch-rows 1000 --parallel-batches 4
+----
+
+Notes:
+
+* Only pass A passes `--schema-file` and `--create-db`. Schema is committed once.
+* `--null-values ''` in pass C makes empty `review_text` cells become absent inputs, letting
+  the `try` clause skip them.
+
+== Step 8: Inspect, verify, iterate
+
+Each pass writes two files next to its data:
+
+* `*-rejects.csv` — the failing rows, reloadable as-is once the cause is fixed
+* `*-rejects.log` — the per-row error messages
+
+Common patterns:
+
+* *`@key` violation in pass A or B* — your `jq` dedupe missed something (often: trailing
+  whitespace, casing differences). Check the rejects CSV, fix the upstream JSON or the `jq`
+  filter, re-run on the rejects file.
+* *`match` found nothing in pass C* — the relation row references a book or reviewer that
+  wasn't loaded. Watch for this: TypeDB treats an empty `match` as a successful zero-result
+  query, so the row will _not_ be flagged in rejects — it'll just quietly produce no review. If
+  pass C looks suspiciously empty, that's where to look.
+* *Datetime parse error* — your CSV value doesn't match TypeDB's expected `datetime` format.
+  Normalize in `jq` (`.reviewed_at | strptime(...) | strftime(...)`) rather than relaxing the
+  schema.
+
+Verify in Console:
+
+[source,typeql]
+----
+match
+  $b isa book, has title $t;
+  $rv (book: $b) isa review, has rating $r;
+select $t, $r;
+----
+
+[source,typeql]
+----
+match
+  $b isa book, has title $t;
+  $rv (book: $b) isa review;
+reduce $reviews = count groupby $t;
+----
+
+== Patterns worth knowing
+
+* *Normalize in `jq`, not in TypeQL.* `jq` is a much better tool for reshaping than a load
+  query is — dedupe, flatten, rename, and type-normalize there, so each CSV is a clean
+  projection of one schema concept.
+* *Lookup-then-insert (`match ... insert`)* is how you load relations. Always match on
+  `@key` attributes — they're the fastest filter and give you a clear failure mode if the
+  referenced entity is missing.
+* *Don't try to upsert in a single pass.* TypeQL has no native upsert. The loader's strength
+  is running the same dataset through cleanly separated passes, not cramming everything into
+  one query.
+* *Iterate against a small slice.* While you're shaping your schema and queries, use
+  `--max-rows 100` and `--stop-on-error` on a throwaway database. Drop the cap and tune
+  `--batch-rows` / `--parallel-batches` once the rejects log is clean.
+* *Checkpoint files are per-run.* If you re-load against a fresh database, delete the
+  checkpoint file from the previous attempt or pass `--no-checkpoint`.
+* *Schema changes don't belong in resumed runs.* `--resume` ignores `--schema-file` and
+  `--create-db`. If you need to evolve the schema mid-load, finish or abandon the current run,
+  evolve the schema separately, then start a new load.

--- a/tools/modules/ROOT/pages/loader/json-example.adoc
+++ b/tools/modules/ROOT/pages/loader/json-example.adoc
@@ -1,4 +1,5 @@
 = JSON to TypeDB
+:test-typeql: linear
 
 This walkthrough takes a nested JSON dataset, designs a schema to fit it, normalizes it into
 CSVs, and loads it with the TypeDB Loader. The loader itself only consumes CSV, so the first

--- a/tools/modules/ROOT/pages/loader/json-example.adoc
+++ b/tools/modules/ROOT/pages/loader/json-example.adoc
@@ -1,12 +1,8 @@
 = JSON to TypeDB
 
-This walkthrough takes you end-to-end from a raw dataset to a fully loaded TypeDB database:
-reading the data, designing a schema to fit it, normalizing it into CSV form, writing the
-loader query, and handling the multi-pass patterns most real datasets require.
-
-We start from JSON — the shape data most often arrives in from an API. The loader itself only
-consumes CSV, so the first real engineering step is going from one to the other; we'll use
-`jq` for that.
+This walkthrough takes a nested JSON dataset, designs a schema to fit it, normalizes it into
+CSVs, and loads it with the TypeDB Loader. The loader itself only consumes CSV, so the first
+step is going from one to the other — we'll use `jq` for that, but keep the focus on the load.
 
 == Step 1: The source data
 
@@ -46,32 +42,17 @@ consumes CSV, so the first real engineering step is going from one to the other;
 }
 ----
 
-Three structural features matter before going further:
+Two things to notice: reviewers repeat across books (the same `alice@example.com` reviews
+multiple books), and `text` can be `null`. Both will shape the schema and the load.
 
-* *Nesting* — reviews live inside books; reviewers live inside reviews. The JSON encodes
-  relationships positionally.
-* *Implicit duplication* — the same reviewer (`alice@example.com`) appears under multiple
-  books. The JSON shape repeats them; the schema will not.
-* *Optional fields* — `text` is `null` for the 1984 review. JSON `null` will become an empty
-  CSV cell once normalized.
+== Step 2: Design the schema
 
-== Step 2: Identify entities and relations
-
-For each piece of information, ask three questions:
-
-. *Does this identify something?* (`isbn`, `reviewer.email`) → key on an entity
-. *Does it describe a thing?* (`title`, `reviewer.name`, `rating`) → an attribute
-. *Does the connection between two things matter on its own?* (a `review` ties a book and a
-  reviewer, and carries its own rating and date) → a relation
-
-The nesting in the JSON is encoding _relationships_, not ownership. A reviewer doesn't "belong
-to" a book in real life — they happened to review one. The schema recovers that fact:
+The JSON's nesting encodes _relationships_, not ownership: a reviewer doesn't belong to a book,
+they happened to review one. The schema recovers that:
 
 * `book` (entity, keyed by `isbn`)
 * `reviewer` (entity, keyed by `email`)
 * `review` (relation linking a book and a reviewer, with its own rating/text/date)
-
-== Step 3: Design the schema
 
 `schema.tql`:
 
@@ -106,48 +87,24 @@ book plays review:book;
 reviewer plays review:reviewer;
 ----
 
-Two choices worth calling out:
+`@key` enforces uniqueness on `isbn` and `email`, so duplicate inserts fail cleanly. `review` is
+a relation that owns its own attributes — no synthetic entity needed.
 
-* *`@key` on `isbn` and `email`* enforces uniqueness, so duplicate inserts fail cleanly — the
-  exact failure mode you want when deduping is incomplete.
-* *`review` is a relation that owns attributes.* In TypeDB, relations are first-class: they
-  carry their own attributes (rating, text, date) instead of forcing you to invent a synthetic
-  entity.
-
-== Step 4: Normalize JSON into CSVs with jq
+== Step 3: Normalize JSON into CSVs
 
 The loader consumes one CSV per pass, with one column per `given` input in the query template.
-We need three CSVs: books, reviewers, reviews. `jq` does this in one shot per file.
-
-=== Books
-
-Each book appears once in the JSON, so no dedup is needed:
+We need three CSVs: books, reviewers, reviews.
 
 [source,bash]
 ----
+# Books — one row per book
 jq -r '
   ["isbn", "title"],
   (.books[] | [.isbn, .title])
   | @csv
 ' source.json > books.csv
-----
 
-Output:
-
-[source,csv]
-----
-"isbn","title"
-"9780441172719","Dune"
-"9780553213119","Frankenstein"
-"9780451524935","1984"
-----
-
-=== Reviewers
-
-Reviewers repeat across books — dedupe inside `jq` using `unique_by`:
-
-[source,bash]
-----
+# Reviewers — deduped by email
 jq -r '
   [.books[].reviews[].reviewer]
   | unique_by(.email)
@@ -155,24 +112,8 @@ jq -r '
     (.[] | [.email, .name])
   | @csv
 ' source.json > reviewers.csv
-----
 
-Output:
-
-[source,csv]
-----
-"reviewer_email","reviewer_name"
-"alice@example.com","Alice"
-"bob@example.com","Bob"
-"carol@example.com","Carol"
-----
-
-=== Reviews
-
-One row per review, carrying the parent book's `isbn` onto each child:
-
-[source,bash]
-----
+# Reviews — one row per review, carrying the parent book's isbn
 jq -r '
   ["isbn", "reviewer_email", "rating", "review_text", "reviewed_at"],
   (.books[] as $b
@@ -182,7 +123,7 @@ jq -r '
 ' source.json > reviews.csv
 ----
 
-Output:
+The resulting `reviews.csv`:
 
 [source,csv]
 ----
@@ -193,26 +134,13 @@ Output:
 "9780451524935","carol@example.com",5,,"2024-02-20"
 ----
 
-Notice the `null` `text` for 1984 became an empty cell (`,,`). The loader will treat it as
-absent with `--null-values ''` — matching the optional `string?` we'll declare in the query
-template.
+The JSON `null` `text` for 1984 became an empty cell (`,,`). The loader will treat it as absent
+with `--null-values ''`, matching the optional `string?` in the query template.
 
-=== `jq` idioms used here
-
-* *`... as $b | ...`* — bind a parent so you can refer back to it inside nested iteration.
-  This is how the book's `isbn` ends up on every child review row.
-* *`unique_by(.field)`* — dedupe an array by a key. Safer than piping to `sort -u` because it
-  works on JSON values rather than on bytes (no quote/comma issues, no header sorted into the
-  data).
-* *`@csv`* — properly quotes strings, escapes embedded commas and quotes, and emits `null` as
-  an empty cell. Always prefer it over hand-rolled string concatenation.
-* *Concatenated outputs* — in `(["a","b"]), (.x | [...])`, the comma is jq's stream-concat
-  operator; it emits the header array first, then the data arrays in order.
-
-== Step 5: Plan the load passes
+== Step 4: Plan the load passes
 
 `@key` makes the multi-pass pattern necessary: you cannot insert the same key twice. The three
-CSVs from step 4 map directly onto three passes:
+CSVs map directly onto three passes:
 
 . *Pass A* — load `books.csv` (unique books)
 . *Pass B* — load `reviewers.csv` (unique reviewers)
@@ -221,7 +149,7 @@ CSVs from step 4 map directly onto three passes:
 
 Pass C must run after A and B because it uses `match` to find the entities it links.
 
-== Step 6: Write the loader queries
+== Step 5: Write the loader queries
 
 *`load_books.tql`*
 
@@ -261,7 +189,7 @@ Each `given` variable must match a CSV header exactly. `review_text` is optional
 nullable (`string?`) and wrap its insert in `try { ... };` — empty cells become absent inputs
 and the clause skips.
 
-== Step 7: Run the loads
+== Step 6: Run the loads
 
 [source,bash]
 ----
@@ -287,41 +215,23 @@ typedb-loader \
   --batch-rows 1000 --parallel-batches 4
 ----
 
-Notes:
+Only pass A passes `--schema-file` and `--create-db`. `--null-values ''` in pass C makes empty
+`review_text` cells become absent inputs, letting the `try` clause skip them.
 
-* Only pass A passes `--schema-file` and `--create-db`. Schema is committed once.
-* `--null-values ''` in pass C makes empty `review_text` cells become absent inputs, letting
-  the `try` clause skip them.
-
-== Step 8: Inspect, verify, iterate
+== Step 7: Inspect, verify, iterate
 
 Each pass writes two files next to its data:
 
 * `*-rejects.csv` — the failing rows, reloadable as-is once the cause is fixed
 * `*-rejects.log` — the per-row error messages
 
-Common patterns:
+Watch for *silent `match` failures in pass C* — if a review row references a book or reviewer
+that wasn't loaded, TypeDB treats the empty `match` as a successful zero-result query, so the
+row will _not_ be flagged in rejects. It'll just quietly produce no review. If pass C looks
+suspiciously empty, that's where to look. Use `--stop-on-error` during initial loads and compare
+row counts to catch this.
 
-* *`@key` violation in pass A or B* — your `jq` dedupe missed something (often: trailing
-  whitespace, casing differences). Check the rejects CSV, fix the upstream JSON or the `jq`
-  filter, re-run on the rejects file.
-* *`match` found nothing in pass C* — the relation row references a book or reviewer that
-  wasn't loaded. Watch for this: TypeDB treats an empty `match` as a successful zero-result
-  query, so the row will _not_ be flagged in rejects — it'll just quietly produce no review. If
-  pass C looks suspiciously empty, that's where to look.
-* *Datetime parse error* — your CSV value doesn't match TypeDB's expected `datetime` format.
-  Normalize in `jq` (`.reviewed_at | strptime(...) | strftime(...)`) rather than relaxing the
-  schema.
-
-Verify in Console:
-
-[source,typeql]
-----
-match
-  $b isa book, has title $t;
-  $rv (book: $b) isa review, has rating $r;
-select $t, $r;
-----
+Verify:
 
 [source,typeql]
 ----
@@ -333,18 +243,12 @@ reduce $reviews = count groupby $t;
 
 == Patterns worth knowing
 
-* *Normalize in `jq`, not in TypeQL.* `jq` is a much better tool for reshaping than a load
-  query is — dedupe, flatten, rename, and type-normalize there, so each CSV is a clean
-  projection of one schema concept.
-* *Lookup-then-insert (`match ... insert`)* is how you load relations. Always match on
-  `@key` attributes — they're the fastest filter and give you a clear failure mode if the
-  referenced entity is missing.
-* *Don't try to upsert in a single pass.* TypeQL has no native upsert. The loader's strength
-  is running the same dataset through cleanly separated passes, not cramming everything into
-  one query.
-* *Iterate against a small slice.* While you're shaping your schema and queries, use
-  `--max-rows 100` and `--stop-on-error` on a throwaway database. Drop the cap and tune
-  `--batch-rows` / `--parallel-batches` once the rejects log is clean.
+* *Normalize before the loader, not inside it.* Reshape, dedupe and rename in `jq` (or whatever
+  tool fits your source) so each CSV is a clean projection of one schema concept. The load
+  queries should be straightforward `insert` or `match ... insert` templates.
+* *Iterate against a small slice.* While shaping your schema and queries, use `--max-rows 100`
+  and `--stop-on-error` on a throwaway database. Drop the cap and tune `--batch-rows` /
+  `--parallel-batches` once the rejects log is clean.
 * *Checkpoint files are per-run.* If you re-load against a fresh database, delete the
   checkpoint file from the previous attempt or pass `--no-checkpoint`.
 * *Schema changes don't belong in resumed runs.* `--resume` ignores `--schema-file` and

--- a/tools/modules/ROOT/pages/loader/json-example.adoc
+++ b/tools/modules/ROOT/pages/loader/json-example.adoc
@@ -210,20 +210,20 @@ and the clause skips.
 [source,bash]
 ----
 # Pass A — also creates the database and applies the schema
-typedb-loader \
+typedb loader \
   --address localhost:1729 --username admin \
   --database reviews --create-db \
   --schema-file schema.tql \
   --query load_books.tql --data books.csv --header
 
 # Pass B — db + schema already exist
-typedb-loader \
+typedb loader \
   --address localhost:1729 --username admin \
   --database reviews \
   --query load_reviewers.tql --data reviewers.csv --header
 
 # Pass C — relations
-typedb-loader \
+typedb loader \
   --address localhost:1729 --username admin \
   --database reviews \
   --query load_reviews.tql --data reviews.csv --header \

--- a/tools/modules/ROOT/pages/loader/json-example.adoc
+++ b/tools/modules/ROOT/pages/loader/json-example.adoc
@@ -236,10 +236,13 @@ Only pass A passes `--schema-file` and `--create-db`. `--null-values ''` in pass
 
 == Step 7: Inspect, verify, iterate
 
-Each pass writes two files next to its data:
+Each pass writes its output into a directory next to the data (default
+`loader_<data-stem>_progress`, override with `--output-dir`):
 
-* `*-rejects.csv` — the failing rows, reloadable as-is once the cause is fixed
-* `*-rejects.log` — the per-row error messages
+* `checkpoint.json` — resumable state for `--resume`
+* `rejects.csv` — the failing rows, reloadable as-is once the cause is fixed (only created if
+  there are rejects)
+* `rejects.log` — the per-row error messages (only created if there are rejects)
 
 Watch for *silent `match` failures in pass C* — if a review row references a book or reviewer
 that wasn't loaded, TypeDB treats the empty `match` as a successful zero-result query, so the
@@ -266,8 +269,9 @@ reduce $reviews = count groupby $t;
 * *Iterate against a small slice.* While shaping your schema and queries, use `--max-rows 100`
   and `--stop-on-error` on a throwaway database. Drop the cap and tune `--batch-rows` /
   `--parallel-batches` once the rejects log is clean.
-* *Checkpoint files are per-run.* If you re-load against a fresh database, delete the
-  checkpoint file from the previous attempt or pass `--no-checkpoint`.
+* *Output directories are per-run.* If you re-load against a fresh database, delete the
+  previous output directory (or pass `--output-dir` to point at a new one, or
+  `--no-checkpoint` to skip checkpointing entirely).
 * *Schema changes don't belong in resumed runs.* `--resume` ignores `--schema-file` and
   `--create-db`. If you need to evolve the schema mid-load, finish or abandon the current run,
   evolve the schema separately, then start a new load.

--- a/tools/modules/ROOT/pages/loader/quickstart.adoc
+++ b/tools/modules/ROOT/pages/loader/quickstart.adoc
@@ -50,7 +50,7 @@ we can match the data into the query correctly.
 
 [source,bash]
 ----
-typedb-loader \
+typedb loader \
   --address localhost:1729 --username admin \
   --database people \
   --schema-file schema.tql --create-db \
@@ -70,13 +70,60 @@ with:
 
 [source,bash]
 ----
-typedb-loader --resume loader_data_progress --password ...
+typedb loader --resume loader_data_progress --password ...
 ----
 
 The checkpoint stores the original parameters and a hash of the data + live schema; you'll get
 a warning prompt if any of those has drifted, and a separate prompt for any batches that were
 in flight when the previous run stopped (the loader can't tell whether they actually
 committed, so you choose between reprocess all, skip all, or decide each).
+
+=== 6. Errors
+
+When a row fails to load, the loader writes it to `rejects.csv` in the output directory and
+records the reason in `rejects.log`. The run keeps going by default,
+since rejects don't abort the load unless you pass `--stop-on-error`.
+
+Suppose the data file repeats `alice`:
+
+[source,csv]
+----
+name,age,active
+alice,34,true
+bob,23,false
+alice,25,false
+carol,29,false
+----
+
+The third row violates `name @key`. Running with `--batch-rows 2`, the loader submits rows 3–4
+as a single batch — and because the batch is one transaction, both rows fail together. The
+resulting `rejects.csv` contains:
+
+[source,csv]
+----
+name,age,active
+alice,25,false
+carol,29,false
+----
+
+It's a valid CSV with the original header, so once you've fixed the upstream cause you can pass
+it straight back to the loader as `--data rejects.csv`.
+
+`rejects.log` records the row range, the batch number, and the full server error:
+
+[source,log]
+----
+rows 3-4, batch 2: query failed:
+[CNT9] Constraint '@unique' has been violated: there is a conflict for value '"alice"'.
+Caused: [DVL9] Instance [1E00 0000 0000 0000 0000 02] of type 'person' has a key constraint violation for attribute ownership of 'name', since it is not the unique owner of attribute '"alice"'.
+Caused: [COW5] Concept write failed due to a data validation error.
+Caused: [WEX1] Write execution failed due to a concept write error.
+Caused: [PEX6] Error executing write operation.
+Caused: [QEX14] Error while execution write pipeline.
+----
+
+You can tweak `--batch-rows` to limit how many row rejections a single error causes.
+
 
 == CSV hygiene
 
@@ -107,7 +154,7 @@ Before committing to a full load, validate the pipeline against a small slice:
 
 [source,bash]
 ----
-typedb-loader \
+typedb loader \
   --address localhost:1729 --username admin \
   --database scratch --create-db --schema-file schema.tql \
   --query load_x.tql --data full_data.csv --header \

--- a/tools/modules/ROOT/pages/loader/quickstart.adoc
+++ b/tools/modules/ROOT/pages/loader/quickstart.adoc
@@ -6,7 +6,19 @@ and resumable runs.
 
 == Example: loading people from a CSV
 
-=== 1. Schema (`schema.tql`)
+=== 1. Data (`data.csv`)
+
+[source,csv]
+----
+name,age,active
+alice,34,true
+bob,23,false
+carol,29,false
+----
+
+We start with some initial data in a CSV format - the format the loader can handle.
+
+=== 2. Schema (`schema.tql`)
 
 [source,typeql]
 ----
@@ -17,7 +29,7 @@ attribute active, value boolean;
 entity person owns name @key, owns age, owns active;
 ----
 
-=== 2. Query template (`query.tql`)
+=== 3. Query template (`query.tql`)
 
 [source,typeql]
 ----
@@ -31,17 +43,8 @@ insert
 The `given` variables become the loader's inputs. The `?` marks them optional, and
 `try { ... };` lets a row succeed even when that column is empty.
 
-=== 3. Data (`data.csv`)
-
-[source,csv]
-----
-name,age,active
-alice,34,true
-bob,,false
-carol,29,
-----
-
-CSV header names must match the `given` variable names exactly.
+By using the column names of the CSV for our `given` variables,
+we can match the data into the query correctly.
 
 === 4. Run
 
@@ -52,9 +55,11 @@ typedb-loader \
   --database people \
   --schema-file schema.tql --create-db \
   --query query.tql \
-  --data data.csv --header \
-  --max-rejects 100
+  --data data.csv --header
 ----
+
+We provide `--schema-file schema.tql --create-db`,
+to allow us to set up the database and load data into it in one go.
 
 === 5. Resuming
 
@@ -70,7 +75,7 @@ warning prompt if either has drifted.
 
 == CSV hygiene
 
-Most loader failures come from the CSV, not from TypeDB. A few things to check before a full
+Many loader failures come from the CSV, not from TypeDB. A few things to check before a full
 load:
 
 * *Headers must match `given` variables exactly* — case-sensitive, no leading or trailing
@@ -78,9 +83,6 @@ load:
   or "unknown variable" on the very first row.
 ** Headers can be omitted - in which case variables will be inserted positionally.
    We recommend including headers to ensure data always ends up used as expected.
-* *Use a real CSV writer.* `jq`'s `@csv`, Python's `csv.writer`, R's `write.csv`, `mlr` —
-  anything that knows the RFC 4180 quoting rules. Hand-built CSV (`echo` + commas) breaks the
-  moment a field contains a comma, quote, or newline.
 * *Embedded quotes are doubled, not backslash-escaped.* `He said "hi"` becomes
   `"He said ""hi"""`. A stray `\"` in a quoted field is treated as the closing quote, and
   every subsequent row will parse against the wrong columns — usually with a confusing
@@ -116,27 +118,13 @@ Once the dry run is clean, drop `--max-rows`, drop `--stop-on-error`, and tune `
 
 == General advice
 
-* *`given` ↔ CSV headers*: the loader binds CSV columns to query variables by name. Mismatches
-  surface as parse rejections — check the rejects log first.
-* *Make optional columns optional in the query, not the CSV*: declare `$x: T?` in `given` and
+* *Make optional columns optional in the query*: declare `$x: T?` in `given` and
   wrap inserts in `try { ... };`. Without `--null-values`, only empty cells become absent inputs.
 * *`--null-values` replaces the empty-cell default — it doesn't extend it.* As soon as you pass
   `--null-values NA`, empty cells stop being treated as null. The example above includes
   `--null-values ''` explicitly so that both empty cells and the string `NULL` count as null.
-* *`--max-rows 0` clears an inherited cap on resume.* `--max-rows` is persisted in the
-  checkpoint, so a resumed run inherits the original cap. To resume past it without specifying a
-  new finite limit, pass `--max-rows 0` to mean "no cap at all".
-* *Tune `--batch-rows` and `--parallel-batches` together*: larger batches mean fewer commits but
-  longer write transactions; more parallelism means more concurrent write conflicts. Start at
-  `1000 × 4` and adjust based on commit failures in the rejects log.
-* *Don't change `--batch-rows` on resume* — the loader's cursor depends on it and will refuse to
-  continue.
 * *`--schema-file` and `--create-db` are ignored on resume*, with a warning. Keep schema setup
   as a separate one-shot step if you expect to iterate.
 * *Two rejects files are written*: `*-rejects.csv` (the raw failing rows, reloadable) and
   `*-rejects.log` (the per-row error message). Re-running the loader on the rejects CSV after a
   fix is a common workflow.
-* *Use `--stop-on-error` for schema bring-up* (so you catch query/CSV mismatches immediately)
-  and *`--max-rejects N` for bulk loads* (let bad rows accumulate, abort if the failure rate is
-  too high).
-* *TLS is on by default.* Only use `--tls-disabled` against a local dev server.

--- a/tools/modules/ROOT/pages/loader/quickstart.adoc
+++ b/tools/modules/ROOT/pages/loader/quickstart.adoc
@@ -1,4 +1,10 @@
 = Quickstart
+:keywords: typedb, typeql, tutorial, guide, loader
+:pageTitle:
+:summary:
+:page-toclevels: 2
+:tabs-sync-option:
+:test-typeql: linear
 
 A CSV-driven bulk loader for TypeDB. Each CSV row is bound to the variables of a TypeQL query
 template and submitted in batches over write transactions, with checkpointing, rejects capture,
@@ -22,6 +28,7 @@ We start with some initial data in a CSV format - the format the loader can hand
 
 [source,typeql]
 ----
+#!test
 define
 attribute name, value string;
 attribute age, value integer;

--- a/tools/modules/ROOT/pages/loader/quickstart.adoc
+++ b/tools/modules/ROOT/pages/loader/quickstart.adoc
@@ -28,7 +28,7 @@ We start with some initial data in a CSV format - the format the loader can hand
 
 [source,typeql]
 ----
-#!test
+#!test[schema]
 define
 attribute name, value string;
 attribute age, value integer;

--- a/tools/modules/ROOT/pages/loader/quickstart.adoc
+++ b/tools/modules/ROOT/pages/loader/quickstart.adoc
@@ -1,0 +1,142 @@
+= Quickstart
+
+A CSV-driven bulk loader for TypeDB. Each CSV row is bound to the variables of a TypeQL query
+template and submitted in batches over write transactions, with checkpointing, rejects capture,
+and resumable runs.
+
+== Example: loading people from a CSV
+
+=== 1. Schema (`schema.tql`)
+
+[source,typeql]
+----
+define
+attribute name, value string;
+attribute age, value integer;
+attribute active, value boolean;
+entity person owns name @key, owns age, owns active;
+----
+
+=== 2. Query template (`query.tql`)
+
+[source,typeql]
+----
+given $name: string, $age: integer?, $active: boolean?;
+insert
+  $p isa person, has name == $name;
+  try { $p has age == $age; };
+  try { $p has active == $active; };
+----
+
+The `given` variables become the loader's inputs. The `?` marks them optional, and
+`try { ... };` lets a row succeed even when that column is empty.
+
+=== 3. Data (`data.csv`)
+
+[source,csv]
+----
+name,age,active
+alice,34,true
+bob,,false
+carol,29,
+----
+
+CSV header names must match the `given` variable names exactly.
+
+=== 4. Run
+
+[source,bash]
+----
+typedb-loader \
+  --address localhost:1729 --username admin \
+  --database people \
+  --schema-file schema.tql --create-db \
+  --query query.tql \
+  --data data.csv --header \
+  --max-rejects 100
+----
+
+=== 5. Resuming
+
+If the run is interrupted (Ctrl+C, network blip, server restart), restart it with:
+
+[source,bash]
+----
+typedb-loader --resume data-checkpoint.json --password ...
+----
+
+The checkpoint stores the original parameters and a hash of the data + live schema; you'll get a
+warning prompt if either has drifted.
+
+== CSV hygiene
+
+Most loader failures come from the CSV, not from TypeDB. A few things to check before a full
+load:
+
+* *Headers must match `given` variables exactly* — case-sensitive, no leading or trailing
+  whitespace, no quoting around the header cell itself. A typo here turns into "missing column"
+  or "unknown variable" on the very first row.
+** Headers can be omitted - in which case variables will be inserted positionally.
+   We recommend including headers to ensure data always ends up used as expected.
+* *Use a real CSV writer.* `jq`'s `@csv`, Python's `csv.writer`, R's `write.csv`, `mlr` —
+  anything that knows the RFC 4180 quoting rules. Hand-built CSV (`echo` + commas) breaks the
+  moment a field contains a comma, quote, or newline.
+* *Embedded quotes are doubled, not backslash-escaped.* `He said "hi"` becomes
+  `"He said ""hi"""`. A stray `\"` in a quoted field is treated as the closing quote, and
+  every subsequent row will parse against the wrong columns — usually with a confusing
+  "unexpected EOF" or column-count error far below the actual culprit.
+* *Normalise to UTF-8 with no BOM.* A leading BOM (`U+FEFF`) silently glues itself onto the
+  first header name, so the column match fails on row one with no obvious cause.
+* *Trim insignificant whitespace.* `  alice@example.com` won't equal `alice@example.com`
+  inside a `match` clause — that's a silent zero-result query, not a reject. Strip it upstream.
+* *Watch for type-coercion surprises in your export.* Leading zeros on phone numbers and
+  postcodes, ISBNs with hyphens, dates that look like integers — a real CSV writer keeps these
+  as strings; bespoke exports often drop the leading zero or split on the hyphen before you
+  see the file.
+
+== Dry-run first
+
+Before committing to a full load, validate the pipeline against a small slice:
+
+[source,bash]
+----
+typedb-loader \
+  --address localhost:1729 --username admin \
+  --database scratch --create-db --schema-file schema.tql \
+  --query load_x.tql --data full_data.csv --header \
+  --max-rows 100 --stop-on-error
+----
+
+This catches schema mismatches, header typos, quoting issues, and datetime format errors within
+seconds, rather than after a multi-minute load. Run against a throwaway database so you can
+`database delete` it before the real load.
+
+Once the dry run is clean, drop `--max-rows`, drop `--stop-on-error`, and tune `--batch-rows`
+/ `--parallel-batches` for the full run.
+
+== General advice
+
+* *`given` ↔ CSV headers*: the loader binds CSV columns to query variables by name. Mismatches
+  surface as parse rejections — check the rejects log first.
+* *Make optional columns optional in the query, not the CSV*: declare `$x: T?` in `given` and
+  wrap inserts in `try { ... };`. Without `--null-values`, only empty cells become absent inputs.
+* *`--null-values` replaces the empty-cell default — it doesn't extend it.* As soon as you pass
+  `--null-values NA`, empty cells stop being treated as null. The example above includes
+  `--null-values ''` explicitly so that both empty cells and the string `NULL` count as null.
+* *`--max-rows 0` clears an inherited cap on resume.* `--max-rows` is persisted in the
+  checkpoint, so a resumed run inherits the original cap. To resume past it without specifying a
+  new finite limit, pass `--max-rows 0` to mean "no cap at all".
+* *Tune `--batch-rows` and `--parallel-batches` together*: larger batches mean fewer commits but
+  longer write transactions; more parallelism means more concurrent write conflicts. Start at
+  `1000 × 4` and adjust based on commit failures in the rejects log.
+* *Don't change `--batch-rows` on resume* — the loader's cursor depends on it and will refuse to
+  continue.
+* *`--schema-file` and `--create-db` are ignored on resume*, with a warning. Keep schema setup
+  as a separate one-shot step if you expect to iterate.
+* *Two rejects files are written*: `*-rejects.csv` (the raw failing rows, reloadable) and
+  `*-rejects.log` (the per-row error message). Re-running the loader on the rejects CSV after a
+  fix is a common workflow.
+* *Use `--stop-on-error` for schema bring-up* (so you catch query/CSV mismatches immediately)
+  and *`--max-rejects N` for bulk loads* (let bad rows accumulate, abort if the failure rate is
+  too high).
+* *TLS is on by default.* Only use `--tls-disabled` against a local dev server.

--- a/tools/modules/ROOT/pages/loader/quickstart.adoc
+++ b/tools/modules/ROOT/pages/loader/quickstart.adoc
@@ -63,15 +63,20 @@ to allow us to set up the database and load data into it in one go.
 
 === 5. Resuming
 
-If the run is interrupted (Ctrl+C, network blip, server restart), restart it with:
+The loader writes its output (checkpoint, rejects CSV, rejects log) into a single directory —
+by default `loader_<data-stem>_progress` next to the data file, or whatever you pass to
+`--output-dir`. If the run is interrupted (Ctrl+C, network blip, server restart), restart it
+with:
 
 [source,bash]
 ----
-typedb-loader --resume data-checkpoint.json --password ...
+typedb-loader --resume loader_data_progress --password ...
 ----
 
-The checkpoint stores the original parameters and a hash of the data + live schema; you'll get a
-warning prompt if either has drifted.
+The checkpoint stores the original parameters and a hash of the data + live schema; you'll get
+a warning prompt if any of those has drifted, and a separate prompt for any batches that were
+in flight when the previous run stopped (the loader can't tell whether they actually
+committed, so you choose between reprocess all, skip all, or decide each).
 
 == CSV hygiene
 
@@ -125,6 +130,6 @@ Once the dry run is clean, drop `--max-rows`, drop `--stop-on-error`, and tune `
   `--null-values ''` explicitly so that both empty cells and the string `NULL` count as null.
 * *`--schema-file` and `--create-db` are ignored on resume*, with a warning. Keep schema setup
   as a separate one-shot step if you expect to iterate.
-* *Two rejects files are written*: `*-rejects.csv` (the raw failing rows, reloadable) and
-  `*-rejects.log` (the per-row error message). Re-running the loader on the rejects CSV after a
-  fix is a common workflow.
+* *Two rejects files are written into the output directory*: `rejects.csv` (the raw failing
+  rows, reloadable) and `rejects.log` (the per-row error message). Re-running the loader on
+  the rejects CSV after a fix is a common workflow.

--- a/tools/modules/ROOT/pages/loader/reference.adoc
+++ b/tools/modules/ROOT/pages/loader/reference.adoc
@@ -1,0 +1,201 @@
+= TypeDB Loader Reference
+
+Reference for every command-line flag accepted by the TypeDB Loader, grouped by topic.
+
+[NOTE]
+====
+On resume (`--resume PATH`), every flag in this document — except `--schema-file` and
+`--create-db`, which are inert on resume — defaults to the value stored in the checkpoint
+unless explicitly overridden on the command line. Defaults shown below are the fresh-run
+defaults; on resume, the "default" is whatever the previous run used.
+====
+
+== Connection
+
+`--address <host:port[,host:port]>`::
+TypeDB server address(es) to connect to. Accepts either a single `host:port` or a comma-
+separated list. Also available under the alias `--addresses`.
++
+*Required.* No default.
+
+`--username <username>`::
+Username for authentication.
++
+*Required.* No default.
+
+`--password <password>`::
+Password for authentication.
++
+If omitted, the loader prompts on stdin (without echo).
+
+`--tls-disabled[=true|false]`::
+Disable TLS encryption on the wire. Defaults to `false` (TLS enabled).
+
+`--tls-root-ca <path>`::
+Path to a custom TLS root CA certificate for the connection.
+
+== Database and schema setup
+
+`--database <name>`::
+Database to load into.
++
+*Required.* No default.
+
+`--schema-file <path>`::
+Path to a TypeQL schema file to apply in a schema transaction before any data loading.
++
+*Ignored (with a warning) when resuming.*
+
+`--create-db[=true|false]`::
+Create the database if it does not already exist. Defaults to `false`.
++
+*Ignored (with a warning) when resuming.*
+
+== Data and query
+
+`--query <path to .tql>`::
+Path to the TypeQL query template used for loading. The query's `given` variables are bound to
+CSV columns by name.
++
+*Required.* No default.
+
+`--data <path to .csv>`::
+Path to the CSV file to load.
++
+*Required.* No default.
+
+`--header[=true|false]`::
+Whether the CSV file has a header row. Defaults to `false`.
++
+With `--header true`, the first row is used as the column-name → `given`-variable mapping. With
+`--header false`, columns are bound positionally in the order declared in `given`.
+
+`--no-header`::
+Force header parsing off. Use this to override a checkpoint that had `--header true` set.
+Mutually exclusive with `--header`.
+
+`--null-values <value>`::
+A string value in the CSV to treat as null. May be repeated to specify multiple sentinels (e.g.
+`--null-values '' --null-values NULL --null-values NA`).
++
+Defaults to treating only empty cells as null.
++
+[IMPORTANT]
+*Replaces, not extends.* As soon as you pass `--null-values NA`, empty cells stop being null
+unless you also pass `--null-values ''` explicitly.
+
+`--max-rows <n>`::
+Process at most `n` data rows. Defaults to all rows.
++
+Pass `--max-rows 0` to clear an inherited cap on resume (the value persists in the checkpoint
+otherwise).
+
+== Batching and parallelism
+
+`--batch-rows <n>`::
+Number of CSV rows submitted in each `query_with_inputs` invocation. Each batch is committed in
+its own write transaction. Defaults to `1000`.
++
+[IMPORTANT]
+*Cannot be changed on resume.* The loader's cursor depends on the original batch size; a
+resume that passes a different value is rejected with an error.
+
+`--parallel-batches <n>`::
+Maximum number of batches submitted concurrently to the server. Defaults to `1` (no parllelism).
++
+Higher values increase throughput at the cost of more concurrent write transactions, which can
+cause commit conflicts. Tune in tandem with `--batch-rows`.
+
+== Rejects
+
+`--rejects-file <path to .csv>`::
+Path for the CSV file containing rejected rows. The file is reloadable as-is once the cause of
+rejection is fixed.
++
+Defaults to `<data-stem>-rejects.csv` alongside the data file.
+
+`--rejects-log <path>`::
+Path for the per-rejection error log (one entry per rejected row, with the failure reason).
++
+Defaults to `<data-stem>-rejects.log` alongside the data file.
+
+== Error handling
+
+`--stop-on-error[=true|false]`::
+Abort on the first row or batch error, instead of skipping and continuing. The offending rows
+are still written to the rejects file before exit. Defaults to `false`.
+
+`--no-stop-on-error`::
+Force stop-on-error off. Use this to override a checkpoint that had it enabled. Mutually
+exclusive with `--stop-on-error`.
+
+`--max-rejects <n>`::
+Abort once the total number of rejected rows exceeds this threshold. Applies independently of
+`--stop-on-error`.
++
+Defaults to unlimited.
+
+== Checkpointing and resume
+
+`--checkpoint-file <path>`::
+Path for the checkpoint JSON file written during the run.
++
+Defaults to `<data-stem>-checkpoint.json` alongside the data file.
++
+A fresh run aborts if the target checkpoint path already exists; pass `--resume` to continue
+from it, `--checkpoint-file` to write elsewhere, or `--no-checkpoint` to disable checkpointing.
+
+`--no-checkpoint`::
+Disable checkpointing entirely. The loader writes no checkpoint file and the run is not
+resumable. Defaults to `false`.
++
+Mutually exclusive with `--resume`.
+
+`--resume <path to checkpoint file>`::
+Resume a previous run from the named checkpoint file. Parameters from the checkpoint are used
+unless explicitly overridden on the command line.
++
+A resumed run never re-applies the schema or creates the database — `--schema-file` and
+`--create-db` are ignored with a warning if supplied.
++
+The loader presents a confirmation prompt before resuming if:
++
+--
+* the data file's hash differs from the checkpoint, or
+* the live TypeDB schema's hash differs from the checkpoint, or
+* the checkpoint records any batches that were in flight when the previous run stopped (the
+  loader prints the first row of each so you can decide whether to re-process them).
+--
+
+== Help and version
+
+`-h`, `--help`::
+Print the auto-generated help message and exit.
+
+`-V`, `--version`::
+Print the loader version and exit.
+
+== Exit codes
+
+[cols="1,3"]
+|===
+| Code | Meaning
+
+| `0` | The run completed; all batches finished. The presence of rejects does not change this.
+| `1` | General error (I/O failure, query parse failure, internal panic).
+| `2` | User-input error (bad/missing flags, invalid combinations, hard checkpoint mismatch).
+| `3` | Connection error (could not reach or authenticate against the server).
+| `130` | Forced exit after a second Ctrl+C — sent only if the user interrupts the graceful drain.
+|===
+
+== Resume behaviour summary
+
+A few cross-cutting rules to keep in mind when reading the per-flag entries above:
+
+* On resume, every flag's effective value is `cli arg if provided, else checkpoint value`.
+* `--batch-rows` is the one exception: it cannot differ from the checkpoint.
+* `--schema-file` and `--create-db` are ignored on resume.
+* `--no-checkpoint` cannot be combined with `--resume`.
+* `--max-rows 0` is a sentinel that clears an inherited cap; any other value sets a new cap.
+* The `--no-X` opt-out flags (`--no-header`, `--no-stop-on-error`) exist solely so a resume can
+  override a checkpoint that had the corresponding flag enabled.

--- a/tools/modules/ROOT/pages/loader/reference.adoc
+++ b/tools/modules/ROOT/pages/loader/reference.adoc
@@ -1,4 +1,9 @@
 = TypeDB Loader Reference
+:keywords: typedb, loader
+:pageTitle:
+:summary:
+:page-toclevels: 2
+:tabs-sync-option:
 
 Reference for every command-line flag accepted by the TypeDB Loader, grouped by topic.
 

--- a/tools/modules/ROOT/pages/loader/reference.adoc
+++ b/tools/modules/ROOT/pages/loader/reference.adoc
@@ -106,18 +106,19 @@ Maximum number of batches submitted concurrently to the server. Defaults to `1` 
 Higher values increase throughput at the cost of more concurrent write transactions, which can
 cause commit conflicts. Tune in tandem with `--batch-rows`.
 
-== Rejects
+== Output directory
 
-`--rejects-file <path to .csv>`::
-Path for the CSV file containing rejected rows. The file is reloadable as-is once the cause of
-rejection is fixed.
-+
-Defaults to `<data-stem>-rejects.csv` alongside the data file.
+The loader writes three artifacts into a single output directory: `checkpoint.json`,
+`rejects.csv` (rejected rows, reloadable as-is once their cause is fixed), and `rejects.log`
+(per-rejection error message). The rejects files are only created when at least one row is
+rejected.
 
-`--rejects-log <path>`::
-Path for the per-rejection error log (one entry per rejected row, with the failure reason).
+`--output-dir <path>`::
+Directory to write the loader's output into. Created if it does not already exist.
 +
-Defaults to `<data-stem>-rejects.log` alongside the data file.
+Defaults to `loader_<data-stem>_progress` alongside the data file.
++
+Cannot be combined with `--resume`, as resuming re-uses the existing output directory.
 
 == Error handling
 
@@ -137,23 +138,20 @@ Defaults to unlimited.
 
 == Checkpointing and resume
 
-`--checkpoint-file <path>`::
-Path for the checkpoint JSON file written during the run.
-+
-Defaults to `<data-stem>-checkpoint.json` alongside the data file.
-+
-A fresh run aborts if the target checkpoint path already exists; pass `--resume` to continue
-from it, `--checkpoint-file` to write elsewhere, or `--no-checkpoint` to disable checkpointing.
-
 `--no-checkpoint`::
 Disable checkpointing entirely. The loader writes no checkpoint file and the run is not
 resumable. Defaults to `false`.
 +
 Mutually exclusive with `--resume`.
++
+A fresh run aborts if a `checkpoint.json` already exists in the chosen output directory; pass
+`--resume <dir>` to continue from it, `--output-dir <other>` to write elsewhere, or
+`--no-checkpoint` to disable checkpointing.
 
-`--resume <path to checkpoint file>`::
-Resume a previous run from the named checkpoint file. Parameters from the checkpoint are used
-unless explicitly overridden on the command line.
+`--resume <path to previous output directory>`::
+Resume a previous run by pointing at its output directory (the one that contains
+`checkpoint.json`). Parameters from the checkpoint are used unless explicitly overridden on the
+command line.
 +
 A resumed run never re-applies the schema or creates the database — `--schema-file` and
 `--create-db` are ignored with a warning if supplied.
@@ -196,6 +194,7 @@ A few cross-cutting rules to keep in mind when reading the per-flag entries abov
 * `--batch-rows` is the one exception: it cannot differ from the checkpoint.
 * `--schema-file` and `--create-db` are ignored on resume.
 * `--no-checkpoint` cannot be combined with `--resume`.
+* `--output-dir` cannot be combined with `--resume`, as it re-uses the existing output directory
 * `--max-rows 0` is a sentinel that clears an inherited cap; any other value sets a new cap.
 * The `--no-X` opt-out flags (`--no-header`, `--no-stop-on-error`) exist solely so a resume can
   override a checkpoint that had the corresponding flag enabled.

--- a/tools/modules/ROOT/pages/loader/sql-example.adoc
+++ b/tools/modules/ROOT/pages/loader/sql-example.adoc
@@ -1,4 +1,5 @@
 = Migrating a SQL Database
+:test-typeql: linear
 
 This walkthrough takes a small relational schema, remodels it for TypeDB, and loads it end-to-end
 with the TypeDB Loader. The modelling shift is brief; the bulk of the work is one loader

--- a/tools/modules/ROOT/pages/loader/sql-example.adoc
+++ b/tools/modules/ROOT/pages/loader/sql-example.adoc
@@ -131,7 +131,10 @@ carries an FK, you can insert the entity and its relation together in a single `
 
 [source,typeql]
 ----
-given $id: integer, $name: string, $email: string;
+given
+    $id: integer,
+    $name: string,
+    $email: string;
 insert
   $c isa customer,
     has customer_id == $id,
@@ -143,7 +146,10 @@ insert
 
 [source,typeql]
 ----
-given $id: integer, $name: string, $price: decimal;
+given
+    $id: integer,
+    $name: string,
+    $price: decimal;
 insert
   $p isa product,
     has product_id == $id,
@@ -155,9 +161,13 @@ insert
 
 [source,typeql]
 ----
-given $id: integer, $customer_id: integer, $created_at: datetime;
+given
+    $id: integer,
+    $customer_id: integer,
+    $created_at: datetime;
 match
-  $c isa customer, has customer_id == $customer_id;
+  $c isa customer,
+    has customer_id == $customer_id;
 insert
   $o isa order,
     has order_id == $id,
@@ -223,9 +233,6 @@ match
   let $line_total = $q * $pr;
 reduce $spend = sum($line_total) groupby $n;
 ----
-
-In SQL, this would be a four-way join with an explicit `GROUP BY`.
-In TypeQL, the relations carry the joins.
 
 == Patterns worth knowing
 

--- a/tools/modules/ROOT/pages/loader/sql-example.adoc
+++ b/tools/modules/ROOT/pages/loader/sql-example.adoc
@@ -1,0 +1,304 @@
+= Migrating a SQL Database
+
+This walkthrough takes you from a relational SQL schema to a fully loaded TypeDB database. This
+requires us to shift the way our data is modelled — predominantly, things that formerly used
+foreign keys will now use relations. Once we've remodelled that, we can use the TypeDB Loader
+to relatively simply perform the actual loading.
+
+We'll use a small e-commerce schema with two common SQL patterns:
+
+* a *1:N foreign key* (an order belongs to a customer), and
+* a *M:N join table with payload* (order line items, with a quantity).
+
+== Step 1: The source schema
+
+[source,sql]
+----
+CREATE TABLE customers (
+  id    INTEGER PRIMARY KEY,
+  name  TEXT NOT NULL,
+  email TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE products (
+  id    INTEGER PRIMARY KEY,
+  name  TEXT NOT NULL,
+  price NUMERIC(10,2) NOT NULL
+);
+
+CREATE TABLE orders (
+  id          INTEGER PRIMARY KEY,
+  customer_id INTEGER NOT NULL REFERENCES customers(id),
+  created_at  TIMESTAMP NOT NULL
+);
+
+CREATE TABLE order_items (
+  order_id   INTEGER NOT NULL REFERENCES orders(id),
+  product_id INTEGER NOT NULL REFERENCES products(id),
+  quantity   INTEGER NOT NULL,
+  PRIMARY KEY (order_id, product_id)
+);
+----
+
+== Step 2: Export to CSV
+
+The loader consumes one CSV per pass, so the bridge from SQL is a per-table dump. From
+PostgreSQL:
+
+[source,bash]
+----
+psql ecommerce <<'SQL'
+\copy customers   TO 'customers.csv'   CSV HEADER
+\copy products    TO 'products.csv'    CSV HEADER
+\copy orders      TO 'orders.csv'      CSV HEADER
+\copy order_items TO 'order_items.csv' CSV HEADER
+SQL
+----
+
+(MySQL: `SELECT ... INTO OUTFILE`. SQLite: `.mode csv` + `.headers on` + `.output`.)
+
+The CSV columns line up with the SQL columns 1:1 — `id`, `customer_id`, etc. We'll keep these
+names through to the loader queries.
+
+== Step 3: SQL → TypeDB, one mapping rule at a time
+
+[cols="1,2"]
+|===
+| SQL pattern | TypeDB pattern
+
+| Table with a primary key
+| Entity that owns the PK as `@key`
+
+| Non-key column
+| Attribute owned by the entity
+
+| 1:N foreign key column
+| Relation between the two entity types
+
+| Pure join table (composite PK only)
+| Relation with one role per FK
+
+| Join table with extra columns
+| Relation that owns those columns as attributes
+
+| Self-referencing FK
+| Relation where both role players are the same type
+
+| `NOT NULL` constraint
+| Plain `owns attr` (TypeDB ownership is optional by default; declare it as required if needed)
+
+| `UNIQUE` constraint
+| `owns attr @unique` (or `@key` if it identifies the type)
+|===
+
+The single most important shift is the third row: in SQL, `orders.customer_id` is a column on
+`orders`. In TypeDB, it doesn't exist as an attribute at all — instead, a `placement` relation
+ties a `customer` to an `order`. Relations are first-class, bidirectional, and can themselves
+carry attributes; FK columns are a workaround for the absence of that primitive.
+
+== Step 4: Design the schema
+
+`schema.tql`:
+
+[source,typeql]
+----
+define
+
+attribute customer_id, value integer;
+attribute product_id, value integer;
+attribute order_id, value integer;
+
+attribute name, value string;
+attribute email, value string;
+attribute price, value decimal;
+attribute created_at, value datetime;
+attribute quantity, value integer;
+
+entity customer,
+  owns customer_id @key,
+  owns name,
+  owns email @unique;
+
+entity product,
+  owns product_id @key,
+  owns name,
+  owns price;
+
+entity order,
+  owns order_id @key,
+  owns created_at;
+
+relation placement,
+  relates customer,
+  relates order;
+
+relation line_item,
+  relates order,
+  relates product,
+  owns quantity;
+
+customer plays placement:customer;
+order plays placement:order;
+order plays line_item:order;
+product plays line_item:product;
+----
+
+Things to notice against the SQL:
+
+* `orders.customer_id` became the `placement` relation, not an attribute of `order`.
+* `order_items` became the `line_item` relation. Its `quantity` payload column became an
+  attribute owned by the relation itself — no synthetic entity.
+* Surrogate IDs (`customer_id`, `product_id`, `order_id`) survive as `@key` attributes because
+  the SQL CSV uses them to encode FKs. If you migrate further, you could often replace them
+  with natural keys (e.g. `email` already identifies a customer).
+
+== Step 5: Plan the load passes
+
+Each relation pass uses `match` on the `@key` attribute of the referenced entity, so entities
+must exist before any relation referencing them is loaded:
+
+. *customers* — entity only
+. *products* — entity only
+. *orders* — entity *and* `placement` relation, in one query (the order CSV already
+  carries the `customer_id`, so we look the customer up while inserting the order)
+. *order_items* — `line_item` relation only
+
+This is one pass per CSV file from step 2. Note that pass 3 is the common shortcut: when the
+entity's CSV already carries an FK, you can insert the entity and its relation together in a
+single `match … insert` pipeline.
+
+== Step 6: Write the loader queries
+
+*`load_customers.tql`*
+
+[source,typeql]
+----
+given $id: integer, $name: string, $email: string;
+insert
+  $c isa customer,
+    has customer_id == $id,
+    has name == $name,
+    has email == $email;
+----
+
+*`load_products.tql`*
+
+[source,typeql]
+----
+given $id: integer, $name: string, $price: decimal;
+insert
+  $p isa product,
+    has product_id == $id,
+    has name == $name,
+    has price == $price;
+----
+
+*`load_orders.tql`*
+
+[source,typeql]
+----
+given $id: integer, $customer_id: integer, $created_at: datetime;
+match
+  $c isa customer, has customer_id == $customer_id;
+insert
+  $o isa order,
+    has order_id == $id,
+    has created_at == $created_at;
+  $pl isa placement, links (customer: $c, order: $o);
+----
+
+*`load_order_items.tql`*
+
+[source,typeql]
+----
+given $order_id: integer, $product_id: integer, $quantity: integer;
+match
+  $o isa order, has order_id == $order_id;
+  $p isa product, has product_id == $product_id;
+insert
+  $li isa line_item, links (order: $o, product: $p),
+    has quantity == $quantity;
+----
+
+Each `given` variable matches a CSV column header from the SQL dump verbatim. The `match` stage
+is the FK resolution — replacing what would have been a join on `customer_id` in SQL.
+
+== Step 7: Run the loads
+
+[source,bash]
+----
+# Pass 1 — customers (also creates db + schema)
+typedb-loader \
+  --address localhost:1729 --username admin \
+  --database shop --create-db --schema-file schema.tql \
+  --query load_customers.tql --data customers.csv --header
+
+# Pass 2 — products
+typedb-loader \
+  --address localhost:1729 --username admin --database shop \
+  --query load_products.tql --data products.csv --header
+
+# Pass 3 — orders + placement
+typedb-loader \
+  --address localhost:1729 --username admin --database shop \
+  --query load_orders.tql --data orders.csv --header \
+  --batch-rows 1000 --parallel-batches 4
+
+# Pass 4 — line items
+typedb-loader \
+  --address localhost:1729 --username admin --database shop \
+  --query load_order_items.tql --data order_items.csv --header \
+  --batch-rows 1000 --parallel-batches 4
+----
+
+== Step 8: Verify
+
+[source,typeql]
+----
+# Orders per customer
+match
+  $c isa customer, has name $n;
+  $o isa order;
+  $pl isa placement, links (customer: $c, order: $o);
+reduce $orders = count groupby $n;
+----
+
+[source,typeql]
+----
+# Total spend per customer
+match
+  $c isa customer, has name $n;
+  $o isa order;
+  $pl isa placement, links (customer: $c, order: $o);
+  $li isa line_item, links (order: $o, product: $p), has quantity $q;
+  $p isa product, has price $pr;
+  let $line_total = $q * $pr;
+reduce $spend = sum($line_total) groupby $n;
+----
+
+In SQL, the second query would be a four-way join (`customers ⋈ orders ⋈ order_items ⋈
+products`) with an explicit `GROUP BY`. In TypeQL, the relations carry the joins — there's no
+join condition because the relations _are_ the conditions.
+
+== Patterns worth knowing
+
+* *Foreign keys are relations, not attributes.* Resist the temptation to model
+  `customer_id` as an attribute of `order` in TypeDB. Doing so reduces TypeDB to an awkward
+  relational store and forfeits the whole point of relations.
+* *Surrogate IDs are scaffolding.* They exist because SQL needs a single column to point to.
+  If a natural key already identifies an entity (an email, a SKU, an ISBN), use that as `@key`
+  and drop the surrogate. The migration is a good moment to do this.
+* *Join tables become relations cleanly.* A two-FK join table maps directly to a binary
+  relation; a three-FK join table maps to a ternary relation. Extra columns become attributes
+  on the relation itself.
+* *Combine entity + relation in one pass when the FK is on the entity's row.* `load_orders`
+  inserts the order and its `placement` link in a single query. This is faster than splitting
+  into two passes and avoids needing an intermediate "orders without customers" state.
+* *`match` failures are silent.* If `load_orders` references a `customer_id` that wasn't
+  loaded, the row produces no order and is _not_ flagged in rejects — TypeDB treats the empty
+  match as a successful empty-result query. Use `--stop-on-error` during initial loads, and
+  compare row counts between the SQL source and the resulting TypeDB instance to catch FK
+  drift.
+* *Order matters; checkpoints don't span passes.* Each pass is a separate loader invocation
+  with its own checkpoint. If a relation pass fails, fix it and `--resume` that pass — but
+  don't try to roll back the entity passes that already committed.

--- a/tools/modules/ROOT/pages/loader/sql-example.adoc
+++ b/tools/modules/ROOT/pages/loader/sql-example.adoc
@@ -253,5 +253,6 @@ reduce $spend = sum($line_total) groupby $n;
   compare row counts between the SQL source and the resulting TypeDB instance to catch FK
   drift.
 * *Order matters; checkpoints don't span passes.* Each pass is a separate loader invocation
-  with its own checkpoint. If a relation pass fails, fix it and `--resume` that pass — but
-  don't try to roll back the entity passes that already committed.
+  with its own output directory (and its own `checkpoint.json` inside). If a relation pass
+  fails, fix it and `--resume <that pass's output dir>` — but don't try to roll back the
+  entity passes that already committed.

--- a/tools/modules/ROOT/pages/loader/sql-example.adoc
+++ b/tools/modules/ROOT/pages/loader/sql-example.adoc
@@ -1,9 +1,8 @@
 = Migrating a SQL Database
 
-This walkthrough takes you from a relational SQL schema to a fully loaded TypeDB database. This
-requires us to shift the way our data is modelled — predominantly, things that formerly used
-foreign keys will now use relations. Once we've remodelled that, we can use the TypeDB Loader
-to relatively simply perform the actual loading.
+This walkthrough takes a small relational schema, remodels it for TypeDB, and loads it end-to-end
+with the TypeDB Loader. The modelling shift is brief; the bulk of the work is one loader
+invocation per CSV.
 
 We'll use a small e-commerce schema with two common SQL patterns:
 
@@ -57,46 +56,15 @@ SQL
 
 (MySQL: `SELECT ... INTO OUTFILE`. SQLite: `.mode csv` + `.headers on` + `.output`.)
 
-The CSV columns line up with the SQL columns 1:1 — `id`, `customer_id`, etc. We'll keep these
-names through to the loader queries.
+The CSV columns line up with the SQL columns 1:1 — we'll keep these names through to the loader
+queries.
 
-== Step 3: SQL → TypeDB, one mapping rule at a time
+== Step 3: Design the TypeDB schema
 
-[cols="1,2"]
-|===
-| SQL pattern | TypeDB pattern
-
-| Table with a primary key
-| Entity that owns the PK as `@key`
-
-| Non-key column
-| Attribute owned by the entity
-
-| 1:N foreign key column
-| Relation between the two entity types
-
-| Pure join table (composite PK only)
-| Relation with one role per FK
-
-| Join table with extra columns
-| Relation that owns those columns as attributes
-
-| Self-referencing FK
-| Relation where both role players are the same type
-
-| `NOT NULL` constraint
-| Plain `owns attr` (TypeDB ownership is optional by default; declare it as required if needed)
-
-| `UNIQUE` constraint
-| `owns attr @unique` (or `@key` if it identifies the type)
-|===
-
-The single most important shift is the third row: in SQL, `orders.customer_id` is a column on
-`orders`. In TypeDB, it doesn't exist as an attribute at all — instead, a `placement` relation
-ties a `customer` to an `order`. Relations are first-class, bidirectional, and can themselves
-carry attributes; FK columns are a workaround for the absence of that primitive.
-
-== Step 4: Design the schema
+The key shift from SQL is that *foreign keys become relations, not attributes*. `orders.customer_id`
+doesn't exist as an attribute of `order` in TypeDB — instead, a `placement` relation ties a
+`customer` to an `order`. Likewise, the `order_items` join table becomes a `line_item` relation
+that owns its `quantity` payload directly.
 
 `schema.tql`:
 
@@ -143,19 +111,10 @@ order plays line_item:order;
 product plays line_item:product;
 ----
 
-Things to notice against the SQL:
+== Step 4: Plan the load passes
 
-* `orders.customer_id` became the `placement` relation, not an attribute of `order`.
-* `order_items` became the `line_item` relation. Its `quantity` payload column became an
-  attribute owned by the relation itself — no synthetic entity.
-* Surrogate IDs (`customer_id`, `product_id`, `order_id`) survive as `@key` attributes because
-  the SQL CSV uses them to encode FKs. If you migrate further, you could often replace them
-  with natural keys (e.g. `email` already identifies a customer).
-
-== Step 5: Plan the load passes
-
-Each relation pass uses `match` on the `@key` attribute of the referenced entity, so entities
-must exist before any relation referencing them is loaded:
+Entities must exist before any relation referencing them is loaded, so the passes follow that
+order:
 
 . *customers* — entity only
 . *products* — entity only
@@ -163,11 +122,10 @@ must exist before any relation referencing them is loaded:
   carries the `customer_id`, so we look the customer up while inserting the order)
 . *order_items* — `line_item` relation only
 
-This is one pass per CSV file from step 2. Note that pass 3 is the common shortcut: when the
-entity's CSV already carries an FK, you can insert the entity and its relation together in a
-single `match … insert` pipeline.
+One pass per CSV file from step 2. Pass 3 is the common shortcut: when the entity's CSV already
+carries an FK, you can insert the entity and its relation together in a single `match … insert`.
 
-== Step 6: Write the loader queries
+== Step 5: Write the loader queries
 
 *`load_customers.tql`*
 
@@ -223,7 +181,7 @@ insert
 Each `given` variable matches a CSV column header from the SQL dump verbatim. The `match` stage
 is the FK resolution — replacing what would have been a join on `customer_id` in SQL.
 
-== Step 7: Run the loads
+== Step 6: Run the loads
 
 [source,bash]
 ----
@@ -251,17 +209,7 @@ typedb-loader \
   --batch-rows 1000 --parallel-batches 4
 ----
 
-== Step 8: Verify
-
-[source,typeql]
-----
-# Orders per customer
-match
-  $c isa customer, has name $n;
-  $o isa order;
-  $pl isa placement, links (customer: $c, order: $o);
-reduce $orders = count groupby $n;
-----
+== Step 7: Verify
 
 [source,typeql]
 ----
@@ -276,24 +224,14 @@ match
 reduce $spend = sum($line_total) groupby $n;
 ----
 
-In SQL, the second query would be a four-way join (`customers ⋈ orders ⋈ order_items ⋈
-products`) with an explicit `GROUP BY`. In TypeQL, the relations carry the joins — there's no
-join condition because the relations _are_ the conditions.
+In SQL, this would be a four-way join with an explicit `GROUP BY`.
+In TypeQL, the relations carry the joins.
 
 == Patterns worth knowing
 
-* *Foreign keys are relations, not attributes.* Resist the temptation to model
-  `customer_id` as an attribute of `order` in TypeDB. Doing so reduces TypeDB to an awkward
-  relational store and forfeits the whole point of relations.
-* *Surrogate IDs are scaffolding.* They exist because SQL needs a single column to point to.
-  If a natural key already identifies an entity (an email, a SKU, an ISBN), use that as `@key`
-  and drop the surrogate. The migration is a good moment to do this.
-* *Join tables become relations cleanly.* A two-FK join table maps directly to a binary
-  relation; a three-FK join table maps to a ternary relation. Extra columns become attributes
-  on the relation itself.
 * *Combine entity + relation in one pass when the FK is on the entity's row.* `load_orders`
-  inserts the order and its `placement` link in a single query. This is faster than splitting
-  into two passes and avoids needing an intermediate "orders without customers" state.
+  inserts the order and its `placement` link in a single query — faster than splitting into two
+  passes, and avoids an intermediate "orders without customers" state.
 * *`match` failures are silent.* If `load_orders` references a `customer_id` that wasn't
   loaded, the row produces no order and is _not_ flagged in rejects — TypeDB treats the empty
   match as a successful empty-result query. Use `--stop-on-error` during initial loads, and

--- a/tools/modules/ROOT/pages/loader/sql-example.adoc
+++ b/tools/modules/ROOT/pages/loader/sql-example.adoc
@@ -203,24 +203,24 @@ is the FK resolution — replacing what would have been a join on `customer_id` 
 [source,bash]
 ----
 # Pass 1 — customers (also creates db + schema)
-typedb-loader \
+typedb loader \
   --address localhost:1729 --username admin \
   --database shop --create-db --schema-file schema.tql \
   --query load_customers.tql --data customers.csv --header
 
 # Pass 2 — products
-typedb-loader \
+typedb loader \
   --address localhost:1729 --username admin --database shop \
   --query load_products.tql --data products.csv --header
 
 # Pass 3 — orders + placement
-typedb-loader \
+typedb loader \
   --address localhost:1729 --username admin --database shop \
   --query load_orders.tql --data orders.csv --header \
   --batch-rows 1000 --parallel-batches 4
 
 # Pass 4 — line items
-typedb-loader \
+typedb loader \
   --address localhost:1729 --username admin --database shop \
   --query load_order_items.tql --data order_items.csv --header \
   --batch-rows 1000 --parallel-batches 4

--- a/tools/modules/ROOT/pages/loader/sql-example.adoc
+++ b/tools/modules/ROOT/pages/loader/sql-example.adoc
@@ -71,6 +71,7 @@ that owns its `quantity` payload directly.
 
 [source,typeql]
 ----
+#!test[schema, commit]
 define
 
 attribute customer_id, value integer;
@@ -180,10 +181,15 @@ insert
 
 [source,typeql]
 ----
-given $order_id: integer, $product_id: integer, $quantity: integer;
+given
+    $order_id: integer,
+    $product_id: integer,
+    $quantity: integer;
 match
-  $o isa order, has order_id == $order_id;
-  $p isa product, has product_id == $product_id;
+  $o isa order,
+    has order_id == $order_id;
+  $p isa product,
+    has product_id == $product_id;
 insert
   $li isa line_item, links (order: $o, product: $p),
     has quantity == $quantity;
@@ -224,6 +230,7 @@ typedb-loader \
 
 [source,typeql]
 ----
+#!test[read]
 # Total spend per customer
 match
   $c isa customer, has name $n;

--- a/tools/modules/ROOT/pages/loader/sql-example.adoc
+++ b/tools/modules/ROOT/pages/loader/sql-example.adoc
@@ -1,4 +1,9 @@
 = Migrating a SQL Database
+:keywords: typedb, typeql, tutorial, guide, loader
+:pageTitle:
+:summary:
+:page-toclevels: 2
+:tabs-sync-option:
 :test-typeql: linear
 
 This walkthrough takes a small relational schema, remodels it for TypeDB, and loads it end-to-end

--- a/tools/modules/ROOT/partials/nav.adoc
+++ b/tools/modules/ROOT/partials/nav.adoc
@@ -4,6 +4,12 @@
 
 * xref:{page-version}@tools::console.adoc[]
 
+* xref:{page-version}@tools::loader/index.adoc[]
+** xref:{page-version}@tools::loader/quickstart.adoc[]
+** xref:{page-version}@tools::loader/json-example.adoc[]
+** xref:{page-version}@tools::loader/sql-example.adoc[]
+** xref:{page-version}@tools::loader/reference.adoc[]
+
 * xref:{page-version}@tools::typeql-check.adoc[]
 
 * xref:{page-version}@tools::admin.adoc[]


### PR DESCRIPTION
## Goal

- Add docs to support TypeDB Loader
- Modify existing docs to support renaming and restructuring of https://github.com/typedb/typedb-console to `typedb/typedb-tools`

## Implementation

- Add quickstart guide for TypeDB Loader
  - Includes a basic CSV loading example
  - Also includes some general-purpose advice
- Add examples for TypeDB Loader
  - JSON loading example
  - SQL loading example
- Add reference docs for TypeDB Loader CLI args
- Update mentions of the `typedb-console` repo to `typedb-tools`
- Replace links to the latest console release on github with links to `https://github.com/typedb/typedb-tools/releases?q=console&expanded=true` (that is, a full-details list of releases filtered by 'console'), since we no longer guarantee that the `latest` release will contain console.