### PR TITLE
Fix CI playbook

### DIFF
--- a/learn-typedb/modules/ROOT/pages/rbac-in-business/index.adoc
+++ b/learn-typedb/modules/ROOT/pages/rbac-in-business/index.adoc
@@ -41,5 +41,3 @@ Each chapter introduces new concepts through Amasoft's story. Read the story, th
 ====
 
 image::rbac-schema-hero.webp[The complete Amasoft RBAC schema in TypeDB Studio's schema visualiser]
-
---

--- a/test/content/antora-playbook-mock-for-ci.yml
+++ b/test/content/antora-playbook-mock-for-ci.yml
@@ -9,6 +9,9 @@ content:
       start_path: home
       branches: HEAD
     - url: ./../..
+      start_path: learn-typedb
+      branches: HEAD
+    - url: ./../..
       start_path: use-cases
       branches: HEAD
     - url: ./../..

--- a/typeql-reference/modules/ROOT/pages/annotations/index.adoc
+++ b/typeql-reference/modules/ROOT/pages/annotations/index.adoc
@@ -179,14 +179,18 @@ include::{page-version}@typeql-reference::annotations/regex.adoc[tags=overview]
 Used
 include::{page-version}@typeql-reference::annotations/distinct.adoc[tags=overview]
 ****
+--
 
+== Metadata annotations
+
+[cols-3]
+--
 .xref:{page-version}@typeql-reference::annotations/doc.adoc[]
 [.clickable]
 ****
 Used
 include::{page-version}@typeql-reference::annotations/doc.adoc[tags=overview]
 ****
---
 
 .xref:{page-version}@typeql-reference::annotations/meta.adoc[]
 [.clickable]


### PR DESCRIPTION
## Goal
The learn-typedb component (added in #1059) was registered in the production antora-playbook.yml but not in the CI mock playbook, so every xref/include targeting `3.x@learn-typedb` failed in CI.

## Implementation
- Fix CI antora build

Also fixes two 'unterminated open block' warnings:
- annotations/index.adoc: the @doc and @meta cards (#1057) were appended with mismatched block delimiters; they now live in their own 'Metadata annotations' section with a properly closed cols-3 block.
- rbac-in-business/index.adoc: stray trailing '--' removed.
