### PR TITLE
Add version to TypeDB Cloud cluster update docs

### DIFF
--- a/reference/modules/ROOT/partials/cloud-api/cluster-update.json.adoc
+++ b/reference/modules/ROOT/partials/cloud-api/cluster-update.json.adoc
@@ -7,6 +7,7 @@
     "backupConfiguration": {
       "frequency": string,
       "retentionDays": number
-    }
+    },
+    "version": string
 }
 ----


### PR DESCRIPTION
## Goal

- Add the `version` field to the docs for updating clusters through TypeDB Cloud

## Implementation

- Add the field