### PR TITLE
Document RocksDB cache-size and write-buffers-limit memory settings

### DIFF
--- a/core-concepts/modules/ROOT/pages/typedb/vertical-scaling.adoc
+++ b/core-concepts/modules/ROOT/pages/typedb/vertical-scaling.adoc
@@ -18,12 +18,14 @@ The primary consumers of memory in TypeDB are RocksDB's caches and buffers, plus
 
 RocksDB memory is governed by two pools, each a single budget *shared across all databases* on the server (not allocated per database):
 
-* a *block cache* (the in-memory cache of data read from disk), which defaults to 1 GiB, and
-* a *write-buffer* budget (holding writes before they are flushed to disk), which defaults to 512 MiB.
+* a *block cache* (the in-memory cache of data read from disk), which defaults to a soft limit of 1 GiB. It may grow beyond this when critical indices are pinned in memory.
+* a *write-buffer* budget (cached writes before they are flushed to disk), which defaults to 512 MiB.
 
-Both pools are configurable via the server's `storage.rocksdb.cache-size` and `storage.rocksdb.write-buffers-limit` settings — see xref:{page-version}@maintenance-operation::typedb-configuration.adoc#_storage[Storage configuration] and the xref:{page-version}@maintenance-operation::typedb-configuration.adoc#_memory_usage[memory-usage] sizing guidance. On top of these, RocksDB also benefits from the operating system's page cache, which is managed by the OS outside the TypeDB process.
+Note that increasing or decreasing these does not affect the durability of commits - the write ahead log (WAL) separately records writes to disk regardless of TypeDB's and RocksDB's in-memory state.
 
-In addition, to maintain performance we recommend that at least 5% of your data size fits in memory, to ensure indexes are easily accessible and speed up querying. Because the block cache is shared server-wide, increase `storage.rocksdb.cache-size` (rather than expecting per-database growth) as the combined working set of your databases grows.
+Both pools are configurable via the server's configuration — see xref:{page-version}@maintenance-operation::typedb-configuration.adoc#_storage[Storage configuration] and the xref:{page-version}@maintenance-operation::typedb-configuration.adoc#_memory_usage[memory-usage] sizing guidance. On top of these, RocksDB also benefits from the operating system's page cache, which is managed by the OS outside the TypeDB process.
+
+To maintain performance we recommend that at least 5% of the total of all your databases' sizes fits in memory, to ensure indexes and bloom filters remain in memory.
 
 == Disk space
 

--- a/core-concepts/modules/ROOT/pages/typedb/vertical-scaling.adoc
+++ b/core-concepts/modules/ROOT/pages/typedb/vertical-scaling.adoc
@@ -14,9 +14,16 @@ Planned work will enable concurrent execution within 1 query and provide major p
 
 == Memory model
 
-The primary consumers of memory in TypeDB are RocksDB (defaults to 1 GB of cache per database in the server), plus working memory buffers per transaction. Any writes submitted to a transaction are buffered in memory until commit, so keeping transactions relatively small (100-1000 queries) is optimal.
+The primary consumers of memory in TypeDB are RocksDB's caches and buffers, plus working memory buffers per transaction. Any writes submitted to a transaction are buffered in memory until commit, so keeping transactions relatively small (100-1000 queries) is optimal.
 
-In addition, to maintain performance we recommend that at least 5% of your data size fits in memory, to ensure indexes are easily accessible and speed up querying.
+RocksDB memory is governed by two pools, each a single budget *shared across all databases* on the server (not allocated per database):
+
+* a *block cache* (the in-memory cache of data read from disk), which defaults to 1 GiB, and
+* a *write-buffer* budget (holding writes before they are flushed to disk), which defaults to 512 MiB.
+
+Both pools are configurable via the server's `storage.rocksdb.cache-size` and `storage.rocksdb.write-buffers-limit` settings — see xref:{page-version}@maintenance-operation::typedb-configuration.adoc#_storage[Storage configuration] and the xref:{page-version}@maintenance-operation::typedb-configuration.adoc#_memory_usage[memory-usage] sizing guidance. On top of these, RocksDB also benefits from the operating system's page cache, which is managed by the OS outside the TypeDB process.
+
+In addition, to maintain performance we recommend that at least 5% of your data size fits in memory, to ensure indexes are easily accessible and speed up querying. Because the block cache is shared server-wide, increase `storage.rocksdb.cache-size` (rather than expecting per-database growth) as the combined working set of your databases grows.
 
 == Disk space
 

