### PR TITLE
Fix TypeQL errors and disjunction clarification

### DIFF
--- a/academy/modules/ROOT/pages/10-using-functions/10.1-functions-as-views.adoc
+++ b/academy/modules/ROOT/pages/10-using-functions/10.1-functions-as-views.adoc
@@ -1,4 +1,5 @@
 = Lesson 10.1: Functions as views
+:test-typeql: linear
 
 == Abstracting complex patterns
 
@@ -28,6 +29,11 @@ Now let's consider how we might apply this domain logic. Suppose we want to quer
 
 [,typeql]
 ----
+#!test[schema]
+#{{
+include::{page-version}@academy::attachment$bookstore-schema.tql[]
+#}}
+#!test[read]
 match
 $book isa book;
 fetch {
@@ -49,6 +55,10 @@ The addition of the verification check makes the query significantly more compli
 
 [,typeql]
 ----
+#!test[schema]
+#{{
+define
+#}}
 fun verified-reviews($book: book) -> { review }:
   match
   $review isa review;
@@ -64,6 +74,7 @@ Now, we can use this encapsulated logic to simplify the query we really wanted t
 
 [,typeql]
 ----
+#!test[read]
 match
 $book isa book;
 fetch {

--- a/academy/modules/ROOT/pages/10-using-functions/10.1-functions-as-views.adoc
+++ b/academy/modules/ROOT/pages/10-using-functions/10.1-functions-as-views.adoc
@@ -67,8 +67,8 @@ Now, we can use this encapsulated logic to simplify the query we really wanted t
 match
 $book isa book;
 fetch {
-  $book: title;
-  average-verified-score: (
+  "title": $book.title,
+  "average-verified-score": (
     match
     let $review in verified-reviews($book);
     $review has score $score;

--- a/academy/modules/ROOT/pages/3-reading-data/3.1-fetching-simple-data.adoc
+++ b/academy/modules/ROOT/pages/3-reading-data/3.1-fetching-simple-data.adoc
@@ -1,4 +1,5 @@
 = Lesson 3.1: Fetching simple data
+:test-typeql: linear
 
 == The Fetch query
 
@@ -325,6 +326,11 @@ Modify the above query to also retrieve the `status` attribute of the order and 
 =====
 [,typeql]
 ----
+#!test[schema]
+#{{
+include::{page-version}@academy::attachment$bookstore-schema.tql[]
+#}}
+#!test[read]
 match
 $book isa paperback, has isbn-13 "9780446310789";
 $line isa order-line (order: $order, item: $book);

--- a/academy/modules/ROOT/pages/3-reading-data/3.1-fetching-simple-data.adoc
+++ b/academy/modules/ROOT/pages/3-reading-data/3.1-fetching-simple-data.adoc
@@ -330,7 +330,7 @@ $book isa paperback, has isbn-13 "9780446310789";
 $line isa order-line (order: $order, item: $book);
 fetch {
   "id": $order.id,
-  "status": $order.status",
+  "status": $order.status,
   "quantity": $line.quantity,
   "price": $book.price
 };

--- a/academy/modules/ROOT/pages/3-reading-data/3.2-fetching-polymorphic-data.adoc
+++ b/academy/modules/ROOT/pages/3-reading-data/3.2-fetching-polymorphic-data.adoc
@@ -256,8 +256,8 @@ This query will retrieve all attributes of all entities. Meanwhile, the followin
 [,typeql]
 ----
 match
-$entity-1 isa! $e1; entity $entity-type-1;
-$entity-2 isa! $e2; entity $entity-type-2;
+$entity-1 isa! $entity-type-1; entity $entity-type-1;
+$entity-2 isa! $entity-type-2; entity $entity-type-2;
 $relation links ($entity-1, $entity-2);
 fetch {
   "entity-1-attributes": { $entity-1.* },

--- a/academy/modules/ROOT/pages/3-reading-data/3.2-fetching-polymorphic-data.adoc
+++ b/academy/modules/ROOT/pages/3-reading-data/3.2-fetching-polymorphic-data.adoc
@@ -1,4 +1,5 @@
 = Lesson 3.2: Fetching polymorphic data
+:test-typeql: linear
 
 == Type inference
 
@@ -242,6 +243,11 @@ Parametric queries are unique in that they are valid over any schema. They match
 
 [,typeql]
 ----
+#!test[schema]
+#{{
+include::{page-version}@academy::attachment$bookstore-schema.tql[]
+#}}
+#!test[read]
 match
 entity $entity-type;
 $entity isa! $entity-type;
@@ -255,6 +261,7 @@ This query will retrieve all attributes of all entities. Meanwhile, the followin
 
 [,typeql]
 ----
+#!test[read]
 match
 $entity-1 isa! $entity-type-1; entity $entity-type-1;
 $entity-2 isa! $entity-type-2; entity $entity-type-2;

--- a/academy/modules/ROOT/pages/3-reading-data/3.4-fetching-schema-types.adoc
+++ b/academy/modules/ROOT/pages/3-reading-data/3.4-fetching-schema-types.adoc
@@ -419,7 +419,7 @@ match
 $type owns name;
 fetch {
   "owner": $type,
-}
+};
 ----
 
 =====

--- a/academy/modules/ROOT/pages/3-reading-data/3.4-fetching-schema-types.adoc
+++ b/academy/modules/ROOT/pages/3-reading-data/3.4-fetching-schema-types.adoc
@@ -1,4 +1,5 @@
 = Lesson 3.4: Fetching schema types
+:test-typeql: linear
 
 == Variablizing types
 
@@ -415,6 +416,11 @@ Write a query to retrieve the list of types that own `name`.
 =====
 [,typeql]
 ----
+#!test[schema]
+#{{
+include::{page-version}@academy::attachment$bookstore-schema.tql[]
+#}}
+#!test[read]
 match
 $type owns name;
 fetch {

--- a/academy/modules/ROOT/pages/3-reading-data/3.4-fetching-schema-types.adoc
+++ b/academy/modules/ROOT/pages/3-reading-data/3.4-fetching-schema-types.adoc
@@ -179,7 +179,7 @@ Modify the above query to also retrieve the type of the relation between `$book`
 match
 $user isa user, has id "u0008";
 $book isa book;
-(executor: $user, action: $action) isa action-execution;
+action-execution (executor: $user, action: $action);
 $rel isa! $relation-type, links ($book, $action);
 $action isa! $action-type;
 fetch {

--- a/academy/modules/ROOT/pages/4-writing-data/4.1-inserting-simple-data.adoc
+++ b/academy/modules/ROOT/pages/4-writing-data/4.1-inserting-simple-data.adoc
@@ -234,7 +234,7 @@ match
 action-execution relates $role;
 fetch {
   "role": $role,
-},
+};
 ----
 =====
 

--- a/academy/modules/ROOT/pages/4-writing-data/4.1-inserting-simple-data.adoc
+++ b/academy/modules/ROOT/pages/4-writing-data/4.1-inserting-simple-data.adoc
@@ -1,4 +1,5 @@
 = Lesson 4.1: Inserting simple data
+:test-typeql: linear
 
 == The Insert query
 
@@ -230,6 +231,11 @@ You can get the labels of the roles in the `action-execution` relation with the 
 
 [,typeql]
 ----
+#!test[schema]
+#{{
+include::{page-version}@academy::attachment$bookstore-schema.tql[]
+#}}
+#!test[read]
 match
 action-execution relates $role;
 fetch {

--- a/academy/modules/ROOT/pages/4-writing-data/4.4-updating-data.adoc
+++ b/academy/modules/ROOT/pages/4-writing-data/4.4-updating-data.adoc
@@ -1,4 +1,5 @@
 = Lesson 4.4: Updating data
+:test-typeql: linear
 
 == Building update queries
 
@@ -41,6 +42,11 @@ In addition to being more efficient and easier for readers to interpret, these q
 
 [,typeql]
 ----
+#!test[schema]
+#{{
+include::{page-version}@academy::attachment$bookstore-schema.tql[]
+#}}
+#!test[write]
 match
 $book isa book, has $art;
 $art isa genre "art";

--- a/academy/modules/ROOT/pages/4-writing-data/4.4-updating-data.adoc
+++ b/academy/modules/ROOT/pages/4-writing-data/4.4-updating-data.adoc
@@ -43,7 +43,7 @@ In addition to being more efficient and easier for readers to interpret, these q
 ----
 match
 $book isa book, has $art;
-$art "art" isa genre;
+$art isa genre "art";
 delete
 has $art of $book;
 insert

--- a/academy/modules/ROOT/pages/5-defining-schemas/5.4-defining-functions.adoc
+++ b/academy/modules/ROOT/pages/5-defining-schemas/5.4-defining-functions.adoc
@@ -6,7 +6,7 @@ In xref:{page-version}@academy::3-reading-data/3.3-using-functions.adoc[Lesson 3
 
 [,typeql]
 ----
-function function_name($arg: arg-type) -> { return-type }:
+fun function_name($arg: arg-type) -> { return-type }:
   <body query pipeline>
   return <variables or operation>;
 ----

--- a/academy/modules/ROOT/pages/7-understanding-query-patterns/7.2-relation-patterns.adoc
+++ b/academy/modules/ROOT/pages/7-understanding-query-patterns/7.2-relation-patterns.adoc
@@ -38,7 +38,7 @@ This can be naturally extended to represent relations with any number of role pl
 
 [,typeql]
 ----
-n-ary-relation (role-1: $a, role-2: $b, role-3: $c, role-4: $d, ...) isa;
+n-ary-relation (role-1: $a, role-2: $b, role-3: $c, role-4: $d, ...);
 ----
 
 We can also represent relations with only a single roleplayer, known as *unary* relations, though doing so is only useful in very niche cases.

--- a/academy/modules/ROOT/pages/7-understanding-query-patterns/7.3-logical-operators.adoc
+++ b/academy/modules/ROOT/pages/7-understanding-query-patterns/7.3-logical-operators.adoc
@@ -93,7 +93,7 @@ include::{page-version}@academy::attachment$bookstore-schema.tql[]
 match
 $book isa book;
 not {
-    ($book, $contributor) isa illustrating;
+    illustrating ($book, $contributor);
 };
 fetch {
   "isbn-13": $book.isbn-13,

--- a/academy/modules/ROOT/pages/7-understanding-query-patterns/7.3-logical-operators.adoc
+++ b/academy/modules/ROOT/pages/7-understanding-query-patterns/7.3-logical-operators.adoc
@@ -90,7 +90,7 @@ not {
     ($book, $contributor) isa illustrating;
 };
 fetch {
-  "isbn-13": book.isbn-13,
+  "isbn-13": $book.isbn-13,
 };
 ----
 

--- a/academy/modules/ROOT/pages/7-understanding-query-patterns/7.3-logical-operators.adoc
+++ b/academy/modules/ROOT/pages/7-understanding-query-patterns/7.3-logical-operators.adoc
@@ -1,4 +1,5 @@
 = Lesson 7.3: Logical operators
+:test-typeql: linear
 
 == Disjunctions
 
@@ -84,6 +85,11 @@ Just as we can represent a disjunction of patterns, we can also represent the ht
 
 [,typeql]
 ----
+#!test[schema]
+#{{
+include::{page-version}@academy::attachment$bookstore-schema.tql[]
+#}}
+#!test[read]
 match
 $book isa book;
 not {

--- a/academy/modules/ROOT/pages/8-composing-clauses/summary.adoc
+++ b/academy/modules/ROOT/pages/8-composing-clauses/summary.adoc
@@ -27,7 +27,7 @@ limit N;
 +
 [,typeql]
 ----
-reduce $count = count groupy $book;
+reduce $count = count groupby $book;
 ----
 
 == xref:{page-version}@academy::8-composing-clauses/8.3-sorting-and-pagination.adoc[Sorting and pagination]

--- a/academy/modules/ROOT/pages/9-modeling-schemas/9.4-using-type-hierarchies.adoc
+++ b/academy/modules/ROOT/pages/9-modeling-schemas/9.4-using-type-hierarchies.adoc
@@ -134,21 +134,20 @@ There is an additional hint that this field in the data table represents a type:
 [,typeql]
 ----
 define
-book sub entity,
-  abstract,
+entity book @abstract,
   owns isbn-13,
   owns isbn-10,
   owns title,
   owns page-count,
-  owns genre
+  owns genre,
   owns price,
   plays contribution:work,
   plays publishing:published;
-paperback sub book,
+entity paperback sub book,
   owns stock;
-hardback sub book,
+entity hardback sub book,
   owns stock;
-ebook sub book;
+entity ebook sub book;
 ----
 
 In general, the following characteristics are good indicators of types stored as data in a particular field:

--- a/academy/modules/ROOT/pages/9-modeling-schemas/9.4-using-type-hierarchies.adoc
+++ b/academy/modules/ROOT/pages/9-modeling-schemas/9.4-using-type-hierarchies.adoc
@@ -1,4 +1,5 @@
 = Lesson 9.4: Using type hierarchies
+:test-typeql: linear
 :page-preamble-card: 1
 
 In the previous two lessons, we created and developed a data model for book data. In this lesson, we'll see how we can introduce type hierarchies into the model so that we can leverage inheritance polymorphism in our queries.
@@ -133,6 +134,20 @@ There is an additional hint that this field in the data table represents a type:
 
 [,typeql]
 ----
+#!test[schema, reset]
+#{{
+define
+attribute isbn-13, value string;
+attribute isbn-10, value string;
+attribute title, value string;
+attribute page-count, value integer;
+attribute genre, value string;
+attribute price, value double;
+attribute stock, value integer;
+relation contribution, relates work;
+relation publishing, relates published;
+#}}
+#---
 define
 entity book @abstract,
   owns isbn-13,

--- a/academy/modules/ROOT/pages/9-modeling-schemas/9.6-using-interface-hierarchies.adoc
+++ b/academy/modules/ROOT/pages/9-modeling-schemas/9.6-using-interface-hierarchies.adoc
@@ -1,4 +1,5 @@
 = Lesson 9.6: Using interface hierarchies
+:test-typeql: linear
 :page-preamble-card: 1
 
 In the previous lesson, we improved the type hierarchies in our book data model by using the principle of composition over inheritance. In this lesson, we'll explore the behaviour of interface hierarchies and see how they can be used to adapt our model in different ways.
@@ -231,6 +232,7 @@ In other cases, it may be more appropriate to override roles. The following sche
 
 [,typeql]
 ----
+#!test[schema, reset]
 define
 entity user,
   plays action-execution:executor;
@@ -278,6 +280,7 @@ If this deduction were correct, it would allow humans to join flocks, despite th
 
 [,typeql]
 ----
+#!test[schema]
 define
 entity animal @abstract;
 entity human sub animal;                      # all humans are animals

--- a/academy/modules/ROOT/pages/9-modeling-schemas/9.6-using-interface-hierarchies.adoc
+++ b/academy/modules/ROOT/pages/9-modeling-schemas/9.6-using-interface-hierarchies.adoc
@@ -235,7 +235,7 @@ define
 entity user,
   plays action-execution:executor;
 entity admin sub user,
-  plays privileged-execution:priveleged-executor;
+  plays privileged-execution:privileged-executor;
 relation action-execution,
   relates action,
   relates executor;
@@ -279,22 +279,21 @@ If this deduction were correct, it would allow humans to join flocks, despite th
 [,typeql]
 ----
 define
-animal sub entity, abstract;
-human sub animal;                             # all humans are animals
-goose sub animal;                             # all geese are animals
-animal-group sub entity, abstract;
-group-membership sub relation,
-  abstract,
+entity animal @abstract;
+entity human sub animal;                      # all humans are animals
+entity goose sub animal;                      # all geese are animals
+entity animal-group @abstract;
+relation group-membership @abstract,
   relates group,
   relates group-member;
-animal-group plays group-membership:group;
-animal plays group-membership:group-member;   # all animals can join animal groups
-flock sub animal-group;                       # all flocks are animal groups
-flock-membership sub group-membership,
+entity animal-group plays group-membership:group;
+entity animal plays group-membership:group-member;  # all animals can join animal groups
+entity flock sub animal-group;                # all flocks are animal groups
+relation flock-membership sub group-membership,
   relates flock as group,
   relates flock-member as group-member;
-flock plays flock-membership:flock;
-goose plays flock-membership:flock-member;  # all geese can join flocks
+entity flock plays flock-membership:flock;
+entity goose plays flock-membership:flock-member;  # all geese can join flocks
 ----
 
 If definitions of interface implementations were covariant in the interface type instead of invariant, then `animal`, and all of its subtypes including `human`, would inherit the ability to play `flock-membership:flock-member`!

--- a/guides/modules/ROOT/pages/typeql/optimizing-typeql.adoc
+++ b/guides/modules/ROOT/pages/typeql/optimizing-typeql.adoc
@@ -12,6 +12,11 @@ The built-in optimizer of TypeDB will decide the optimal order of evaluation of 
 
 [,typeql]
 ----
+#!test[schema]
+#{{
+include::{page-version}@typeql-reference::example$tql/conjunction.tql[tags=patterns-schema]
+#}}
+#!test[read]
 match
   $x isa user;
   $x has username "john_1";
@@ -20,6 +25,7 @@ and the query pipeline
 
 [,typeql]
 ----
+#!test[read]
 match
   $x isa user;
 match
@@ -91,6 +97,7 @@ We expect the second query to run faster, as it evaluates the `<expensive-patter
 Negations, especially nested negations, can be extremely expensive query operations: indeed, to ensure that something does not exist, we usually must search the entire domain of possibilities. It is therefore paramount to reduce the "`size of the domain`" prior to using negation. For example, the query
 [,typeql]
 ----
+#!test[read]
 match
   $x isa user;
   not {
@@ -106,6 +113,12 @@ does the following:
 This can equivalently be achieved by the following query:
 [,typeql]
 ----
+#!test[read]
+#{{
+with fun user_count() -> integer:
+match $u isa user;
+return count($u);
+#}}
 match
   $x isa user;
   friendship ($x, $y);

--- a/guides/modules/ROOT/pages/typeql/optimizing-typeql.adoc
+++ b/guides/modules/ROOT/pages/typeql/optimizing-typeql.adoc
@@ -95,7 +95,7 @@ match
   $x isa user;
   not {
     $y isa user;
-    not { friendship ($x, $y) };
+    not { friendship ($x, $y); };
   };
 limit 1;
 ----

--- a/reference/modules/ROOT/partials/http-api/requests/query-given.json.adoc
+++ b/reference/modules/ROOT/partials/http-api/requests/query-given.json.adoc
@@ -1,7 +1,7 @@
 [source,json]
 ----
 {
-  "query": "given $p: person, $n: string; $dob: datetime-tz;\ninsert $p has name == $name, date-of-birth == $dob;",
+  "query": "given $p: person, $n: string, $dob: datetime-tz;\ninsert $p has name == $n, has date-of-birth == $dob;",
   "given": [
     {
         "p": {

--- a/typeql-reference/modules/ROOT/examples/tql/schema_annotations.tql
+++ b/typeql-reference/modules/ROOT/examples/tql/schema_annotations.tql
@@ -5,7 +5,7 @@ define
   entity element @abstract;
 // end::abstract-entity[]
 
-  entity content @abstract, sub root,
+  entity content @abstract, sub element,
     owns is-visible,
     plays subscription:content;
 

--- a/typeql-reference/modules/ROOT/pages/data-model.adoc
+++ b/typeql-reference/modules/ROOT/pages/data-model.adoc
@@ -235,7 +235,7 @@ Further optionality features coming soon!
 ----
 match
   $x isa user;
-  not { friendship ($x, $y); }
+  not { friendship ($x, $y); };
 ----
 where the variable `$y` is internal. The class of internal variable also includes *anonymous* variables (indicated by `$_`).
 

--- a/typeql-reference/modules/ROOT/pages/data-model.adoc
+++ b/typeql-reference/modules/ROOT/pages/data-model.adoc
@@ -1,4 +1,5 @@
 = Data and query model
+:test-typeql: linear
 
 This page gives a brief technical overview of TypeDB's type system and query model.
 
@@ -126,6 +127,19 @@ The `match` stage is the only data pipeline stage which filters and retrieves da
 For the curious reader: TypeDB adheres to the principle of "`queries as types`" (an analog of https://en.wikipedia.org/wiki/Curry%E2%80%93Howard_correspondence[propositions as types]). This means, patterns in `match` stage are really types (of the data that the stage retrieves). For example, a TypeQL conjunction
 [,typeql]
 ----
+#!test[schema]
+#{{
+define
+  attribute age, value integer;
+  attribute access-level, value integer;
+  relation friendship, relates friend @card(0..2);
+  entity user, owns age, plays friendship:friend;
+  entity VIP sub user;
+  entity admin sub user, owns access-level;
+  entity type1;
+  entity type2;
+#}}
+#!test[read]
 match
   $field1 isa type1;
   $field2 isa type2;
@@ -141,6 +155,7 @@ struct query_answers {
 Similarly, a TypeQL disjunction
 [,typeql]
 ----
+#!test[read]
 match
   { $option1 isa type1; }
   or { $option2 isa type2; };
@@ -166,6 +181,7 @@ Stages in TypeQL xref:{page-version}@typeql-reference::index.adoc#queries[data p
 --
 [,typeql]
 ----
+#!test[read]
 match $someone isa $user;
 ----
 implies that `$someone` isa an instance variable.
@@ -175,6 +191,10 @@ implies that `$someone` isa an instance variable.
 --
 [,typeql]
 ----
+#!test[read]
+#{{
+match let $other_val = 1;
+#}}
 match let $computed_val = $other_val + 1;
 ----
 implies that `$computed_val` is a value variable.
@@ -184,6 +204,7 @@ implies that `$computed_val` is a value variable.
 --
 [,typeql]
 ----
+#!test[read]
 match $something isa $type;
 ----
 implies that `$type` is a type variable.
@@ -205,6 +226,7 @@ Each variable in a stage can appear in one of the following three modes.
 --
 [,typeql]
 ----
+#!test[read]
 match $x isa user, has age 33;
 limit 1;
 match friendship ($y, $x);  # $x is an input for this stage
@@ -215,12 +237,13 @@ match friendship ($y, $x);  # $x is an input for this stage
 --
 [,typeql]
 ----
+#!test[read]
 match
  $x isa user;
  { $x isa VIP; }
  or { $x isa admin, has access-level $lvl; $lvl > 9000; };
 ----
-here `$u` is output, whereas `$lvl` is internal to the second branch of the disjunction.
+here `$x` is output, whereas `$lvl` is internal to the second branch of the disjunction.
 
 *Optional* variables are a subclass of returnable variables: these or variables that may be left empty in the stages output (you may think of this as assigning them to the unit `()` of the unit type, which is implicit in our type system).
 [NOTE]
@@ -233,6 +256,7 @@ Further optionality features coming soon!
 --
 [,typeql]
 ----
+#!test[read]
 match
   $x isa user;
   not { friendship ($x, $y); };
@@ -242,6 +266,7 @@ where the variable `$y` is internal. The class of internal variable also include
 An important aspect of internal variables is they do not lead to result duplication. For example,
 [,typeql]
 ----
+#!test[read]
 match
   $x isa user;
   friendship ($x, $_);

--- a/typeql-reference/modules/ROOT/pages/expressions/builtin-functions.adoc
+++ b/typeql-reference/modules/ROOT/pages/expressions/builtin-functions.adoc
@@ -133,7 +133,7 @@ Returns all metadata of the provided `owns` as a stream of key-value pairs, if i
 
 [,typeql]
 ----
-let $key, $value in get_all_owns_meta(person, name);
+let $key, $value in get_owns_all_meta(person, name);
 
 $key == "color"
 $value == "#0088FF"

--- a/typeql-reference/modules/ROOT/pages/functions/functions-vs-rules.adoc
+++ b/typeql-reference/modules/ROOT/pages/functions/functions-vs-rules.adoc
@@ -77,31 +77,40 @@ match
 ----
 
 An equally valid way is to see a function as a predicate computing whether one node is a reachable from the other.
+Since recursion must go through a stream-returning function (see the note below), the boolean predicate delegates the recursion to a stream helper:
 [,typeql]
 ----
+#!test[schema]
 define
-fun reachable($from: node, $to: node) -> boolean:
+fun is_reachable($from: node, $to: node) -> boolean:
+match
+  let $r in reachable_nodes($from);
+  $r is $to;
+return check;
+
+fun reachable_nodes($from: node) -> { node }:
 match
   {
     (from_: $from, to: $to) isa edge;
   } or {
-    (from_: $from, to: $via) isa edge;
-    true == reachable($via, $to);
+    let $via in reachable_nodes($from);
+    (from_: $via, to: $to) isa edge;
   };
-return check;
+return { $to };
 
+#!test[read]
 # query
 match
   $x isa node; $y isa node;
-  true == reachable($x, $y);
+  true == is_reachable($x, $y);
 ----
 
 [NOTE]
 ====
-This predicate formulation is not yet accepted by the current version of TypeDB:
-recursion is only supported through stream-returning functions, so defining this function fails with
-`[FUN9] Detected a recursive cycle through a negation, reduction or single return`.
-Use a stream formulation, like the ones shown on this page, for recursive functions.
+A directly recursive formulation of the predicate — calling `is_reachable` inside its own body — is rejected by TypeDB:
+recursion may only pass through stream-returning functions, not through single-return or `check` functions
+(`[FUN9] Detected a recursive cycle through a negation, reduction or single return`).
+Delegating the recursion to a stream-returning helper, as above, satisfies this restriction.
 ====
 
 == Arguments & return values

--- a/typeql-reference/modules/ROOT/pages/functions/functions-vs-rules.adoc
+++ b/typeql-reference/modules/ROOT/pages/functions/functions-vs-rules.adoc
@@ -96,6 +96,14 @@ match
   true == reachable($x, $y);
 ----
 
+[NOTE]
+====
+This predicate formulation is not yet accepted by the current version of TypeDB:
+recursion is only supported through stream-returning functions, so defining this function fails with
+`[FUN9] Detected a recursive cycle through a negation, reduction or single return`.
+Use a stream formulation, like the ones shown on this page, for recursive functions.
+====
+
 == Arguments & return values
 From the example, there are multiple ways of expressing the same rule as a function.
 This is understandable given (mathematically) a relation is a collection of tuples,

--- a/typeql-reference/modules/ROOT/pages/functions/functions-vs-rules.adoc
+++ b/typeql-reference/modules/ROOT/pages/functions/functions-vs-rules.adoc
@@ -80,7 +80,7 @@ An equally valid way is to see a function as a predicate computing whether one n
 [,typeql]
 ----
 define
-fun reachable($from: node, $to: node) -> bool:
+fun reachable($from: node, $to: node) -> boolean:
 match
   {
     (from_: $from, to: $to) isa edge;

--- a/typeql-reference/modules/ROOT/pages/functions/functions-vs-rules.adoc
+++ b/typeql-reference/modules/ROOT/pages/functions/functions-vs-rules.adoc
@@ -62,10 +62,10 @@ define
 fun reachable() -> { node, node }:
 match
   {
-    (from_: $from, to: $to) isa edge;
+    edge (from_: $from, to: $to);
   } or {
     let $from, $via in reachable();
-    (from_: $via, to: $to) isa edge;
+    edge (from_: $via, to: $to);
   };
 return { $from, $to };
 
@@ -77,7 +77,7 @@ match
 ----
 
 An equally valid way is to see a function as a predicate computing whether one node is a reachable from the other.
-Since recursion must go through a stream-returning function (see the note below), the boolean predicate delegates the recursion to a stream helper:
+Since recursion must go through a stream-returning function, the boolean predicate delegates the recursion to a stream helper:
 [,typeql]
 ----
 #!test[schema]
@@ -91,10 +91,10 @@ return check;
 fun reachable_nodes($from: node) -> { node }:
 match
   {
-    (from_: $from, to: $to) isa edge;
+    edge (from_: $from, to: $to);
   } or {
     let $via in reachable_nodes($from);
-    (from_: $via, to: $to) isa edge;
+    edge (from_: $via, to: $to);
   };
 return { $to };
 
@@ -104,14 +104,6 @@ match
   $x isa node; $y isa node;
   true == is_reachable($x, $y);
 ----
-
-[NOTE]
-====
-A directly recursive formulation of the predicate — calling `is_reachable` inside its own body — is rejected by TypeDB:
-recursion may only pass through stream-returning functions, not through single-return or `check` functions
-(`[FUN9] Detected a recursive cycle through a negation, reduction or single return`).
-Delegating the recursion to a stream-returning helper, as above, satisfies this restriction.
-====
 
 == Arguments & return values
 From the example, there are multiple ways of expressing the same rule as a function.
@@ -131,10 +123,10 @@ define
 fun reachable_from($from: node) -> { node }:
 match
   {
-    (from_: $from, to: $to) isa edge;
+    edge (from_: $from, to: $to);
   } or {
     let $via in reachable_from($from);
-    (from_: $via, to: $to) isa edge;
+    edge (from_: $via, to: $to);
   };
 return { $to };
 

--- a/typeql-reference/modules/ROOT/pages/functions/scalar.adoc
+++ b/typeql-reference/modules/ROOT/pages/functions/scalar.adoc
@@ -90,6 +90,14 @@ It can be used in cases when only the first answer is needed or when there canno
 
 With the `last` keyword, the whole stream is consumed, and only its last answer is returned.
 
+[WARNING]
+====
+`first` and `last` select from the stream in the order the engine produces answers.
+Unless the function's pipeline orders the stream explicitly (e.g. with a `sort` stage), this order is not defined.
+In particular, the branches of a xref:{page-version}@typeql-reference::patterns/disjunctions.adoc#_branches_are_non_exclusive_and_unordered[disjunction are non-exclusive and unordered]:
+if more than one branch is satisfied, `return first` may return the answer of any satisfied branch — a disjunction followed by `return first` is not an `if`/`else` conditional.
+====
+
 .Example of a stream modification
 [,typeql]
 ----

--- a/typeql-reference/modules/ROOT/pages/patterns/disjunctions.adoc
+++ b/typeql-reference/modules/ROOT/pages/patterns/disjunctions.adoc
@@ -81,6 +81,71 @@ match
 //  that could return None values for branch-local variables.
 // Revert to 19fb67756bfb76018315c6c7b380913683ca052c if needed (2025/08/08).
 
+[#_branches_are_non_exclusive_and_unordered]
+=== Branches are non-exclusive and unordered
+
+A disjunction is a true logical "`or`", not a conditional:
+every branch whose pattern is satisfied contributes answers, and the branches are evaluated in no particular order.
+A branch is never "`skipped`" because an earlier branch already matched.
+
+This matters whenever only some answers of the resulting stream are kept — for example with
+`return first` in a xref:{page-version}@typeql-reference::functions/scalar.adoc[scalar function] or a `limit` stage in a pipeline.
+Consider this attempt at a tiered classification, reading `or` as if it were an `if`/`else if`/`else`:
+
+[,typeql]
+----
+#!test[schema]
+define
+fun classify($score: integer) -> string:
+match
+  { $score > 8; let $label = "high"; }
+  or { $score > 4; let $label = "medium"; }
+  or { let $label = "low"; };
+return first $label;
+----
+
+The function defines and type-checks, but does not do what the `if`/`else` reading suggests.
+The last branch is unguarded, so it is satisfied for every `$score`, and for a score of `10` all three branches are satisfied.
+The function's `match` therefore produces an answer per satisfied branch,
+and since branches are unordered, `return first` may return *any* of `"high"`, `"medium"`, or `"low"` — for any input.
+
+Re-declaring the function with a stream return makes the behavior visible: every satisfied branch yields an answer.
+
+[,typeql]
+----
+#!test[schema]
+define
+fun classify_all($score: integer) -> { string }:
+match
+  { $score > 8; let $label = "high"; }
+  or { $score > 4; let $label = "medium"; }
+  or { let $label = "low"; };
+return { $label };
+
+#!test[read, count=3]
+match
+  let $label in classify_all(10);
+----
+
+[WARNING]
+====
+When a single answer is to be selected from a stream produced by a disjunction —
+with `return first`, `return last`, or a `limit` stage —
+write the branches to be mutually exclusive, so that at most one branch can be satisfied by any answer:
+
+[,typeql]
+----
+#!test[schema]
+define
+fun classify_tiered($score: integer) -> string:
+match
+  { $score > 8; let $label = "high"; }
+  or { $score > 4; $score <= 8; let $label = "medium"; }
+  or { $score <= 4; let $label = "low"; };
+return first $label;
+----
+====
+
 == Examples
 1. Retrieve friends and friends of friends of a user;
 +


### PR DESCRIPTION
## Goal
Clean up TypeQL syntax errors and clarify behaviour of disjunctions according to user feedback. We also add more testing tags to examples in Academy.

## Implementation

Disjunction branches are a true logical OR: non-exclusive and unordered. A disjunction feeding 'return first' silently returns an arbitrary branch's answer, which reads like if/else but isn't. Document this prominently in the disjunction reference (with a CI-tested example proving all satisfied branches yield answers) and add a matching warning to the scalar-function first/last section.

Also fix TypeQL syntax errors found in a full-docs snippet audit, all in blocks not covered by the docs test harness:

- functions-vs-rules: '-> bool' return type (only 'boolean' exists)
- Fix various syntax errors

We also add more testing tags to code snippets, inserting hidden schema blocks where required.