--- a/maintenance-operation/modules/ROOT/pages/typedb-configuration.adoc
+++ b/maintenance-operation/modules/ROOT/pages/typedb-configuration.adoc
@@ -160,7 +160,23 @@ This helps to make the process of upgrading TypeDB easier.
 2+^| Storage
 | `storage.data-directory`
 | Path to the user data directory. Defaults to within the server distribution under `server/data`. +
+
+| `storage.rocksdb.cache-size`
+| Size of the shared RocksDB block cache, the in-memory LRU cache of uncompressed data blocks read from disk. This is a single pool shared by *all* databases on the server, not a per-database limit. Default value: `1gb` (1 GiB). +
+This is a soft limit: it may be exceeded slightly by index and filter blocks that RocksDB pins in memory. See <<_memory_usage>> for sizing guidance.
+
+| `storage.rocksdb.write-buffers-limit`
+| Total memory budget for the shared RocksDB write-buffer manager — the in-memory write buffers (memtables) that hold uncommitted and recently-committed writes before they are flushed to disk. This is a single pool shared by *all* databases on the server, not a per-database limit. Default value: `512mb` (512 MiB). +
+When the limit is reached, writes are stalled (slowed) until memory is freed by a flush, rather than allowed to grow without bound. See <<_memory_usage>> for sizing guidance.
 |===
+
+[#_byte_size_format]
+[NOTE]
+====
+Size values such as `storage.rocksdb.cache-size` and `storage.rocksdb.write-buffers-limit` are written as an integer with an optional, case-insensitive unit suffix: `B`, `KB`/`KiB`, `MB`/`MiB`, `GB`/`GiB`, or `TB`/`TiB`. A bare number is interpreted as bytes.
+
+The units are *binary* (powers of 1024), so `KB` is identical to `KiB`, `MB` to `MiB`, and so on. In particular, *`1gb` means 1 GiB = 1,073,741,824 bytes* (not 10^9^ bytes). Fractional values (e.g. `1.5gb`) are not accepted; use a smaller unit instead (e.g. `1536mb`). Examples: `1gb`, `512mb`, `1024MiB`, `2048`.
+====
 
 [#_diagnostics]
 === Diagnostics
@@ -216,3 +232,28 @@ ulimit -n
 ----
 
 We recommend this is increased to at least `50 000`.
+
+[#_memory_usage]
+=== Memory usage
+
+The resident memory of a TypeDB server is dominated by the two shared RocksDB pools configured under `storage.rocksdb`, plus the operating system's page cache:
+
+* *Block cache* (`storage.rocksdb.cache-size`, default `1gb`) — caches uncompressed data blocks read from disk so that hot reads are served from memory. A single cache is shared across all databases on the server.
+* *Write buffers* (`storage.rocksdb.write-buffers-limit`, default `512mb`) — hold writes in memory before they are flushed to disk. A single write-buffer budget is shared across all databases on the server.
+* *OS page cache* — RocksDB relies on the operating system's file cache to hold recently-accessed files (including the compressed forms of data blocks). This memory is managed by the OS, lives outside the TypeDB process, and is reclaimed automatically under memory pressure, but it is important to leave headroom for it.
+
+Both `storage.rocksdb` limits are server-wide totals, so they do *not* need to be scaled up for each additional database. They should instead be sized relative to the host's total RAM and the active working set across all databases.
+
+[NOTE]
+====
+The two `storage.rocksdb` pools are soft accounting limits on TypeDB's own caches and buffers; they are not a hard cap on the server's total memory. Transaction working memory (writes are buffered in memory until commit), query execution, and the OS page cache all consume additional memory on top of them. When sizing a host, leave ample headroom above `cache-size` + `write-buffers-limit` rather than provisioning RAM exactly equal to their sum.
+====
+
+As rough guidance for a dedicated host:
+
+* The defaults (`1gb` block cache + `512mb` write buffers, roughly 1.5 GiB of TypeDB-managed cache and buffers) suit small deployments and development machines.
+* To improve read performance, increase `storage.rocksdb.cache-size` so that the working set fits in cache. As a starting point, aim for at least 5% of the on-disk data size across all databases to fit in the block cache, and leave a comparable amount of free RAM for the OS page cache.
+* Reserve memory for the OS, the page cache, and transaction/query working memory in addition to the two pools above; avoid configuring `cache-size` + `write-buffers-limit` close to the host's total RAM.
+* Increase `storage.rocksdb.write-buffers-limit` for sustained, write-heavy workloads if you observe write stalls; the limit trades memory for write throughput.
+
+Server memory consumption can be observed live via the `server_resources_count{kind="memoryUsedInBytes"}` metric on the diagnostics monitoring endpoint — see xref:{page-version}@maintenance-operation::diagnostics-endpoint.adoc#_server_resource_usage[Server resource usage].

--- a/maintenance-operation/modules/ROOT/pages/typedb-configuration.adoc
+++ b/maintenance-operation/modules/ROOT/pages/typedb-configuration.adoc
@@ -152,6 +152,7 @@ The `storage` section of the configuration contains the storage layer options.
 ====
 For production use, it is recommended that the `storage.data-directory` is set to a path outside the `$TYPEDB_HOME`
 (directory with TypeDB server files).
+
 This helps to make the process of upgrading TypeDB easier.
 ====
 
@@ -162,12 +163,13 @@ This helps to make the process of upgrading TypeDB easier.
 | Path to the user data directory. Defaults to within the server distribution under `server/data`. +
 
 | `storage.rocksdb.cache-size`
-| Size of the shared RocksDB block cache, the in-memory LRU cache of uncompressed data blocks read from disk. This is a single pool shared by *all* databases on the server, not a per-database limit. Default value: `1gb` (1 GiB). +
-This is a soft limit: it may be exceeded slightly by index and filter blocks that RocksDB pins in memory. See <<_memory_usage>> for sizing guidance.
+| Size of the shared RocksDB block cache, the in-memory cache of data blocks read from disk. This is a single pool shared by all databases on the server. Default value: `1gb` (1 GiB). +
+This is a soft limit: it may be exceeded by index and filter blocks that RocksDB pins in memory.
 
 | `storage.rocksdb.write-buffers-limit`
-| Total memory budget for the shared RocksDB write-buffer manager — the in-memory write buffers (memtables) that hold uncommitted and recently-committed writes before they are flushed to disk. This is a single pool shared by *all* databases on the server, not a per-database limit. Default value: `512mb` (512 MiB). +
-When the limit is reached, writes are stalled (slowed) until memory is freed by a flush, rather than allowed to grow without bound. See <<_memory_usage>> for sizing guidance.
+| Total memory budget for the RocksDB write-buffer manager — the in-memory write buffers (memtables) that hold writes before they are organized on disk. This is a single pool shared by *all* databases on the server. Default value: `512mb` (512 MiB). +
+When the limit is reached, writes are stalled (slowed) until memory is freed by a flush, rather than allowed to grow without bound. Note: does not affect durability guarantees, which are provided by the WAL.
+
 |===
 
 [#_byte_size_format]
@@ -175,7 +177,7 @@ When the limit is reached, writes are stalled (slowed) until memory is freed by 
 ====
 Size values such as `storage.rocksdb.cache-size` and `storage.rocksdb.write-buffers-limit` are written as an integer with an optional, case-insensitive unit suffix: `B`, `KB`/`KiB`, `MB`/`MiB`, `GB`/`GiB`, or `TB`/`TiB`. A bare number is interpreted as bytes.
 
-The units are *binary* (powers of 1024), so `KB` is identical to `KiB`, `MB` to `MiB`, and so on. In particular, *`1gb` means 1 GiB = 1,073,741,824 bytes* (not 10^9^ bytes). Fractional values (e.g. `1.5gb`) are not accepted; use a smaller unit instead (e.g. `1536mb`). Examples: `1gb`, `512mb`, `1024MiB`, `2048`.
+The units are binary (powers of 1024), so `KB` is identical to `KiB`, `MB` to `MiB`, and so on. `1gb` means 1 GiB = 1,073,741,824 bytes. Fractional values (e.g. `1.5gb`) are not accepted; use a smaller unit instead (e.g. `1536mb`). Examples: `1gb`, `512mb`, `1024MiB`, `2048`.
 ====
 
 [#_diagnostics]
@@ -236,24 +238,19 @@ We recommend this is increased to at least `50 000`.
 [#_memory_usage]
 === Memory usage
 
-The resident memory of a TypeDB server is dominated by the two shared RocksDB pools configured under `storage.rocksdb`, plus the operating system's page cache:
+The resident memory of a TypeDB server is dominated by the two shared RocksDB pools configured under `storage.rocksdb`, plus transactional and query execution memory.
 
-* *Block cache* (`storage.rocksdb.cache-size`, default `1gb`) — caches uncompressed data blocks read from disk so that hot reads are served from memory. A single cache is shared across all databases on the server.
-* *Write buffers* (`storage.rocksdb.write-buffers-limit`, default `512mb`) — hold writes in memory before they are flushed to disk. A single write-buffer budget is shared across all databases on the server.
-* *OS page cache* — RocksDB relies on the operating system's file cache to hold recently-accessed files (including the compressed forms of data blocks). This memory is managed by the OS, lives outside the TypeDB process, and is reclaimed automatically under memory pressure, but it is important to leave headroom for it.
+* *Block cache* (`storage.rocksdb.cache-size`, default `1gb`) — caches uncompressed data blocks read from disk so that hot reads are served from memory. Increasing this generally improves read performance.
+* *Write buffers* (`storage.rocksdb.write-buffers-limit`, default `512mb`) — hold writes in memory as they are flushed to disk. Hitting the limit causes write slowdowns as memory is cleared. Increasing this generally improves bulk loading performance but rarely affects low throughput occasional writes.
 
-Both `storage.rocksdb` limits are server-wide totals, so they do *not* need to be scaled up for each additional database. They should instead be sized relative to the host's total RAM and the active working set across all databases.
+Both `storage.rocksdb` limits are server-wide totals, so they do not need to be scaled up for each additional database. They should instead be sized relative to the host's total RAM and the active working set across all databases.
 
-[NOTE]
-====
-The two `storage.rocksdb` pools are soft accounting limits on TypeDB's own caches and buffers; they are not a hard cap on the server's total memory. Transaction working memory (writes are buffered in memory until commit), query execution, and the OS page cache all consume additional memory on top of them. When sizing a host, leave ample headroom above `cache-size` + `write-buffers-limit` rather than provisioning RAM exactly equal to their sum.
-====
+Working, dynamically allocated memory is also required for TypeDB's transactional write buffers, query execution working space, and the OS page cache. The easiest way to keep these predictable is to try to use smaller rather than larger write transactions.
 
 As rough guidance for a dedicated host:
 
-* The defaults (`1gb` block cache + `512mb` write buffers, roughly 1.5 GiB of TypeDB-managed cache and buffers) suit small deployments and development machines.
-* To improve read performance, increase `storage.rocksdb.cache-size` so that the working set fits in cache. As a starting point, aim for at least 5% of the on-disk data size across all databases to fit in the block cache, and leave a comparable amount of free RAM for the OS page cache.
-* Reserve memory for the OS, the page cache, and transaction/query working memory in addition to the two pools above; avoid configuring `cache-size` + `write-buffers-limit` close to the host's total RAM.
+* To improve read performance, increase `storage.rocksdb.cache-size` so that the working set fits in cache. As a minimum, aim for at least 5% of the on-disk data size across all databases to fit in the block cache.
+* Avoid configuring `cache-size` + `write-buffers-limit` close to the host's total RAM as this leaves little room for the rest of the server's working set.
 * Increase `storage.rocksdb.write-buffers-limit` for sustained, write-heavy workloads if you observe write stalls; the limit trades memory for write throughput.
 
 Server memory consumption can be observed live via the `server_resources_count{kind="memoryUsedInBytes"}` metric on the diagnostics monitoring endpoint — see xref:{page-version}@maintenance-operation::diagnostics-endpoint.adoc#_server_resource_usage[Server resource usage].


### PR DESCRIPTION
## Goal

Document new server settings `storage.rocksdb.cache-size` (default 1gb) and `storage.rocksdb.write-buffers-limit` (default 512mb).

We also describe how memory is used what can be expected for tuning.

## Implementation
